### PR TITLE
Fix incorrect div type assignment

### DIFF
--- a/data/tlg0062/tlg068/tlg0062.tlg068.perseus-eng4.xml
+++ b/data/tlg0062/tlg068/tlg0062.tlg068.perseus-eng4.xml
@@ -840,7 +840,7 @@ Love and Desire. They shall be your guides. Love will assail her in all his migh
 
 </div>
 
-<div type="edition" subtype="book" xml:base="urn:cts:greekLit:tlg0062.tlg068.perseus-eng4" n="21">
+<div type="textpart" subtype="book" xml:base="urn:cts:greekLit:tlg0062.tlg068.perseus-eng4" n="21">
 <head>XXI</head>
 
 <head><label>Ares</label>. <label>Hermes</label></head>


### PR DESCRIPTION
This commit fixes a div which was incorrectly assigned as `type="edition"` when it should be `type="textpart"`.