### PR TITLE
(tlg0085)-tlg0085.tlg001

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ language: python
 dist: xenial
 
 python:
-  - '3.7'
+  - '3.9'
 
 install:
   - pip3 install HookTest

--- a/data/tlg0085/__cts__.xml
+++ b/data/tlg0085/__cts__.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg0085" urn="urn:cts:greekLit:tlg0085">
-        
-   <ti:groupname xml:lang="eng">Aeschylus</ti:groupname>
-        
-   <ti:groupname xml:lang="eng">Aeschylus</ti:groupname>
-    
-   <ti:groupname>Aeschylus</ti:groupname>
-        
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="greekLit:tlg0085" urn="urn:cts:greekLit:tlg0085">        
+   <ti:groupname xml:lang="eng">Aeschylus</ti:groupname>               
 </ti:textgroup>

--- a/data/tlg0085/tlg001/__cts__.xml
+++ b/data/tlg0085/tlg001/__cts__.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0085.tlg001" xml:lang="grc" groupUrn="urn:cts:greekLit:tlg0085">
     
-    <ti:title xml:lang="grc">Ἱκέτιδες</ti:title>
+    <ti:title xml:lang="lat">Supplices</ti:title>
     <ti:edition xml:lang="grc" workUrn="urn:cts:greekLit:tlg0085.tlg001" urn="urn:cts:greekLit:tlg0085.tlg001.perseus-grc2">
-        <ti:label xml:lang="grc">Ἱκέτιδεςs</ti:label>
+        <ti:label xml:lang="grc">Ἱκέτιδες</ti:label>
         <ti:description xml:lang="eng">Aeschylus, Volume 1. Smyth, Herbert Weir, editor. London; New York: 
             William Heinemann; G.P. Putnam's Sons, 1922.</ti:description>
     </ti:edition>    

--- a/data/tlg0085/tlg001/__cts__.xml
+++ b/data/tlg0085/tlg001/__cts__.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:greekLit:tlg0085.tlg001" xml:lang="grc" groupUrn="urn:cts:greekLit:tlg0085">
     
-    <ti:title xml:lang="eng">Suppliant Maidens</ti:title>
+    <ti:title xml:lang="grc">Ἱκέτιδες</ti:title>
     <ti:edition xml:lang="grc" workUrn="urn:cts:greekLit:tlg0085.tlg001" urn="urn:cts:greekLit:tlg0085.tlg001.perseus-grc2">
-        <ti:label xml:lang="eng">Suppliant Maidens</ti:label>
-        <ti:description xml:lang="eng">Aeschylus, creator; Aeschylus with an English translation Vol I; Smyth, Herbert Weir, 1857- 1937, editor, translator; Cambridge, Mass., Harvard University Press; London, William Heinemann, Ltd.: 1922.</ti:description>
-    </ti:edition>
-    
+        <ti:label xml:lang="grc">Ἱκέτιδεςs</ti:label>
+        <ti:description xml:lang="eng">Aeschylus, Volume 1. Smyth, Herbert Weir, editor. London; New York: 
+            William Heinemann; G.P. Putnam's Sons, 1922.</ti:description>
+    </ti:edition>    
     <ti:translation urn="urn:cts:greekLit:tlg0085.tlg001.perseus-eng2" xml:lang="eng" workUrn="urn:cts:greekLit:tlg0085.tlg001">
         <ti:label xml:lang="eng">Suppliant Maidens</ti:label>
-        <ti:description xml:lang="eng">Aeschylus, creator; Aeschylus with an English translation Vol I; Smyth, Herbert Weir, 1857- 1937, translator. Cambridge, Mass., Harvard University Press; London, William Heinemann, Ltd.: 1922.</ti:description>
+        <ti:description xml:lang="eng">Aeschylus, Volume 1. Smyth, Herbert Weir, translator. London; New York: 
+            William Heinemann; G.P. Putnam's Sons, 1922.</ti:description>
     </ti:translation>
     
 </ti:work>

