### PR TITLE
(tlg0005_tlg0031_amp) Replace "amp" with "&amp;" in publishers' names

### DIFF
--- a/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc1.xml
+++ b/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc1.xml
@@ -31,7 +31,7 @@
             <editor role="editor">R. J. Cholmeley, M.A.</editor>
             <imprint>
               <pubPlace>London</pubPlace>
-              <publisher>George Bell amp Sons</publisher>
+              <publisher>George Bell and Sons</publisher>
               <date>1901</date>
             </imprint>
           </monogr>

--- a/data/tlg0005/tlg002/tlg0005.tlg002.perseus-grc1.xml
+++ b/data/tlg0005/tlg002/tlg0005.tlg002.perseus-grc1.xml
@@ -31,7 +31,7 @@
             <editor role="editor">R. J. Cholmeley, M.A.</editor>
             <imprint>
               <pubPlace>London</pubPlace>
-              <publisher>George Bell amp Sons</publisher>
+              <publisher>George Bell and Sons</publisher>
               <date>1901</date>
             </imprint>
           </monogr>

--- a/data/tlg0031/tlg003/tlg0031.tlg003.perseus-grc2.xml
+++ b/data/tlg0031/tlg003/tlg0031.tlg003.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg004/tlg0031.tlg004.perseus-grc2.xml
+++ b/data/tlg0031/tlg004/tlg0031.tlg004.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg005/tlg0031.tlg005.perseus-grc2.xml
+++ b/data/tlg0031/tlg005/tlg0031.tlg005.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg006/tlg0031.tlg006.perseus-grc2.xml
+++ b/data/tlg0031/tlg006/tlg0031.tlg006.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg007/tlg0031.tlg007.perseus-grc2.xml
+++ b/data/tlg0031/tlg007/tlg0031.tlg007.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg008/tlg0031.tlg008.perseus-grc2.xml
+++ b/data/tlg0031/tlg008/tlg0031.tlg008.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg009/tlg0031.tlg009.perseus-grc2.xml
+++ b/data/tlg0031/tlg009/tlg0031.tlg009.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg010/tlg0031.tlg010.perseus-grc2.xml
+++ b/data/tlg0031/tlg010/tlg0031.tlg010.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg011/tlg0031.tlg011.perseus-grc2.xml
+++ b/data/tlg0031/tlg011/tlg0031.tlg011.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg012/tlg0031.tlg012.perseus-grc2.xml
+++ b/data/tlg0031/tlg012/tlg0031.tlg012.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg013/tlg0031.tlg013.perseus-grc2.xml
+++ b/data/tlg0031/tlg013/tlg0031.tlg013.perseus-grc2.xml
@@ -39,7 +39,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg014/tlg0031.tlg014.perseus-grc2.xml
+++ b/data/tlg0031/tlg014/tlg0031.tlg014.perseus-grc2.xml
@@ -39,7 +39,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg015/tlg0031.tlg015.perseus-grc2.xml
+++ b/data/tlg0031/tlg015/tlg0031.tlg015.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg016/tlg0031.tlg016.perseus-grc2.xml
+++ b/data/tlg0031/tlg016/tlg0031.tlg016.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg017/tlg0031.tlg017.perseus-grc2.xml
+++ b/data/tlg0031/tlg017/tlg0031.tlg017.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg018/tlg0031.tlg018.perseus-grc2.xml
+++ b/data/tlg0031/tlg018/tlg0031.tlg018.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg019/tlg0031.tlg019.perseus-grc2.xml
+++ b/data/tlg0031/tlg019/tlg0031.tlg019.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg020/tlg0031.tlg020.perseus-grc2.xml
+++ b/data/tlg0031/tlg020/tlg0031.tlg020.perseus-grc2.xml
@@ -39,7 +39,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg021/tlg0031.tlg021.perseus-grc2.xml
+++ b/data/tlg0031/tlg021/tlg0031.tlg021.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg022/tlg0031.tlg022.perseus-grc2.xml
+++ b/data/tlg0031/tlg022/tlg0031.tlg022.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg023/tlg0031.tlg023.perseus-grc2.xml
+++ b/data/tlg0031/tlg023/tlg0031.tlg023.perseus-grc2.xml
@@ -41,7 +41,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg024/tlg0031.tlg024.perseus-grc2.xml
+++ b/data/tlg0031/tlg024/tlg0031.tlg024.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg025/tlg0031.tlg025.perseus-grc2.xml
+++ b/data/tlg0031/tlg025/tlg0031.tlg025.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg026/tlg0031.tlg026.perseus-grc2.xml
+++ b/data/tlg0031/tlg026/tlg0031.tlg026.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>

--- a/data/tlg0031/tlg027/tlg0031.tlg027.perseus-grc2.xml
+++ b/data/tlg0031/tlg027/tlg0031.tlg027.perseus-grc2.xml
@@ -40,7 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
                         </respStmt>
                         <imprint>
                             <pubPlace>New York</pubPlace>
-                            <publisher>Harper amp Brothers, Franklin Square</publisher>
+                            <publisher>Harper and Brothers, Franklin Square</publisher>
                             <date>1882</date>
                         </imprint>
                     </monogr>


### PR DESCRIPTION
The publisher names "George Bell amp Sons" and "Harper amp Brothers, Franklin Square" used `amp` instead of `&amp;`, the XML entity for an ampersand. The first commit fixes them to use `&amp;`. I found these using the command `git grep '[^&]\bamp\b'`. I made the change using the commands
```
sed -i -e 's/George Bell amp Sons/George Bell \&amp; Sons/g' data/tlg0005/*/*.xml
sed -i -e 's/Harper amp Brothers/Harper \&amp; Brothers/g' data/tlg0031/*/*.xml
```
I checked against book scans that show printed ampersands:
* https://archive.org/details/idyllsoftheocrit00theo_0/page/n4/mode/1up
* https://archive.org/details/newtestamentino00west/page/3/mode/1up

A second commit changes occurrences of "George Bell *and* Sons" and "Harper *and* Brothers" to the corresponding forms with an ampersand in place of "and". I don't know if this is desired, but I added it for consistency. I made the second change using the commands
```
sed -i -e 's/George Bell and Sons/George Bell \&amp; Sons/g' data/*/*/*.xml
sed -i -e 's/Harper and Brothers/Harper \&amp; Brothers/g' data/tlg0031/*/*.xml
```

P.S. While looking at this, I noticed an inconsistency in the metadata of tlg0031.tlg003.perseus-grc2. [\_\_cts\_\_.xml](https://github.com/PerseusDL/canonical-greekLit/blob/b62d9f6221c1bfaf7d72ea572921d8435985720e/data/tlg0031/tlg003/__cts__.xml#L11) gives the year 1885, but [tlg0031.tlg003.perseus-grc2.xml](https://github.com/PerseusDL/canonical-greekLit/blob/b62d9f6221c1bfaf7d72ea572921d8435985720e/data/tlg0031/tlg003/tlg0031.tlg003.perseus-grc2.xml#L45) says 1882.