### PR TITLE
(tlg0016)_all_files

### DIFF
--- a/data/tlg0016/__cts__.xml
+++ b/data/tlg0016/__cts__.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg0016" urn="urn:cts:greekLit:tlg0016">
         
-   <ti:groupname xml:lang="en">Herodotus</ti:groupname>
+   <ti:groupname xml:lang="eng">Herodotus</ti:groupname>
         
 </ti:textgroup>

--- a/data/tlg0016/tlg001/__cts__.xml
+++ b/data/tlg0016/tlg001/__cts__.xml
@@ -4,7 +4,7 @@
    <ti:title xml:lang="eng">Histories</ti:title>
 
    <ti:edition urn="urn:cts:greekLit:tlg0016.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0016.tlg001">
-      <ti:label xml:lang="eng">Histories</ti:label>
+      <ti:label xml:lang="grc">Ἱστορίαι</ti:label>
       <ti:description xml:lang="eng">Herodotus. Godley, Alfred Denis, editor. Cambridge, MA; London: Harvard University Press; William
          Heinemann, Ltd., 1920-1925 (printing).</ti:description>
    </ti:edition>

--- a/data/tlg0016/tlg001/__cts__.xml
+++ b/data/tlg0016/tlg001/__cts__.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0016" projid="greekLit:tlg001" urn="urn:cts:greekLit:tlg0016.tlg001" xml:lang="grc">
             
-   <ti:title xml:lang="eng">The Histories</ti:title>
+   <ti:title xml:lang="eng">Histories</ti:title>
 
    <ti:edition urn="urn:cts:greekLit:tlg0016.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0016.tlg001">
-      <ti:label xml:lang="eng">Histories, Herodotus with an English translation</ti:label>
-      <ti:description xml:lang="eng">Herodotus, creator; Godley, Alfred Denis, 1856-1926, editor</ti:description>
+      <ti:label xml:lang="eng">Histories</ti:label>
+      <ti:description xml:lang="eng">Herodotus. Godley, Alfred Denis, editor. Cambridge, MA; London: Harvard University Press; William
+         Heinemann, Ltd., 1920-1925 (printing).</ti:description>
    </ti:edition>
    
    <ti:translation urn="urn:cts:greekLit:tlg0016.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0016.tlg001">
-      <ti:label xml:lang="eng">Histories, Herodotus with an English translation</ti:label>
-      <ti:description xml:lang="eng">Herodotus, creator; Godley, Alfred Denis, 1856-1926, translator</ti:description>
+      <ti:label xml:lang="eng">Histories</ti:label>
+      <ti:description xml:lang="eng">Herodotus. Godley, Alfred Denis, translator. Cambridge, MA; London: Harvard University Press; William
+         Heinemann, Ltd., 1920-1925 (printing).</ti:description>
    </ti:translation>
         
 </ti:work>

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
@@ -3,7 +3,8 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Histories</title>            
+            <title>The Histories</title>  
+            <title type="sub">Modernized Text</title>
             <author>Herodotus</author>
             <editor role="translator">A. D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Histories</title>
-            
+            <title>The Histories</title>            
             <author>Herodotus</author>
             <editor role="translator">A. D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
@@ -33,17 +32,23 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Herodotus, with an English translation by A. D. Godley</title><idno type="ISBN">0674991303</idno><idno type="ISBN">0674991311</idno><idno type="ISBN">0674991338</idno><idno type="ISBN">0674991346</idno>
+                  <title>Herodotus</title>
+                  <editor>A.D. Godley</editor>
                   <imprint>
                      <pubPlace>Cambridge</pubPlace>
+                     <pubPlace>London</pubPlace>
                      <publisher>Harvard University Press</publisher>
-                     <date>1920</date>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <date type="printing">1920-1925</date>
                   </imprint>
-               </monogr>
-               
-               
-               
-               
+               </monogr>  
+               <series>
+                  <title>Loeb Classical Library</title>
+               </series>
+               <ref target="https://archive.org/details/historiesvolumei00hero_249/page/n5/mode/2up">The Internet Archive</ref><!-- Volume 1 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero_114/page/n8/mode/2up">The Internet Archive</ref><!-- Volume 2 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero_574/page/n10/mode/2up">The Internet Archive</ref><!-- Volume 3 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero/page/n8/mode/2up">The Internet Archive</ref><!-- Volume 4 -->               
             </biblStruct>
          </sourceDesc>
       </fileDesc>
@@ -157,9 +162,9 @@
             <date from="-0450" to="-0425">5 c. B.C.</date>
          </creation>
          <langUsage>
-            <language ident="eng">English </language>
-            <language ident="grc">Greek </language>
-            <language ident="lat">Latin </language>
+            <language ident="eng">English</language>
+            <language ident="grc">Greek</language>
+            <language ident="lat">Latin</language>
          </langUsage>
          <textClass default="true">
             <catRef scheme="perseus.class" target="perseus.form.prose perseus.genre.history"/>
