### PR TITLE
fixing some entities in cts data

### DIFF
--- a/data/tlg0007/tlg001/__cts__.xml
+++ b/data/tlg0007/tlg001/__cts__.xml
@@ -20,7 +20,7 @@
       <ti:label xml:lang="eng">Theseus (trans. Perrin; Heinemann 1914)</ti:label>
         
       <ti:description xml:lang="eng">Perseus:bib:oclc,40115288, Perseus:bib:isbn,0674990528,
-            Plutarch. Plutarch&amp;apos;s Lives. with an English Translation by. Bernadotte Perrin.
+            Plutarch. Plutarch&apos;s Lives. with an English Translation by. Bernadotte Perrin.
             Cambridge, MA. Harvard University Press. London. William Heinemann Ltd. 1914.
             1.</ti:description>
         

--- a/data/tlg0007/tlg007/__cts__.xml
+++ b/data/tlg0007/tlg007/__cts__.xml
@@ -8,7 +8,7 @@
       <ti:label xml:lang="eng">Solon</ti:label>
     
       <ti:description xml:lang="eng">Perseus:bib:oclc,40115288, Perseus:bib:isbn,0674990528, Plutarch.
-      Plutarch&amp;apos;s Lives. with an English Translation by. Bernadotte Perrin. Cambridge, MA.
+      Plutarch&apos;s Lives. with an English Translation by. Bernadotte Perrin. Cambridge, MA.
       Harvard University Press. London. William Heinemann Ltd. 1914. 1.</ti:description>
     
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>

--- a/data/tlg0007/tlg047/__cts__.xml
+++ b/data/tlg0007/tlg047/__cts__.xml
@@ -20,7 +20,7 @@
                 
       <ti:label xml:lang="eng">Alexander (trans. Perrin; Heinemann 1919)</ti:label>
                 
-      <ti:description xml:lang="eng">Perseus:bib:oclc,40115288, Perseus:bib:isbn,0674991109, Plutarch. Plutarch&amp;apos;s Lives. with an English Translation by. Bernadotte Perrin. Cambridge, MA. Harvard University Press. London. William Heinemann Ltd. 1919. 7.</ti:description>
+      <ti:description xml:lang="eng">Perseus:bib:oclc,40115288, Perseus:bib:isbn,0674991109, Plutarch. Plutarch&apos;s Lives. with an English Translation by. Bernadotte Perrin. Cambridge, MA. Harvard University Press. London. William Heinemann Ltd. 1919. 7.</ti:description>
                 
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
             

--- a/data/tlg0561/tlg001/__cts__.xml
+++ b/data/tlg0561/tlg001/__cts__.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0561" urn="urn:cts:greekLit:tlg0561.tlg001" xml:lang="grc">
             
-   <ti:title xml:lang="eng">Daphnis &amp; Chloe</ti:title>
+   <ti:title xml:lang="eng">Daphnis &amp;amp; Chloe</ti:title>
             
    <ti:edition workUrn="urn:cts:greekLit:tlg0561.tlg001" urn="urn:cts:greekLit:tlg0561.tlg001.perseus-grc1">
                 
-      <ti:label xml:lang="eng">Daphnis &amp; Chloe</ti:label>
+      <ti:label xml:lang="eng">Daphnis &amp;amp; Chloe</ti:label>
                 
       <description xml:lang="eng"></description>
                 


### PR DESCRIPTION
I'm a little dubious about the double escaping that's required here -- I think it's a limitation of Nautilus but need to discuss with @PonteIneptique .

Am going to merge for now so Nautilus creates a working inventory from these files.