### PR TITLE
Update tlg0548.tlg001__cts__.xml

### DIFF
--- a/data/tlg0548/tlg001/__cts__.xml
+++ b/data/tlg0548/tlg001/__cts__.xml
@@ -4,16 +4,14 @@
    <ti:title xml:lang="eng">Library</ti:title>
     
     <ti:edition urn="urn:cts:greekLit:tlg0548.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0548.tlg001" xml:lang="grc">
-        <ti:label xml:lang="eng">Library</ti:label>
-        <ti:description xml:lang="eng">Apollodorus. The Library, with an English
-          Translation. Frazer, James George, Sir, 1854-1941, editor, translator. Cambridge, MA,
+        <ti:label xml:lang="grc">Βιβλιοθήκη</ti:label>
+        <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA,
           Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>
     </ti:edition>
       
-   <ti:translation projid="greekLit:perseus-eng1" urn="urn:cts:greekLit:tlg0548.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0548.tlg001">     
+   <ti:translation urn="urn:cts:greekLit:tlg0548.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0548.tlg001">     
       <ti:label xml:lang="eng">Library</ti:label>      
-      <ti:description xml:lang="eng">Apollodorus. The Library, with an English
-          Translation. Frazer, James George, Sir, 1854-1941, editor, translator. Cambridge, MA,
+      <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA,
           Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>    
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>   
    </ti:translation>   

--- a/data/tlg0548/tlg001/__cts__.xml
+++ b/data/tlg0548/tlg001/__cts__.xml
@@ -5,14 +5,12 @@
     
     <ti:edition urn="urn:cts:greekLit:tlg0548.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0548.tlg001" xml:lang="grc">
         <ti:label xml:lang="grc">Βιβλιοθήκη</ti:label>
-        <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA,
-          Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>
+        <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA: Harvard University Press; London: William Heinemann Ltd. 1921.</ti:description>
     </ti:edition>
       
    <ti:translation urn="urn:cts:greekLit:tlg0548.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0548.tlg001">     
       <ti:label xml:lang="eng">Library</ti:label>      
-      <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA,
-          Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>    
+      <ti:description xml:lang="eng">Apollodorus. The Library. Frazer, James George, Sir, editor. Cambridge, MA: Harvard University Press; London: William Heinemann Ltd. 1921.</ti:description>    
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>   
    </ti:translation>   
 </ti:work>

--- a/data/tlg0548/tlg001/__cts__.xml
+++ b/data/tlg0548/tlg001/__cts__.xml
@@ -4,17 +4,17 @@
    <ti:title xml:lang="eng">Library</ti:title>
     
     <ti:edition urn="urn:cts:greekLit:tlg0548.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0548.tlg001" xml:lang="grc">
-        <ti:label xml:lang="eng">Library, The library</ti:label>
-        <ti:description xml:lang="eng">Apollodorus, creator; Frazer, James George, Sir, 1854-1941, editor; Frazer, James George, Sir, 1854-1941, editor, translator</ti:description>
+        <ti:label xml:lang="eng">Library</ti:label>
+        <ti:description xml:lang="eng">Apollodorus. The Library, with an English
+          Translation. Frazer, James George, Sir, 1854-1941, editor, translator. Cambridge, MA,
+          Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>
     </ti:edition>
       
    <ti:translation projid="greekLit:perseus-eng1" urn="urn:cts:greekLit:tlg0548.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0548.tlg001">     
       <ti:label xml:lang="eng">Library</ti:label>      
-      <ti:description xml:lang="eng">Perseus:bib:oclc,28280131, Perseus:bib:isbn,0674991354,
-          Perseus:bib:isbn,0674991362, Apollodorus. Apollodorus, The Library, with an English
-          Translation by Sir James George Frazer, F.B.A., F.R.S. in 2 Volumes. Cambridge, MA,
-          Harvard University Press; London, William Heinemann Ltd. 1921. Includes Frazer&amp;apos;s
-          notes.</ti:description>    
+      <ti:description xml:lang="eng">Apollodorus. The Library, with an English
+          Translation. Frazer, James George, Sir, 1854-1941, editor, translator. Cambridge, MA,
+          Harvard University Press; London, William Heinemann Ltd. 1921.</ti:description>    
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>   
    </ti:translation>   
 </ti:work>


### PR DESCRIPTION
Standardized the title description and edition metadata to OGL standards since file is converted and showing up in Scaife.