### PR TITLE
tlg0020.tlg003 Fix typo "Sheild"→"Shield"

### DIFF
--- a/data/tlg0020/tlg003/__cts__.xml
+++ b/data/tlg0020/tlg003/__cts__.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0020" projid="greekLit:tlg003" urn="urn:cts:greekLit:tlg0020.tlg003" xml:lang="grc">
-   <ti:title xml:lang="eng">Sheild of Heracles</ti:title>
+   <ti:title xml:lang="eng">Shield of Heracles</ti:title>
    <ti:edition projid="greekLit:perseus-grc2" urn="urn:cts:greekLit:tlg0020.tlg003.perseus-grc2" workUrn="urn:cts:greekLit:tlg0020.tlg003">
-      <ti:label xml:lang="eng">Sheild of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
+      <ti:label xml:lang="eng">Shield of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
       <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
                     (Hugh Gerard), d. 1924, translator; Evelyn-White, Hugh G. (Hugh Gerard), d.
                     1924, editor</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:edition>
    <ti:translation projid="greekLit:perseus-eng2" urn="urn:cts:greekLit:tlg0020.tlg003.perseus-eng2" workUrn="urn:cts:greekLit:tlg0020.tlg003" xml:lang="eng">
-      <ti:label xml:lang="eng">Sheild of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
+      <ti:label xml:lang="eng">Shield of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
       <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
                     (Hugh Gerard), d. 1924, translator</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>


### PR DESCRIPTION
https://scaife.perseus.org/library/urn:cts:greekLit:tlg0020.tlg003/ shows a misspelling, "Sheild of Heracles". I presume the text comes from the \_\_cts\_\_.xml file. The title is spelled correctly in tlg0020.tlg003.perseus-grc2.xml and tlg0020.tlg003.perseus-eng2.xml.