### PR TITLE
Fix edition URN for urn:cts:greekLit:tlg0655.tlg001

### DIFF
--- a/data/tlg0655/tlg001/__cts__.xml
+++ b/data/tlg0655/tlg001/__cts__.xml
@@ -1,6 +1,6 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0655" xml:lang="grc" urn="urn:cts:greekLit:tlg0655.tlg001">
     <ti:title xml:lang="lat">Narrationes Amatoriae</ti:title>
-    <ti:edition urn="urn:cts:greekLit:tlg0655.tlg001.perseus-grc2.xml" workUrn="urn:cts:greekLit:tlg0655.tlg001" xml:lang="grc">
+    <ti:edition urn="urn:cts:greekLit:tlg0655.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0655.tlg001" xml:lang="grc">
         <ti:label xml:lang="grc">Ἐρωτικὰ Παθήματα</ti:label>
         <ti:description xml:lang="mul">Parthenius. Erotici Scriptores Graeci, Vol. 1. Hercher, Rudolph, editor. Leipzig: Teubner, 1858.</ti:description>
     </ti:edition>


### PR DESCRIPTION
I found a small typo in the `__cts__` header that was preventing the latest content from being loaded on scaife.perseus.org.

I searched the repo via https://github.com/search?q=repo%3APerseusDL%2Fcanonical-greekLit%20xml%22%20workUrn&type=code and no other instances found.

This type of typo is something that wouldn't be caught by Hooktest, but probably could be caught by some other CI / CD step.

cc: @AlisonBabeu 