### PR TITLE
(tlg1271)_all files

### DIFF
--- a/data/tlg1271/__cts__.xml
+++ b/data/tlg1271/__cts__.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg1271" urn="urn:cts:greekLit:tlg1271">
     
-   <ti:groupname xml:lang="eng">Clement of Rome</ti:groupname>
+   <ti:groupname xml:lang="mul">Clemens Romanus (Clement of Rome)</ti:groupname>
     
 </ti:textgroup>

--- a/data/tlg1271/tlg001/__cts__.xml
+++ b/data/tlg1271/tlg001/__cts__.xml
@@ -6,7 +6,7 @@
    
    <ti:translation urn="urn:cts:greekLit:tlg1271.tlg001.perseus-eng1" xml:lang="eng" workUrn="urn:cts:greekLit:tlg1271.tlg001">
       <ti:label xml:lang="eng">The First Epistle of Clement to the Corinthians</ti:label>
-      <ti:description xml:lang="eng">Clement of Rome. The Apostolic Fathers with an English translation by Kirsopp Lake. In Two Volumes. Vol. I. Cambridge, MA: Harvard University Press; London: William Heinemann Ltd. 1912.</ti:description>
+      <ti:description xml:lang="eng">Clement of Rome. The Apostolic Fathers, Volume 1. Lake, Kirsopp, editor. London: William Heinemann Ltd.; New York: The Macmillan Company, 1912.</ti:description>
    </ti:translation>
    
  

--- a/data/tlg1271/tlg001/tlg1271.tlg001.perseus-eng1.xml
+++ b/data/tlg1271/tlg001/tlg1271.tlg001.perseus-eng1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>  
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>  
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+  <teiHeader xml:lang="eng">
     <fileDesc>
       <titleStmt>
         <title>The First Epistle of Clement to the Corinthians</title>
@@ -26,14 +26,19 @@
         <biblStruct>
           <monogr>
             <author>Clement of Rome</author>
-            <title>The Apostolic Fathers with an English translation by Kirsopp Lake. In Two Volumes. Vol. I.</title>
-            <imprint>
-              <publisher>Cambridge, MA, Harvard University Press; London, William Heinemann
-                Ltd.</publisher>
-              <date type="printing">1912</date>
-            </imprint>
+              <editor role="translator">Kirsopp Lake</editor>
+              <title>The Apostolic Fathers</title>
+              <imprint>
+                  <pubPlace>London</pubPlace>                           
+                  <publisher>William Heinemann</publisher>
+                  <pubPlace>New York</pubPlace>       
+                  <publisher>The Macmillan Company</publisher>
+                  <date>1912</date>
+              </imprint>
+              <biblScope unit="volume">1</biblScope>
           </monogr>
-            <ref target="https://archive.org/details/in.ernet.dli.2015.232411">Internet Archive</ref>
+            <ref target="https://archive.org/details/in.ernet.dli.2015.232411/page/n13/mode/2up">Internet
+                Archive</ref>
         </biblStruct>
       </sourceDesc>
     </fileDesc>

--- a/data/tlg1271/tlg002/__cts__.xml
+++ b/data/tlg1271/tlg002/__cts__.xml
@@ -2,13 +2,9 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg1271" urn="urn:cts:greekLit:tlg1271.tlg002" xml:lang="grc">
 
    
-   <ti:title xml:lang="eng">The Second Epistle of Clement to the Corinthians</ti:title>
-   
+   <ti:title xml:lang="eng">The Second Epistle of Clement to the Corinthians</ti:title>   
    <ti:translation urn="urn:cts:greekLit:tlg1271.tlg002.perseus-eng1" xml:lang="eng" workUrn="urn:cts:greekLit:tlg1271.tlg002">
       <ti:label xml:lang="eng">The Second Epistle of Clement to the Corinthians</ti:label>
-      <ti:description xml:lang="eng">Clement of Rome. The Apostolic Fathers with an English translation by Kirsopp Lake. In Two Volumes. Vol. I. Cambridge, MA: Harvard University Press; London: William Heinemann Ltd. 1912.</ti:description>
+      <ti:description xml:lang="eng">Clement of Rome. The Apostolic Fathers, Volume 1. Lake, Kirsopp, editor. London: William Heinemann Ltd.; New York: The Macmillan Company, 1912.</ti:description>
    </ti:translation>
-   
- 
-
 </ti:work>

--- a/data/tlg1271/tlg002/tlg1271.tlg002.perseus-eng1.xml
+++ b/data/tlg1271/tlg002/tlg1271.tlg002.perseus-eng1.xml
@@ -26,14 +26,18 @@
         <biblStruct>
           <monogr>
             <author>Clement of Rome</author>
-            <title>The Apostolic Fathers with an English translation by Kirsopp Lake. In Two Volumes. Vol. I.</title>
+            <editor role="translator">Kirsopp Lake</editor>
+            <title>The Apostolic Fathers</title>
             <imprint>
-              <publisher>Cambridge, MA, Harvard University Press; London, William Heinemann
-                Ltd.</publisher>
-              <date type="printing">1912</date>
+              <pubPlace>London</pubPlace>                           
+              <publisher>William Heinemann</publisher>
+              <pubPlace>New York</pubPlace>       
+              <publisher>The Macmillan Company</publisher>
+              <date>1912</date>
             </imprint>
+            <biblScope unit="volume">1</biblScope>
           </monogr>
-            <ref target="https://archive.org/details/in.ernet.dli.2015.232411">Internet Archive</ref>
+          <ref target="https://archive.org/details/in.ernet.dli.2015.232411/page/n133/mode/2up">Internet Archive</ref>
         </biblStruct>
       </sourceDesc>
     </fileDesc>


### PR DESCRIPTION
Updated textgroup.
Used Clement of Rome as author for letters known to be authored by him.
And used Clemens Romanus for the attributed texts.