### PR TITLE
Update tlg0011.tlg004.perseus-eng2.xml

### DIFF
--- a/data/tlg0011/tlg004/tlg0011.tlg004.perseus-eng2.xml
+++ b/data/tlg0011/tlg004/tlg0011.tlg004.perseus-eng2.xml
@@ -421,7 +421,7 @@ it still would not have been fit that you should leave the guilt unpunished as i
             </sp>
             <sp>
                <speaker>Chorus</speaker>
-               <l n="297">But there is no one to convict him.  But here they bring at last the godlike prophet, the only man in whom truth lives.</l>
+               <l n="297">But there is one to convict him.  But here they bring at last the godlike prophet, the only man in whom truth lives.</l>
             </sp>
          
 


### PR DESCRIPTION
removed "no one" and changed to "one" on line 297 per print edition and Greek 
fix #1331