### PR TITLE
tlg0627.tlg046.perseus-eng1.xml - Remove extra xml tags

### DIFF
--- a/data/tlg0627/tlg046/tlg0627.tlg046.perseus-eng1.xml
+++ b/data/tlg0627/tlg046/tlg0627.tlg046.perseus-eng1.xml
@@ -372,4 +372,3 @@
     </body>
   </text>
 </TEI>
-</body></text></TEI>


### PR DESCRIPTION
Remove several extra xml tags at the end of the file that prevent it from being parsed with a strict xml parser.

It looks like this issue has been encountered before, but it was never fixed.
Fixes #490