### PR TITLE
Correctly identify translations

### DIFF
--- a/data/tlg0014/tlg062/tlg0014.tlg062.perseus-eng2.xml
+++ b/data/tlg0014/tlg062/tlg0014.tlg062.perseus-eng2.xml
@@ -95,7 +95,7 @@
 
 	<text xml:lang="eng">
 		<body>
-		  <div type="edition" n="urn:cts:greekLit:tlg0014.tlg062.perseus-eng2" xml:lang="eng">
+		  <div type="translation" n="urn:cts:greekLit:tlg0014.tlg062.perseus-eng2" xml:lang="eng">
 			<head>Exordia</head>
 <div type="textpart" subtype="exordium" n="1"> 
 <div type="textpart" subtype="section" n="1"><p><note anchored="true" resp="DeWitt">The beginning of Philippic 1 (<bibl n="Dem. 4">Dem. 4</bibl>) differs but slightly from this.</note> If it had been proposed to discuss some new measure, men of <placeName key="perseus,Athens">Athens</placeName>, I should have waited until most of the regular speakers had declared their opinions, and if any of their views had pleased me, I should have held my peace; otherwise, I should then have attempted to say what I myself think. But since you are now considering matters on which these speakers have often spoken before, I feel that, even if the first to rise, I may reasonably appear to be speaking after them.</p></div>

--- a/data/tlg0014/tlg063/tlg0014.tlg063.perseus-eng2.xml
+++ b/data/tlg0014/tlg063/tlg0014.tlg063.perseus-eng2.xml
@@ -93,7 +93,7 @@
 
 	<text xml:lang="eng">
 		<body>
-		  <div type="edition" n="urn:cts:greekLit:tlg0014.tlg063.perseus-eng2" xml:lang="eng">
+		  <div type="translation" n="urn:cts:greekLit:tlg0014.tlg063.perseus-eng2" xml:lang="eng">
 		  <head>Letters</head>
 <div type="textpart" subtype="letter" n="1">
   <head>On Political Harmony</head> 

--- a/data/tlg0031/tlg001/tlg0031.tlg001.perseus-eng2.xml
+++ b/data/tlg0031/tlg001/tlg0031.tlg001.perseus-eng2.xml
@@ -89,7 +89,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg001.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg001.perseus-eng2">
                 <head>The Gospel According to Matthew</head>
                 
                 <div type="textpart" subtype="chapter" n="1">

--- a/data/tlg0031/tlg002/tlg0031.tlg002.perseus-eng2.xml
+++ b/data/tlg0031/tlg002/tlg0031.tlg002.perseus-eng2.xml
@@ -87,7 +87,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg002.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg002.perseus-eng2">
                 <head>The Gospel According to Mark</head>
                 <div type="textpart" subtype="chapter" n="1">
 

--- a/data/tlg0031/tlg003/tlg0031.tlg003.perseus-eng2.xml
+++ b/data/tlg0031/tlg003/tlg0031.tlg003.perseus-eng2.xml
@@ -86,7 +86,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg003.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg003.perseus-eng2">
                 <head>The Gospel According to Luke</head>
                 <div type="textpart" subtype="chapter" n="1">
                 

--- a/data/tlg0031/tlg004/tlg0031.tlg004.perseus-eng2.xml
+++ b/data/tlg0031/tlg004/tlg0031.tlg004.perseus-eng2.xml
@@ -83,7 +83,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg004.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg004.perseus-eng2">
                 <head>The Gospel According to John</head>
                 <div type="textpart" subtype="chapter" n="1">
                     

--- a/data/tlg0031/tlg005/tlg0031.tlg005.perseus-eng2.xml
+++ b/data/tlg0031/tlg005/tlg0031.tlg005.perseus-eng2.xml
@@ -87,7 +87,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg005.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg005.perseus-eng2">
                 <head>Acts</head>
                 <div type="textpart" subtype="chapter" n="1">
                     

