### PR TITLE
tlg0007.tlg090.perseus-eng3/4

### DIFF
--- a/data/tlg0007/tlg090/__cts__.xml
+++ b/data/tlg0007/tlg090/__cts__.xml
@@ -5,13 +5,13 @@
 
     <ti:translation urn="urn:cts:greekLit:tlg0007.tlg090.perseus-eng3"
         workUrn="urn:cts:greekLit:tlg0007.tlg090" xml:lang="eng">
-        <ti:label xml:lang="eng">The <foreign xml:lang="grc">Ε</foreign> at Delphi</ti:label>
+        <ti:label xml:lang="mul">The Ε at Delphi</ti:label>
         <ti:description xml:lang="mul">Plutarch. Moralia, Vol. 5. Babbitt, Frank Cole, translator. Cambridge, MA: Harvard University Press; London: William Heinemann Ltd., 1936 (printing).</ti:description>
     </ti:translation>
 
     <ti:translation urn="urn:cts:greekLit:tlg0007.tlg090.perseus-eng4"
         workUrn="urn:cts:greekLit:tlg0007.tlg090" xml:lang="eng">
-        <ti:label xml:lang="eng">Of the word <foreign xml:lang="grc">ΕΙ</foreign> engraven over the gate of Apollo's temple at Delphi.></ti:label>
+        <ti:label xml:lang="mul">Of the word ΕΙ engraven over the gate of Apollo's temple at Delphi</ti:label>
         <ti:description xml:lang="eng">Plutarch. Plutarch's Morals, Vol. 4. Goodwin, William W., editor; Kippax, R, translator. Boston: Little, Brown, and Company; Cambridge: Press of John Wilson and Son, 1874.</ti:description>
     </ti:translation>
 


### PR DESCRIPTION
Updated language tagging from "eng" to "mul" and deleted foreign lang tag

Fix https://github.com/scaife-viewer/scaife-viewer/issues/639