### PR TITLE
(tlg0006.tlg002.perseus-eng2.xml, tlg0006.tlg004.perseus-grc2.xml) Fix a missing `<speaker>`

### DIFF
--- a/data/tlg0006/tlg002/tlg0006.tlg002.perseus-eng2.xml
+++ b/data/tlg0006/tlg002/tlg0006.tlg002.perseus-eng2.xml
@@ -1219,7 +1219,7 @@
    <milestone resp="perseus" n="1006" unit="card"/>
    
 <div type="textpart" subtype="episode">
-   <sp><speaker></speaker>
+   <sp><speaker>Chorus</speaker>
       <l xml:base="urn:cts:greekLit:tlg0006.tlg002.perseus-eng2" resp="perseus" rend="indent" n="1006">But see, Admetus! yonder, I believe, comes Alcmena’s son toward thy hearth.</l>
    </sp>
    

--- a/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
+++ b/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
@@ -1829,7 +1829,7 @@
 
 <milestone n="1018" unit="card" resp="perseus"/>
 
-<sp><speaker>—</speaker>
+<sp><speaker>Χορός</speaker>
     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1018">παραινέσαι σοι σμικρόν, Ἀλκμήνη, θέλω, </l>
     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1019">τὸν ἄνδρʼ ἀφεῖναι τόνδʼ, ἐπεὶ δοκεῖ πόλει. </l>
 </sp>
@@ -1838,7 +1838,7 @@
     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1020">τί δʼ, ἢν θάνῃ τε καὶ πόλει πιθώμεθα; </l>
 </sp>
 
-<sp><speaker>—</speaker>
+<sp><speaker>Χορός</speaker>
     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1021">τὰ λῷστ’ ἂν εἴη· πῶς τάδʼ οὖν γενήσεται; </l>
 </sp>
 


### PR DESCRIPTION
The corresponding Greek file has `<sp><speaker>Χορός</speaker>...</sp>`. So
this appears to just be an oversight.