--- a/data/tlg0031/tlg006/tlg0031.tlg006.perseus-eng2.xml
+++ b/data/tlg0031/tlg006/tlg0031.tlg006.perseus-eng2.xml
@@ -83,7 +83,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg006.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg006.perseus-eng2">
                 <head>Paul's Letter to the Romans</head>
                 <div type="textpart" subtype="chapter" n="1">
                     

--- a/data/tlg0031/tlg007/tlg0031.tlg007.perseus-eng2.xml
+++ b/data/tlg0031/tlg007/tlg0031.tlg007.perseus-eng2.xml
@@ -78,7 +78,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg007.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg007.perseus-eng2">
                 <head>Paul's First Letter to the Corinthians</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg008/tlg0031.tlg008.perseus-eng2.xml
+++ b/data/tlg0031/tlg008/tlg0031.tlg008.perseus-eng2.xml
@@ -77,7 +77,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg008.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg008.perseus-eng2">
                 <head>Paul's Second Letter to the Corinthians</head>
                 <div type="textpart" subtype="chapter" n="1">
                  

--- a/data/tlg0031/tlg009/tlg0031.tlg009.perseus-eng2.xml
+++ b/data/tlg0031/tlg009/tlg0031.tlg009.perseus-eng2.xml
@@ -76,7 +76,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg009.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg009.perseus-eng2">
                 <head>Paul's Letter to the Galatians</head>
                 <div type="textpart" subtype="chapter" n="1">
                  

--- a/data/tlg0031/tlg010/tlg0031.tlg010.perseus-eng2.xml
+++ b/data/tlg0031/tlg010/tlg0031.tlg010.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg010.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg010.perseus-eng2">
                 <head>Paul's Letter to the Ephesians</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg011/tlg0031.tlg011.perseus-eng2.xml
+++ b/data/tlg0031/tlg011/tlg0031.tlg011.perseus-eng2.xml
@@ -83,7 +83,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg011.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg011.perseus-eng2">
                 <head>Paul's Letter to the Philippians</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg012/tlg0031.tlg012.perseus-eng2.xml
+++ b/data/tlg0031/tlg012/tlg0031.tlg012.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg012.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg012.perseus-eng2">
                 <head>Paul's Letter to the Colossians</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg013/tlg0031.tlg013.perseus-eng2.xml
+++ b/data/tlg0031/tlg013/tlg0031.tlg013.perseus-eng2.xml
@@ -86,7 +86,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="en">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg013.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg013.perseus-eng2">
                 <head>Paul's First Letter to the Thessalonians</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg014/tlg0031.tlg014.perseus-eng2.xml
+++ b/data/tlg0031/tlg014/tlg0031.tlg014.perseus-eng2.xml
@@ -87,7 +87,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg014.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg014.perseus-eng2">
                 <head>Paul's Second Letter to the Thessalonians</head>
                 <div type="textpart" subtype="chapter" n="1">
                 

--- a/data/tlg0031/tlg015/tlg0031.tlg015.perseus-eng2.xml
+++ b/data/tlg0031/tlg015/tlg0031.tlg015.perseus-eng2.xml
@@ -86,7 +86,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg015.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg015.perseus-eng2">
                 <head>Paul's First Letter to Timothy</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg016/tlg0031.tlg016.perseus-eng2.xml
+++ b/data/tlg0031/tlg016/tlg0031.tlg016.perseus-eng2.xml
@@ -86,7 +86,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg016.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg016.perseus-eng2">
                 <head>Paul's Second Letter to Timothy</head>
                 <div type="textpart" subtype="chapter" n="1">
                 

--- a/data/tlg0031/tlg017/tlg0031.tlg017.perseus-eng2.xml
+++ b/data/tlg0031/tlg017/tlg0031.tlg017.perseus-eng2.xml
@@ -85,7 +85,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg017.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg017.perseus-eng2">
                 <head>Paul's Letter to Titus</head>
                 <div type="textpart" subtype="chapter" n="1">
                 

