### PR TITLE
Fix typo in Euclid's Elements

### DIFF
--- a/data/tlg1799/tlg001/tlg1799.tlg001.perseus-grc2.xml
+++ b/data/tlg1799/tlg001/tlg1799.tlg001.perseus-grc2.xml
@@ -355,7 +355,7 @@ New header.
 ἡ <num>ΔΛ</num> τῇ <num>ΔΗ</num>, ὧν ἡ <num>ΔΑ</num> τῇ 
 <num>ΔΒ</num> ἴση ἐστίν. λοιπὴ ἄρα ἡ 
 <num>ΑΛ</num> λοιπῇ τῇ <num>ΒΗ</num> ἐστὶν ἴση. 
-<lb rend="displayNum" n="20"/>ἐδείχθηdδὲ καὶ ἡ <num>ΒΓ</num> τῇ <num>ΒΗ</num> 
+<lb rend="displayNum" n="20"/>ἐδείχθη δὲ καὶ ἡ <num>ΒΓ</num> τῇ <num>ΒΗ</num> 
 ἴση· ἑκατέρα ἄρα τῶν <num>ΑΛ</num>, 
 <num>ΒΓ</num> τῇ <num>ΒΗ</num> ἐστὶν ἴση. τὰ δὲ τῷ αὐτῷ ἴσα καὶ ἀλλήλοις 
 ἐστὶν ἴσα· καὶ ἡ <num>ΑΛ</num> ἄρα τῇ <num>ΒΓ</num> ἐστὶν ἴση. </p>


### PR DESCRIPTION
This change removes an extra 'd' character from Euclid's Elements that was introduced in 7d8e4c5.