@@ -175,6 +180,7 @@
          <change when="19920801" who="DAS">Cleaned up notes and changed chapters to DIV2's.</change>
          <change when="20151222" who="Bridget Almas">Converted to EpiDoc</change>
          <change when="20151222" who="Bridget Almas">Bumped URN</change>
+         <change when="20220228" who="Alison Babeu">Updated bibliographic metadata</change>         
       </revisionDesc>
    </teiHeader>
 

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-eng2.xml
@@ -3,8 +3,8 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Histories</title>  
-            <title type="sub">Modernized Text</title>
+            <title>The Histories</title> 
+            <title type="sub">Modernized by Perseus</title>
             <author>Herodotus</author>
             <editor role="translator">A. D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
@@ -5,9 +5,9 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>The Histories</title>
-            
+            <title>Histories</title>            
             <author>Herodotus</author>
+            <editor>A.D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -32,17 +32,23 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Herodotus, with an English translation by A. D. Godley</title><idno type="ISBN">0674991303</idno><idno type="ISBN">0674991311</idno><idno type="ISBN">0674991338</idno><idno type="ISBN">0674991346</idno>
+                  <title>Herodotus</title>
+                  <editor>A.D. Godley</editor>
                   <imprint>
                      <pubPlace>Cambridge</pubPlace>
+                     <pubPlace>London</pubPlace>
                      <publisher>Harvard University Press</publisher>
-                     <date>1920</date>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <date type="printing">1920-1925</date>
                   </imprint>
                </monogr>
-               <ref target="https://archive.org/details/historiesvolumei00hero_249/page/n5/mode/2up">The Internet Archive</ref>
-               <ref target="https://archive.org/details/historiesvolumei00hero_114/page/n8/mode/2up">The Internet Archive</ref>
-               <ref target="https://archive.org/details/historiesvolumei00hero_574/page/n10/mode/2up">The Internet Archive</ref>
-               <ref target="https://archive.org/details/historiesvolumei00hero/page/n8/mode/2up">The Internet Archive</ref>
+               <series>
+                  <title>Loeb Classical Library</title>
+               </series>               
+               <ref target="https://archive.org/details/historiesvolumei00hero_249/page/n5/mode/2up">The Internet Archive</ref><!-- Volume 1 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero_114/page/n8/mode/2up">The Internet Archive</ref><!-- Volume 2 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero_574/page/n10/mode/2up">The Internet Archive</ref><!-- Volume 3 -->
+               <ref target="https://archive.org/details/historiesvolumei00hero/page/n8/mode/2up">The Internet Archive</ref><!-- Volume 4 -->
               </biblStruct>
          </sourceDesc>
       </fileDesc>
@@ -80,6 +86,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
          <change when="20151222" who="Bridget Almas">Converted to EpiDoc</change>
          <change when="20151222" who="Bridget Almas">Bumped URN</change>
          <change when="20180618" who="Gregory Crane">removed duplicated ἐκ in 7.26</change>
+         <change when="20220228" who="Alison Babeu">Updated bibliographic metadata</change>
       </revisionDesc>
    </teiHeader>
    <text>

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
@@ -2,10 +2,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI  xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Histories</title>    
+            <title xml:lang="grc">Ἱστορίαι</title>    
             <author>Herodotus</author>
             <editor>A.D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
+++ b/data/tlg0016/tlg001/tlg0016.tlg001.perseus-grc2.xml
@@ -5,7 +5,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Histories</title>            
+            <title>Histories</title>    
             <author>Herodotus</author>
             <editor>A.D. Godley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>


### PR DESCRIPTION
Updated cts metadata and header info.
Added in a subtitle to the English translation about it being a modernized text.

Per #1323.

@lcerrato Some questions.
1. I wasn't sure about the top level CTS textgroup being in English, but I changed "The Histories" to Histories. Should I look up a Greek title for the ` <ti:label xml:lang="eng">Histories</ti:label>` within the Greek edition.

2. I also wasn't sure about how to add in the note about the text in English being modernized but have started by adding a subtitle.  ` <title type="sub">Modernized Text</title>` We can probably do better than this. 

3. Also the notesSttmt lists several names that aren't included in the `<respStmt>` 
 `  <notesStmt>
            <note anchored="true">This text was modernized by Steven Ott, to remove archaisms. It
               was reviewed by John Marincola, and revisions were made accordingly.</note>
            <note anchored="true">Text scanned at U. Chicago in 1988-9. Basic tagging done by EM,
               Scott Ettinger, Roger Travis.</note>
         </notesStmt>`

Should these names be added?  Thanks for all your help.