--- a/data/tlg0031/tlg018/tlg0031.tlg018.perseus-eng2.xml
+++ b/data/tlg0031/tlg018/tlg0031.tlg018.perseus-eng2.xml
@@ -85,7 +85,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg018.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg018.perseus-eng2">
                 <head>Paul's Letter to Philemon</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg019/tlg0031.tlg019.perseus-eng2.xml
+++ b/data/tlg0031/tlg019/tlg0031.tlg019.perseus-eng2.xml
@@ -87,7 +87,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg019.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg019.perseus-eng2">
                 <head>The Letter to the Hebrews</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg020/tlg0031.tlg020.perseus-eng2.xml
+++ b/data/tlg0031/tlg020/tlg0031.tlg020.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg020.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg020.perseus-eng2">
                 <head>The Letter from James</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg021/tlg0031.tlg021.perseus-eng2.xml
+++ b/data/tlg0031/tlg021/tlg0031.tlg021.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg021.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg021.perseus-eng2">
                 <head>Peter's First Letter</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg022/tlg0031.tlg022.perseus-eng2.xml
+++ b/data/tlg0031/tlg022/tlg0031.tlg022.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg022.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg022.perseus-eng2">
                 <head>Peter's Second Letter</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg023/tlg0031.tlg023.perseus-eng2.xml
+++ b/data/tlg0031/tlg023/tlg0031.tlg023.perseus-eng2.xml
@@ -85,7 +85,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg023.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg023.perseus-eng2">
                 <head>John's First Letter</head>
                 <div type="textpart" subtype="chapter" n="1">
                    

--- a/data/tlg0031/tlg024/tlg0031.tlg024.perseus-eng2.xml
+++ b/data/tlg0031/tlg024/tlg0031.tlg024.perseus-eng2.xml
@@ -85,7 +85,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg024.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg024.perseus-eng2">
                 <head>John's Second Letter</head>
                 <div type="textpart" subtype="chapter" n="1">
                  

--- a/data/tlg0031/tlg025/tlg0031.tlg025.perseus-eng2.xml
+++ b/data/tlg0031/tlg025/tlg0031.tlg025.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg025.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg025.perseus-eng2">
                 <head>John's Third Letter</head>
                 <div type="textpart" subtype="chapter" n="1">
                   

--- a/data/tlg0031/tlg026/tlg0031.tlg026.perseus-eng2.xml
+++ b/data/tlg0031/tlg026/tlg0031.tlg026.perseus-eng2.xml
@@ -85,7 +85,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg026.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg026.perseus-eng2">
                 <head>The Letter from Jude</head>
                 <div type="textpart" subtype="chapter" n="1">
                     <div type="textpart" subtype="verse" n="1"><p>

--- a/data/tlg0031/tlg027/tlg0031.tlg027.perseus-eng2.xml
+++ b/data/tlg0031/tlg027/tlg0031.tlg027.perseus-eng2.xml
@@ -84,7 +84,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     </teiHeader>
     <text xml:lang="eng">
         <body>
-            <div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg027.perseus-eng2">
+            <div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0031.tlg027.perseus-eng2">
                 <head>The Revelation to John</head>
                 <div type="textpart" subtype="chapter" n="1">
                     <div type="textpart" subtype="verse" n="1"><p>

--- a/data/tlg0032/tlg004/tlg0032.tlg004.perseus-eng2.xml
+++ b/data/tlg0032/tlg004/tlg0032.tlg004.perseus-eng2.xml
@@ -90,7 +90,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
         
         <text xml:lang="eng">
                 <body>
-                        <div type="edition" n="urn:cts:greekLit:tlg0032.tlg004.perseus-eng2" xml:lang="eng">
+                        <div type="translation" n="urn:cts:greekLit:tlg0032.tlg004.perseus-eng2" xml:lang="eng">
 
                         <div type="textpart" subtype="chapter" n="1">
                                 <div type="textpart" subtype="section" n="1">

--- a/data/tlg0032/tlg005/tlg0032.tlg005.perseus-eng2.xml
+++ b/data/tlg0032/tlg005/tlg0032.tlg005.perseus-eng2.xml
@@ -75,7 +75,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text xml:lang="eng">
         <body>
             