--- a/data/tlg0085/tlg001/tlg0085.tlg001.perseus-eng2.xml
+++ b/data/tlg0085/tlg001/tlg0085.tlg001.perseus-eng2.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title type="work">Suppliant Maidens</title>
+            <title>Suppliant Maidens</title>
             <title type="sub">Modernized by Perseus</title>
             <author>Aeschylus</author>
-            <editor role="translator" n="Smyth">Herbert Weir Smyth, Ph. D.</editor>
+            <editor role="translator">Herbert Weir Smyth</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -29,14 +29,19 @@
             <biblStruct>
                <monogr>
                   <author>Aeschylus</author>
-                  <title>Aeschylus, with an English translation by Herbert Weir Smyth, Ph. D. in two volumes.  2.  Suppliant Women</title>
-                  <editor>Herbert Weir Smyth, Ph. D.</editor>
+                  <title>Aeschylus</title>
+                  <title type="sub">Suppliant Maidens Persians Prometheus Seven Against Thebes</title>
+                  <editor role="translator">Herbert Weir Smyth</editor>
                   <imprint>
-                     <pubPlace>Cambridge, MA</pubPlace>
-                     <publisher>Harvard University Press</publisher>
-                     <date>1926</date>
+                     <pubPlace>New York</pubPlace>
+                     <pubPlace>London</pubPlace>                     
+                     <publisher>William Heinemann</publisher>
+                     <publisher>G.P. Putnam's Sons</publisher>
+                     <date>1922</date>
                   </imprint>
+                  <biblScope unit="volume">1</biblScope>
                </monogr>
+               <ref target="https://hdl.handle.net/2027/uc1.32106006136839?urlappend=%3Bseq=51%3Bownerid=9007199263410116-55">HathiTrust</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/tlg0085/tlg001/tlg0085.tlg001.perseus-grc2.xml
+++ b/data/tlg0085/tlg001/tlg0085.tlg001.perseus-grc2.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title type="work">Suppliant Maidens</title>
-            
+            <title xml:lang="grc">Ἱκέτιδεςs</title>            
             <author>Aeschylus</author>
-            <editor role="editor" n="Smyth">Herbert Weir Smyth, Ph.D.</editor>
+            <editor>Herbert Weir Smyth</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -27,13 +26,19 @@
             <biblStruct>
                <monogr>
                   <author>Aeschylus</author>
-                  <title>Aeschylus, with an English translation by Herbert Weir Smyth, Ph. D. in two volumes. 1.Suppliant Women</title>
+                  <title>Aeschylus</title>
+                  <title type="sub">Suppliant Maidens Persians Prometheus Seven Against Thebes</title>
+                  <editor>Herbert Weir Smyth</editor>
                   <imprint>
-                     <pubPlace>Cambridge</pubPlace>
-                     <publisher>Cambridge, Mass., Harvard University Press; London, William Heinemann, Ltd.</publisher>
-                     <date>1926</date>
+                     <pubPlace>New York</pubPlace>
+                     <pubPlace>London</pubPlace>                     
+                     <publisher>William Heinemann</publisher>
+                     <publisher>G.P. Putnam's Sons</publisher>
+                     <date>1922</date>
                   </imprint>
+                  <biblScope unit="volume">1</biblScope>
                </monogr>
+               <ref target="https://hdl.handle.net/2027/uc1.32106006136839?urlappend=%3Bseq=51%3Bownerid=9007199263410116-55">HathiTrust</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/tlg0085/tlg001/tlg0085.tlg001.perseus-grc2.xml
+++ b/data/tlg0085/tlg001/tlg0085.tlg001.perseus-grc2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title xml:lang="grc">Ἱκέτιδεςs</title>            
+            <title xml:lang="grc">Ἱκέτιδες</title>            
             <author>Aeschylus</author>
             <editor>Herbert Weir Smyth</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>


### PR DESCRIPTION
Updated Aeschylus textgroup
Updated cts_.xml to reflect Greek work title as the title of the work
Corrected bibliographic metadata (publishers, year published in cts to be consistent between CTS and
TEI-XML headers etc.

@lcerrato if this looks good I will go ahead and make the same changes to the other files. 