### PR TITLE
Update tlg0007.tlg001.perseus-eng3.xml

### DIFF
--- a/data/tlg0007/tlg001/tlg0007.tlg001.perseus-eng3.xml
+++ b/data/tlg0007/tlg001/tlg0007.tlg001.perseus-eng3.xml
@@ -917,7 +917,7 @@
                is said that he did not take away with him all the maidens on whom the lot fell at
                that time, but picked out two young men of his acquaintance who had fresh and girlish
                faces, but eager and manly spirits, and changed their outward appearance almost
-               entirely by giving them warn baths and keeping them out of the sun, by arranging
+               entirely by giving them warm baths and keeping them out of the sun, by arranging
                their hair, and by smoothing their skin and beautifying their complexions with
                unguents; he also taught them to imitate maidens as closely as possible in their
                speech, their dress, and their gait, and to leave no difference that could be
@@ -1255,7 +1255,7 @@
                   <p>
             </p>
                   <p>After this, when Peirithous was about to marry Deidameia, he asked Theseus to come to
-               the wedding, and see the country, and become acquainted with the Iapithae. Now he had
+               the wedding, and see the country, and become acquainted with the Lapithae. Now he had
                invited the Centaurs also to the wedding feast. And when these were flown with
                insolence and wine, and laid hands upon the women, the Lapithae took vengeance upon
                them. Some of them they slew upon the spot, the rest they afterwards overcame in war


### PR DESCRIPTION
typo report JK20220604 
In Plut. Thes. 23.2, it reads "warn baths" instead of "warm baths."
In Plut. Thes. 30.3, it reads "with the Iapithae" instead of  "with the Lapithae."