-            <div type="edition" n="urn:cts:greekLit:tlg0032.tlg005.perseus-eng2" xml:lang="eng">
+            <div type="translation" n="urn:cts:greekLit:tlg0032.tlg005.perseus-eng2" xml:lang="eng">
             <div type="textpart" subtype="section" n="1">
                 <p><milestone ed="P" unit="para"/>It seems to me fitting to hand down to memory,
                     furthermore, how <persName><surname>Socrates</surname></persName>, on being

--- a/data/tlg0032/tlg006/tlg0032.tlg006.perseus-eng2.xml
+++ b/data/tlg0032/tlg006/tlg0032.tlg006.perseus-eng2.xml
@@ -93,7 +93,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
     <text xml:lang="eng">
         <body>
-            <div type="edition" n="urn:cts:greekLit:tlg0032.tlg006.perseus-eng2" xml:lang="eng">
+            <div type="translation" n="urn:cts:greekLit:tlg0032.tlg006.perseus-eng2" xml:lang="eng">
 
                 <div type="textpart" subtype="book" n="1">
                     <div type="textpart" subtype="chapter" n="1">

--- a/data/tlg0032/tlg007/tlg0032.tlg007.perseus-eng2.xml
+++ b/data/tlg0032/tlg007/tlg0032.tlg007.perseus-eng2.xml
@@ -86,7 +86,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 	<text xml:lang="eng">
 	<body>
-		<div type="edition" n="urn:cts:greekLit:tlg0032.tlg007.perseus-eng2" xml:lang="eng">
+		<div type="translation" n="urn:cts:greekLit:tlg0032.tlg007.perseus-eng2" xml:lang="eng">
 
 			<div type="textpart" subtype="book" n="1">
 	<div type="textpart" subtype="chapter" n="1">

--- a/data/tlg0059/tlg031/tlg0059.tlg031.perseus-eng2.xml
+++ b/data/tlg0059/tlg031/tlg0059.tlg031.perseus-eng2.xml
@@ -86,7 +86,7 @@
 	
    <text xml:lang="eng">
       <body> 
-         <div type="edition" n="urn:cts:greekLit:tlg0059.tlg031.perseus-eng2" xml:lang="eng"> 
+         <div type="translation" n="urn:cts:greekLit:tlg0059.tlg031.perseus-eng2" xml:lang="eng"> 
             <div type="textpart" subtype="section" resp="perseus" n="17">
                <milestone unit="page" resp="Stephanus" n="17"/><milestone unit="section" resp="Stephanus" n="17a"/> 
 

--- a/data/tlg0525/tlg001/tlg0525.tlg001.perseus-eng2.xml
+++ b/data/tlg0525/tlg001/tlg0525.tlg001.perseus-eng2.xml
@@ -100,7 +100,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 	
 <text xml:lang="eng">
 	<body>
-		<div xml:lang="eng" n="urn:cts:greekLit:tlg0525.tlg001.perseus-eng2" type="edition">
+		<div xml:lang="eng" n="urn:cts:greekLit:tlg0525.tlg001.perseus-eng2" type="translation">
 <div n="1" subtype="book" type="textpart">
 	<head><placeName key="tgn,7002681">Attica</placeName></head>
 	<div n="1" subtype="chapter" type="textpart">

--- a/data/tlg0551/tlg002/tlg0551.tlg002.perseus-eng2.xml
+++ b/data/tlg0551/tlg002/tlg0551.tlg002.perseus-eng2.xml
@@ -84,7 +84,7 @@
    </teiHeader>
    <text xml:lang="eng">
 				  <body>
-				  	<div type="edition" xml:lang="eng"  n="urn:cts:greekLit:tlg0551.tlg002.perseus-eng2">
+				  	<div type="translation" xml:lang="eng"  n="urn:cts:greekLit:tlg0551.tlg002.perseus-eng2">
 					
 					       <head>CONCERNING THE KINGS</head>
 				  		<div subtype="chapter" type="textpart" >

--- a/data/tlg0551/tlg003/tlg0551.tlg003.perseus-eng2.xml
+++ b/data/tlg0551/tlg003/tlg0551.tlg003.perseus-eng2.xml
@@ -77,7 +77,7 @@
 	  </teiHeader>
    <text xml:lang="eng">
 				  <body>
-				  	<div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0551.tlg003.perseus-eng2">
+				  	<div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0551.tlg003.perseus-eng2">
 					    <head>CONCERNING ITALY</head>
 					    <div subtype="chapter" type="textpart">
 						      <head>Fragments</head>

--- a/data/tlg0551/tlg004/tlg0551.tlg004.perseus-eng2.xml
+++ b/data/tlg0551/tlg004/tlg0551.tlg004.perseus-eng2.xml
@@ -85,7 +85,7 @@
 		
 	</teiHeader><text xml:lang="eng">
 				<body>
-					<div type="edition" xml:lang="eng" n="urn:cts:greekLit:tlg0551.tlg004.perseus-eng2">
+					<div type="translation" xml:lang="eng" n="urn:cts:greekLit:tlg0551.tlg004.perseus-eng2">
 					<head>THE SAMNITE HISTORY</head>
 					<div type ="textpart" subtype="chapter">
 						<head>Fragments</head>

--- a/data/tlg0551/tlg005/tlg0551.tlg005.perseus-eng2.xml
+++ b/data/tlg0551/tlg005/tlg0551.tlg005.perseus-eng2.xml
@@ -95,7 +95,7 @@
 	  </teiHeader>
    <text xml:lang="en">
 				  <body>
-         <div xml:lang="grc" type="edition" n="urn:cts:greekLit:tlg0551.tlg005.perseus-eng2">
+         <div xml:lang="grc" type="translation" n="urn:cts:greekLit:tlg0551.tlg005.perseus-eng2">
 					
 					       <head>THE GALLIC HISTORY</head>
 					       <div type="textpart" subtype="chapter">

--- a/data/tlg0551/tlg006/tlg0551.tlg006.perseus-eng2.xml
+++ b/data/tlg0551/tlg006/tlg0551.tlg006.perseus-eng2.xml
@@ -87,7 +87,7 @@
 	
 	</teiHeader><text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg006.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg006.perseus-eng2" xml:lang="eng">
 					<head>OF SICILY AND THE OTHER ISLANDS</head>
 					<div type="textpart" subtype="chapter">
 						<head>Fragments</head>

--- a/data/tlg0551/tlg007/tlg0551.tlg007.perseus-eng2.xml
+++ b/data/tlg0551/tlg007/tlg0551.tlg007.perseus-eng2.xml
@@ -115,7 +115,7 @@ fix the XML files so they are valid, make the SGML obsolete so no one is confuse
 	
 	  <text xml:lang="eng">
 				  <body >
-				     <div type="edition" n="urn:cts:greekLit:tlg0551.tlg007.perseus-eng2" xml:lang="eng">
+				     <div type="translation" n="urn:cts:greekLit:tlg0551.tlg007.perseus-eng2" xml:lang="eng">
 					    <head>THE WARS IN SPAIN</head>
 					    <div n="1" type="textpart" subtype="chapter">
 						      <head n="1">CHAPTER I</head>

--- a/data/tlg0551/tlg008/tlg0551.tlg008.perseus-eng2.xml
+++ b/data/tlg0551/tlg008/tlg0551.tlg008.perseus-eng2.xml
@@ -98,7 +98,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div n="urn:cts:greekLit:tlg0551.tlg008.perseus-eng2" type="edition" xml:lang="eng">
+					<div n="urn:cts:greekLit:tlg0551.tlg008.perseus-eng2" type="translation" xml:lang="eng">
 					<head>THE HANNIBALIC WAR</head>
 					<div n="1" type="textpart" subtype="chapter">
 						<head>CHAPTER I</head>

--- a/data/tlg0551/tlg009/tlg0551.tlg009.perseus-eng2.xml
+++ b/data/tlg0551/tlg009/tlg0551.tlg009.perseus-eng2.xml
@@ -101,7 +101,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div n="urn:cts:greekLit:tlg0551.tlg009.perseus-eng2" type="edition" xml:lang="eng">
+					<div n="urn:cts:greekLit:tlg0551.tlg009.perseus-eng2" type="translation" xml:lang="eng">
 					<head>THE PUNIC WARS</head>
 					<div n="1" type="textpart" subtype="chapter">
 						<head>CHAPTER I</head>

--- a/data/tlg0551/tlg010/tlg0551.tlg010.perseus-eng2.xml
+++ b/data/tlg0551/tlg010/tlg0551.tlg010.perseus-eng2.xml
@@ -97,7 +97,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg010.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg010.perseus-eng2" xml:lang="eng">
 					<head>NUMIDIAN AFFAIRS</head>
 					<div subtype="chapter" type="textpart" n="1">
 						<div n="I" type="textpart" subtype="fragment"><cit>

--- a/data/tlg0551/tlg011/tlg0551.tlg011.perseus-eng2.xml
+++ b/data/tlg0551/tlg011/tlg0551.tlg011.perseus-eng2.xml
@@ -92,7 +92,7 @@
       </change>--><change when="2014-08-01" who="Stella Dee">edited markup</change><change when="2016-01-05" who="TDBuck">p4 to p5</change></revisionDesc></teiHeader>
 	<text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg011.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg011.perseus-eng2" xml:lang="eng">
 					<head>MACEDONIAN AFFAIRS</head>
 					<div type="textpart" subtype="chapter" n="1">
 						<head>Fragments</head>

--- a/data/tlg0551/tlg012/tlg0551.tlg012.perseus-eng2.xml
+++ b/data/tlg0551/tlg012/tlg0551.tlg012.perseus-eng2.xml
@@ -100,7 +100,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg012.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg012.perseus-eng2" xml:lang="eng">
 					<head>THE ILLYRIAN WARS</head>
 					<div n="1" type="textpart" subtype="textpart">
 						<head>CHAPTER I</head>

--- a/data/tlg0551/tlg013/tlg0551.tlg013.perseus-eng2.xml
+++ b/data/tlg0551/tlg013/tlg0551.tlg013.perseus-eng2.xml
@@ -106,7 +106,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg013.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg013.perseus-eng2" xml:lang="eng">
 					<head>THE SYRIAN WARS</head>
 					<div n="1" type="textpart" subtype="chapter">
 						<head>CHAPTER I</head>

--- a/data/tlg0551/tlg014/tlg0551.tlg014.perseus-eng2.xml
+++ b/data/tlg0551/tlg014/tlg0551.tlg014.perseus-eng2.xml
@@ -99,7 +99,7 @@
 	
 	<text xml:lang="eng">
 				<body>
-					<div type="edition" n="urn:cts:greekLit:tlg0551.tlg014.perseus-eng2" xml:lang="eng">
+					<div type="translation" n="urn:cts:greekLit:tlg0551.tlg014.perseus-eng2" xml:lang="eng">
 					<head>THE MITHRIDATIC WARS</head>
 					<div n="1" type="textpart" subtype="chapter">
 						<head>CHAPTER I</head>

--- a/data/tlg0551/tlg017/tlg0551.tlg017.perseus-eng2.xml
+++ b/data/tlg0551/tlg017/tlg0551.tlg017.perseus-eng2.xml
@@ -90,7 +90,7 @@ cvs log keyword
 	<text xml:lang="eng">
 		<body>
 
-			<div type="edition" n="urn:cts:greekLit:tlg0551.tlg017.perseus-eng2" xml:lang="eng">
+			<div type="translation" n="urn:cts:greekLit:tlg0551.tlg017.perseus-eng2" xml:lang="eng">
 				<div n="1" type="textpart" subtype="book">
 				<head>THE CIVIL WARS</head>
 				<!--


### PR DESCRIPTION
A number of translations are incorrectly marked as:

```xml
<div type="edition" ...>...</div>
```

Instead, they should be marked as:

```xml
<div type="translation" ...>...</div>
```