### PR TITLE
tlg0014_all_files-the great name change

### DIFF
--- a/data/tlg0014/tlg001/tlg0014.tlg001.perseus-eng2.xml
+++ b/data/tlg0014/tlg001/tlg0014.tlg001.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>First Olynthiac</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg001/tlg0014.tlg001.perseus-grc2.xml
+++ b/data/tlg0014/tlg001/tlg0014.tlg001.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">Ὀλυνθιακὸς α΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg002/tlg0014.tlg002.perseus-eng2.xml
+++ b/data/tlg0014/tlg002/tlg0014.tlg002.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Second Olynthiac</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg002/tlg0014.tlg002.perseus-grc2.xml
+++ b/data/tlg0014/tlg002/tlg0014.tlg002.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			      <titleStmt>
 			      	<title xml:lang="grc">Ὀλυνθιακὸς β΄</title>
 				        <author>Demosthenes</author>
-			      	    <editor>S. H. Butcher</editor>
+			      	    <editor>Samuel Henry Butcher</editor>
 				        <sponsor>Perseus Project, Tufts University</sponsor>
 				        <principal>Gregory Crane</principal>
 				        <respStmt>
@@ -32,7 +32,7 @@
 				        	<monogr>
 				        		<author>Demosthenes</author>
 				        		<title xml:lang="lat">Demosthenis Orationes</title>
-				        		<editor>S. H. Butcher</editor>
+				        		<editor>Samuel Henry Butcher</editor>
 				        		<imprint>
 				        			<publisher>Clarendon Press</publisher>
 				        			<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg003/tlg0014.tlg003.perseus-eng2.xml
+++ b/data/tlg0014/tlg003/tlg0014.tlg003.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Third Olynthiac</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg003/tlg0014.tlg003.perseus-grc2.xml
+++ b/data/tlg0014/tlg003/tlg0014.tlg003.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			      <titleStmt>
 			      	<title xml:lang="grc">Ὀλυνθιακὸς γ΄</title>
 				        <author>Demosthenes</author>
-			      	    <editor>S. H. Butcher</editor>
+			      	    <editor>Samuel Henry Butcher</editor>
 				        <sponsor>Perseus Project, Tufts University</sponsor>
 				        <principal>Gregory Crane</principal>
 				        <respStmt>
@@ -31,7 +31,7 @@
 				            <monogr>
 				                <author>Demosthenes</author>
 				                <title xml:lang="lat">Demosthenis Orationes</title>
-				                <editor>S. H. Butcher</editor>
+				                <editor>Samuel Henry Butcher</editor>
 				                <imprint>
 				                    <publisher>Clarendon Press</publisher>
 				                    <pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg004/tlg0014.tlg004.perseus-eng2.xml
+++ b/data/tlg0014/tlg004/tlg0014.tlg004.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>First Philippic</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg004/tlg0014.tlg004.perseus-grc2.xml
+++ b/data/tlg0014/tlg004/tlg0014.tlg004.perseus-grc2.xml
@@ -6,7 +6,7 @@
          <titleStmt>
             <title xml:lang="grc">κατὰ Φιλίππου α΄</title>
             <author>Demosthenes</author>
-            <editor>S. H. Butcher</editor>
+            <editor>Samuel Henry Butcher</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -31,7 +31,7 @@
                <monogr>
                   <author>Demosthenes</author>
                   <title xml:lang="lat">Demosthenis Orationes</title>
-                  <editor>S. H. Butcher</editor>
+                  <editor>Samuel Henry Butcher</editor>
                   <imprint>
                      <publisher>Clarendon Press</publisher>
                      <pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg005/tlg0014.tlg005.perseus-eng2.xml
+++ b/data/tlg0014/tlg005/tlg0014.tlg005.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>On the Peace</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg005/tlg0014.tlg005.perseus-grc2.xml
+++ b/data/tlg0014/tlg005/tlg0014.tlg005.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title>περὶ τῆς εἰρήνης</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg006/tlg0014.tlg006.perseus-eng2.xml
+++ b/data/tlg0014/tlg006/tlg0014.tlg006.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Second Philippic</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg006/tlg0014.tlg006.perseus-grc2.xml
+++ b/data/tlg0014/tlg006/tlg0014.tlg006.perseus-grc2.xml
@@ -7,7 +7,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Φιλίππου β΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -33,7 +33,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg007/tlg0014.tlg007.perseus-eng2.xml
+++ b/data/tlg0014/tlg007/tlg0014.tlg007.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>On Halonnesus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg007/tlg0014.tlg007.perseus-grc2.xml
+++ b/data/tlg0014/tlg007/tlg0014.tlg007.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ Ἀλοννήσου</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg008/tlg0014.tlg008.perseus-eng2.xml
+++ b/data/tlg0014/tlg008/tlg0014.tlg008.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>On the Chersonese</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg008/tlg0014.tlg008.perseus-grc2.xml
+++ b/data/tlg0014/tlg008/tlg0014.tlg008.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τῶν ἐν Χερρονήσῳ</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg009/tlg0014.tlg009.perseus-eng2.xml
+++ b/data/tlg0014/tlg009/tlg0014.tlg009.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Third Philippic</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg009/tlg0014.tlg009.perseus-grc2.xml
+++ b/data/tlg0014/tlg009/tlg0014.tlg009.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Φιλίππου γ΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -33,7 +33,7 @@
 				<monogr>
 				<author>Demosthenes</author>
 					<title xml:lang="lat">Demosthenis Orationes</title>
-					<editor>S. H. Butcher</editor>
+					<editor>Samuel Henry Butcher</editor>
 					<imprint>
 						<publisher>Clarendon Press</publisher>
 						<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg010/tlg0014.tlg010.perseus-eng2.xml
+++ b/data/tlg0014/tlg010/tlg0014.tlg010.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Fourth Philippic</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg010/tlg0014.tlg010.perseus-grc2.xml
+++ b/data/tlg0014/tlg010/tlg0014.tlg010.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Φιλίππου δ΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg011/tlg0014.tlg011.perseus-eng2.xml
+++ b/data/tlg0014/tlg011/tlg0014.tlg011.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Answer to Philip’s Letter</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg011/tlg0014.tlg011.perseus-grc2.xml
+++ b/data/tlg0014/tlg011/tlg0014.tlg011.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς τὴν ἐπιστολήν τὴν Φιλίππου</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg012/tlg0014.tlg012.perseus-eng2.xml
+++ b/data/tlg0014/tlg012/tlg0014.tlg012.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Philip’s Letter</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg012/tlg0014.tlg012.perseus-grc2.xml
+++ b/data/tlg0014/tlg012/tlg0014.tlg012.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ἐπιστολή [Φιλίππου]</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg013/tlg0014.tlg013.perseus-eng2.xml
+++ b/data/tlg0014/tlg013/tlg0014.tlg013.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>On Organization</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg013/tlg0014.tlg013.perseus-grc2.xml
+++ b/data/tlg0014/tlg013/tlg0014.tlg013.perseus-grc2.xml
@@ -7,7 +7,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ συντάξεως</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -32,7 +32,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg014/tlg0014.tlg014.perseus-eng2.xml
+++ b/data/tlg0014/tlg014/tlg0014.tlg014.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>On the Navy-Boards</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg014/tlg0014.tlg014.perseus-grc2.xml
+++ b/data/tlg0014/tlg014/tlg0014.tlg014.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τῶν συμμοριῶν</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg015/tlg0014.tlg015.perseus-eng2.xml
+++ b/data/tlg0014/tlg015/tlg0014.tlg015.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>For the Liberty of the Rhodians</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg015/tlg0014.tlg015.perseus-grc2.xml
+++ b/data/tlg0014/tlg015/tlg0014.tlg015.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ὑπὲρ τῆς Ῥοδίων ἐλευθερίας</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -32,7 +32,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg016/tlg0014.tlg016.perseus-eng2.xml
+++ b/data/tlg0014/tlg016/tlg0014.tlg016.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>For the People of Megalopolis</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg016/tlg0014.tlg016.perseus-grc2.xml
+++ b/data/tlg0014/tlg016/tlg0014.tlg016.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ὑπὲρ Μεγαλοπολιτῶν</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -31,7 +31,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg017/tlg0014.tlg017.perseus-eng2.xml
+++ b/data/tlg0014/tlg017/tlg0014.tlg017.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>On the Treaty with Alexander</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,7 +31,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg017/tlg0014.tlg017.perseus-grc2.xml
+++ b/data/tlg0014/tlg017/tlg0014.tlg017.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τῶν πρὸς Ἀλέξανδρον συνθηκῶν</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher><pubPlace>Oxford</pubPlace>
 							<date>1903</date>

--- a/data/tlg0014/tlg018/tlg0014.tlg018.perseus-eng2.xml
+++ b/data/tlg0014/tlg018/tlg0014.tlg018.perseus-eng2.xml
@@ -5,8 +5,8 @@
             <titleStmt>
                 <title>On the Crown</title>
                 <author>Demosthenes</author>
-                <editor role="translator">C. A. Vince</editor>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">Charles Anthony Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -31,8 +31,8 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">De Corona, De Falsa Legatione, XVIII, XIX</title>
-                        <editor role="translator">C. A. Vince</editor>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">Charles Anthony Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg018/tlg0014.tlg018.perseus-grc2.xml
+++ b/data/tlg0014/tlg018/tlg0014.tlg018.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ὑπὲρ Κτησιφῶντος περὶ τοῦ στεφάνου</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg019/tlg0014.tlg019.perseus-eng2.xml
+++ b/data/tlg0014/tlg019/tlg0014.tlg019.perseus-eng2.xml
@@ -5,8 +5,8 @@
             <titleStmt>
                 <title>On the Embassy</title>
                 <author>Demosthenes</author>
-                <editor role="translator">C. A. Vince</editor>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">Charles Anthony Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,8 +30,8 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">De Corona, De Falsa Legatione, XVIII, XIX</title>
-                        <editor role="translator">C. A. Vince</editor>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">Charles Anthony Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg019/tlg0014.tlg019.perseus-grc2.xml
+++ b/data/tlg0014/tlg019/tlg0014.tlg019.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τῆς παραπρεσβείας</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenis Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher><pubPlace>Oxford</pubPlace>
 							<date>1903</date>

--- a/data/tlg0014/tlg020/tlg0014.tlg020.perseus-eng2.xml
+++ b/data/tlg0014/tlg020/tlg0014.tlg020.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Leptines</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Olynthiacs, Philippics, Minor Public Speeches, Speech Against Leptines, I-XVII, XX</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg020/tlg0014.tlg020.perseus-grc2.xml
+++ b/data/tlg0014/tlg020/tlg0014.tlg020.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τῆς Ἀτελείας πρὸς Λεπτίνην</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg021/tlg0014.tlg021.perseus-eng2.xml
+++ b/data/tlg0014/tlg021/tlg0014.tlg021.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Meidias</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg021/tlg0014.tlg021.perseus-grc2.xml
+++ b/data/tlg0014/tlg021/tlg0014.tlg021.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Μειδίου περὶ τοῦ Κονδύλου</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg022/tlg0014.tlg022.perseus-eng2.xml
+++ b/data/tlg0014/tlg022/tlg0014.tlg022.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Androtion</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg022/tlg0014.tlg022.perseus-grc2.xml
+++ b/data/tlg0014/tlg022/tlg0014.tlg022.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀνδροτίωνος παρανόμων</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg023/tlg0014.tlg023.perseus-eng2.xml
+++ b/data/tlg0014/tlg023/tlg0014.tlg023.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aristocrates</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg023/tlg0014.tlg023.perseus-grc2.xml
+++ b/data/tlg0014/tlg023/tlg0014.tlg023.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀριστοκράτους</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg024/tlg0014.tlg024.perseus-eng2.xml
+++ b/data/tlg0014/tlg024/tlg0014.tlg024.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Timocrates</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg024/tlg0014.tlg024.perseus-grc2.xml
+++ b/data/tlg0014/tlg024/tlg0014.tlg024.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Τιμοκράτους</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg025/tlg0014.tlg025.perseus-eng2.xml
+++ b/data/tlg0014/tlg025/tlg0014.tlg025.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aristogeiton I</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg025/tlg0014.tlg025.perseus-grc2.xml
+++ b/data/tlg0014/tlg025/tlg0014.tlg025.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀριστογείτονος α΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg026/tlg0014.tlg026.perseus-eng2.xml
+++ b/data/tlg0014/tlg026/tlg0014.tlg026.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aristogeiton II</title>
                 <author>Demosthenes</author>
-                <editor role="translator">J. H. Vince</editor>
+                <editor role="translator">James Herbert Vince</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Against Meidias, Androtion, Aristocrates, Timocrates, Aristogeiton</title>
-                        <editor role="translator">J.H. Vince</editor>
+                        <editor role="translator">James Herbert Vince</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg026/tlg0014.tlg026.perseus-grc2.xml
+++ b/data/tlg0014/tlg026/tlg0014.tlg026.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀριστογείτονος β΄</title>
 				<author>Demosthenes</author>
-				<editor>S. H. Butcher</editor>
+				<editor>Samuel Henry Butcher</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>S. H. Butcher</editor>
+						<editor>Samuel Henry Butcher</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg027/tlg0014.tlg027.perseus-eng2.xml
+++ b/data/tlg0014/tlg027/tlg0014.tlg027.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aphobus I</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg027/tlg0014.tlg027.perseus-grc2.xml
+++ b/data/tlg0014/tlg027/tlg0014.tlg027.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀφόβου ἐπιτροπῆς α΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg028/tlg0014.tlg028.perseus-eng2.xml
+++ b/data/tlg0014/tlg028/tlg0014.tlg028.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aphobus II</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg028/tlg0014.tlg028.perseus-grc2.xml
+++ b/data/tlg0014/tlg028/tlg0014.tlg028.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ἀφόβου β΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg029/tlg0014.tlg029.perseus-eng2.xml
+++ b/data/tlg0014/tlg029/tlg0014.tlg029.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Aphobus III</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg029/tlg0014.tlg029.perseus-grc2.xml
+++ b/data/tlg0014/tlg029/tlg0014.tlg029.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Ἄφοβον ὑπὲρ Φάνου ψευδομαρτυριῶν γ΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg030/tlg0014.tlg030.perseus-eng2.xml
+++ b/data/tlg0014/tlg030/tlg0014.tlg030.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Onetor I</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg030/tlg0014.tlg030.perseus-grc2.xml
+++ b/data/tlg0014/tlg030/tlg0014.tlg030.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Ὀνήτορα ἐξούλης α΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg031/tlg0014.tlg031.perseus-eng2.xml
+++ b/data/tlg0014/tlg031/tlg0014.tlg031.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Against Onetor II</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg031/tlg0014.tlg031.perseus-grc2.xml
+++ b/data/tlg0014/tlg031/tlg0014.tlg031.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title>πρὸς Ὀνήτορα ἐξούλης β΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg032/tlg0014.tlg032.perseus-eng2.xml
+++ b/data/tlg0014/tlg032/tlg0014.tlg032.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Zenothemis</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg032/tlg0014.tlg032.perseus-grc2.xml
+++ b/data/tlg0014/tlg032/tlg0014.tlg032.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Ζηνόθεμιν παραγραφή</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg033/tlg0014.tlg033.perseus-eng2.xml
+++ b/data/tlg0014/tlg033/tlg0014.tlg033.perseus-eng2.xml
@@ -6,7 +6,7 @@
             <titleStmt>
                 <title>Against Apaturius</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -30,7 +30,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg033/tlg0014.tlg033.perseus-grc2.xml
+++ b/data/tlg0014/tlg033/tlg0014.tlg033.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Ἀπατούριον παραγραφή</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg034/tlg0014.tlg034.perseus-eng2.xml
+++ b/data/tlg0014/tlg034/tlg0014.tlg034.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Phormio</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg034/tlg0014.tlg034.perseus-grc2.xml
+++ b/data/tlg0014/tlg034/tlg0014.tlg034.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Φορμίωνα ὑπὲρ δανείου</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -29,7 +29,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg035/tlg0014.tlg035.perseus-eng2.xml
+++ b/data/tlg0014/tlg035/tlg0014.tlg035.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Lacritus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg035/tlg0014.tlg035.perseus-grc2.xml
+++ b/data/tlg0014/tlg035/tlg0014.tlg035.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς τὴν Λάκριτον παραγραφὴν</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg036/tlg0014.tlg036.perseus-eng2.xml
+++ b/data/tlg0014/tlg036/tlg0014.tlg036.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>For Phormio</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg036/tlg0014.tlg036.perseus-grc2.xml
+++ b/data/tlg0014/tlg036/tlg0014.tlg036.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">παραγραφὴ ὑπὲρ Φορμίωνος</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg037/tlg0014.tlg037.perseus-eng2.xml
+++ b/data/tlg0014/tlg037/tlg0014.tlg037.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Pantaenetus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg037/tlg0014.tlg037.perseus-grc2.xml
+++ b/data/tlg0014/tlg037/tlg0014.tlg037.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">παραγραφὴ πρὸς Πανταίνετον</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg038/tlg0014.tlg038.perseus-eng2.xml
+++ b/data/tlg0014/tlg038/tlg0014.tlg038.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Nausimachus and Xenopeithes</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg038/tlg0014.tlg038.perseus-grc2.xml
+++ b/data/tlg0014/tlg038/tlg0014.tlg038.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">παραγραφὴ πρὸς Ναυσίμακον καὶ Ξενοπείθην</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg039/tlg0014.tlg039.perseus-eng2.xml
+++ b/data/tlg0014/tlg039/tlg0014.tlg039.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Boeotus I</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg039/tlg0014.tlg039.perseus-grc2.xml
+++ b/data/tlg0014/tlg039/tlg0014.tlg039.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Βοιωτὸν περὶ τοῦ Ὀνόματος</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg040/tlg0014.tlg040.perseus-eng2.xml
+++ b/data/tlg0014/tlg040/tlg0014.tlg040.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Boeotus II</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XXVII-XL</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg040/tlg0014.tlg040.perseus-grc2.xml
+++ b/data/tlg0014/tlg040/tlg0014.tlg040.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Βοιωτὸν περὶ προικὸς μητρῴας</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Demosthenes Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg041/tlg0014.tlg041.perseus-eng2.xml
+++ b/data/tlg0014/tlg041/tlg0014.tlg041.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Spudias</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg041/tlg0014.tlg041.perseus-grc2.xml
+++ b/data/tlg0014/tlg041/tlg0014.tlg041.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Σπουδίαν ὑπὲρ προικός</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg042/tlg0014.tlg042.perseus-eng2.xml
+++ b/data/tlg0014/tlg042/tlg0014.tlg042.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Phaenippus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg042/tlg0014.tlg042.perseus-grc2.xml
+++ b/data/tlg0014/tlg042/tlg0014.tlg042.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Φαίνιππον περὶ ἀντιδόσεως</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg043/tlg0014.tlg043.perseus-eng2.xml
+++ b/data/tlg0014/tlg043/tlg0014.tlg043.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Macartatus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg043/tlg0014.tlg043.perseus-grc2.xml
+++ b/data/tlg0014/tlg043/tlg0014.tlg043.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Μακάρτατον περὶ Ἁγνίου κλήρου</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg044/tlg0014.tlg044.perseus-eng2.xml
+++ b/data/tlg0014/tlg044/tlg0014.tlg044.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Leochares</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg044/tlg0014.tlg044.perseus-grc2.xml
+++ b/data/tlg0014/tlg044/tlg0014.tlg044.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Λεωκάρη περὶ τοῦ Ἀρχιάδου κλήρου</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg045/tlg0014.tlg045.perseus-eng2.xml
+++ b/data/tlg0014/tlg045/tlg0014.tlg045.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Stephanus I</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg045/tlg0014.tlg045.perseus-grc2.xml
+++ b/data/tlg0014/tlg045/tlg0014.tlg045.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Στεφάνου ψευδομαρτυριῶν α΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg046/tlg0014.tlg046.perseus-eng2.xml
+++ b/data/tlg0014/tlg046/tlg0014.tlg046.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Stephanus II</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg046/tlg0014.tlg046.perseus-grc2.xml
+++ b/data/tlg0014/tlg046/tlg0014.tlg046.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Στεφάνου ψευδομαρτυριῶν β΄</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg047/tlg0014.tlg047.perseus-eng2.xml
+++ b/data/tlg0014/tlg047/tlg0014.tlg047.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Evergus And Mnesibulus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg047/tlg0014.tlg047.perseus-grc2.xml
+++ b/data/tlg0014/tlg047/tlg0014.tlg047.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Εὐέργου καὶ Μνησιβούλου ψευδομαρτυριῶν</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg048/tlg0014.tlg048.perseus-eng2.xml
+++ b/data/tlg0014/tlg048/tlg0014.tlg048.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Olympiodorus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg048/tlg0014.tlg048.perseus-grc2.xml
+++ b/data/tlg0014/tlg048/tlg0014.tlg048.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Ὀλυμπιοδώρου βλάβης</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg049/tlg0014.tlg049.perseus-eng2.xml
+++ b/data/tlg0014/tlg049/tlg0014.tlg049.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Timotheus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orations XLI-XLIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg049/tlg0014.tlg049.perseus-grc2.xml
+++ b/data/tlg0014/tlg049/tlg0014.tlg049.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Τιμόθεον ὑπὲρ χρέως</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg050/tlg0014.tlg050.perseus-eng2.xml
+++ b/data/tlg0014/tlg050/tlg0014.tlg050.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Polycles</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg050/tlg0014.tlg050.perseus-grc2.xml
+++ b/data/tlg0014/tlg050/tlg0014.tlg050.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Πολυκλέα περὶ τοῦ ἐπιτριηραρχήματος</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg051/tlg0014.tlg051.perseus-eng2.xml
+++ b/data/tlg0014/tlg051/tlg0014.tlg051.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>On The Trierarchic Crown</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg051/tlg0014.tlg051.perseus-grc2.xml
+++ b/data/tlg0014/tlg051/tlg0014.tlg051.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">περὶ τοῦ Στεφάνου τῆς τριηραρκίας</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg052/tlg0014.tlg052.perseus-eng2.xml
+++ b/data/tlg0014/tlg052/tlg0014.tlg052.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Callipus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg052/tlg0014.tlg052.perseus-grc2.xml
+++ b/data/tlg0014/tlg052/tlg0014.tlg052.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Κάλλιππον</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg053/tlg0014.tlg053.perseus-eng2.xml
+++ b/data/tlg0014/tlg053/tlg0014.tlg053.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Nicostratus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg053/tlg0014.tlg053.perseus-grc2.xml
+++ b/data/tlg0014/tlg053/tlg0014.tlg053.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Νικόστρατον περὶ ἀνδραπόδων ἀπογραφῆς Ἀρεθουσίου</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg054/tlg0014.tlg054.perseus-eng2.xml
+++ b/data/tlg0014/tlg054/tlg0014.tlg054.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Conon</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg054/tlg0014.tlg054.perseus-grc2.xml
+++ b/data/tlg0014/tlg054/tlg0014.tlg054.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Κόνωνος αἰκείας</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg055/tlg0014.tlg055.perseus-eng2.xml
+++ b/data/tlg0014/tlg055/tlg0014.tlg055.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Callicles</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg055/tlg0014.tlg055.perseus-grc2.xml
+++ b/data/tlg0014/tlg055/tlg0014.tlg055.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">πρὸς Καλλικλέα περὶ χωρίου βλάβης</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg056/tlg0014.tlg056.perseus-eng2.xml
+++ b/data/tlg0014/tlg056/tlg0014.tlg056.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Dionysodorus</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg056/tlg0014.tlg056.perseus-grc2.xml
+++ b/data/tlg0014/tlg056/tlg0014.tlg056.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Διονυσοδώρου βλάβης</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg057/tlg0014.tlg057.perseus-eng2.xml
+++ b/data/tlg0014/tlg057/tlg0014.tlg057.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Eubulides</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg057/tlg0014.tlg057.perseus-grc2.xml
+++ b/data/tlg0014/tlg057/tlg0014.tlg057.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ἔφεσις πρὸς Εὐβουλίδην</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg058/tlg0014.tlg058.perseus-eng2.xml
+++ b/data/tlg0014/tlg058/tlg0014.tlg058.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Against Theocrines</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                         <author>Demosthenes</author>
                         <title>Demosthenes</title>
                         <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                        <editor role="translator">A. T. Murray</editor>
+                        <editor role="translator">Augustus Taber Murray</editor>
                         <imprint>
                             <pubPlace>London</pubPlace>
                             <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg058/tlg0014.tlg058.perseus-grc2.xml
+++ b/data/tlg0014/tlg058/tlg0014.tlg058.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ἔνδειξις κατὰ Θεοκρίνου</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg059/tlg0014.tlg059.perseus-eng2.xml
+++ b/data/tlg0014/tlg059/tlg0014.tlg059.perseus-eng2.xml
@@ -5,7 +5,7 @@
             <titleStmt>
                 <title>Apollodorus Against Neaera</title>
                 <author>Demosthenes</author>
-                <editor role="translator">A. T. Murray</editor>
+                <editor role="translator">Augustus Taber Murray</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -29,7 +29,7 @@
                             <author>Demosthenes</author>
                             <title>Demosthenes</title>
                             <title type="sub">Private Orations: Orationes L-LVIII, in Neaeram LIX</title>
-                            <editor role="translator">A. T. Murray</editor>
+                            <editor role="translator">Augustus Taber Murray</editor>
                             <imprint>
                                 <pubPlace>London</pubPlace>
                                 <pubPlace>Cambridge, MA</pubPlace>

--- a/data/tlg0014/tlg059/tlg0014.tlg059.perseus-grc2.xml
+++ b/data/tlg0014/tlg059/tlg0014.tlg059.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">κατὰ Νεαίρας</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg060/tlg0014.tlg060.perseus-grc2.xml
+++ b/data/tlg0014/tlg060/tlg0014.tlg060.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ἐπιτάφιος</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg061/tlg0014.tlg061.perseus-grc2.xml
+++ b/data/tlg0014/tlg061/tlg0014.tlg061.perseus-grc2.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title xml:lang="grc">ἐρωτικὸς</title>
 				<author>Demosthenes</author>
-				<editor>W. Rennie</editor>
+				<editor>William Rennie</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -30,7 +30,7 @@
 					<monogr>
 						<author>Demosthenes</author>
 						<title xml:lang="lat">Orationes</title>
-						<editor>W. Rennie</editor>
+						<editor>William Rennie</editor>
 						<imprint>
 							<publisher>Clarendon Press</publisher>
 							<pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg062/tlg0014.tlg062.perseus-grc2.xml
+++ b/data/tlg0014/tlg062/tlg0014.tlg062.perseus-grc2.xml
@@ -6,7 +6,7 @@
 <titleStmt>
       <title xml:lang="grc">προοίμια δημηγορικά</title>
 <author>Demosthenes</author>
-      <editor>W. Rennie</editor>
+      <editor>William Rennie</editor>
 <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>
 <respStmt>
@@ -30,7 +30,7 @@
         <monogr>
          <author>Demosthenes</author>
          <title xml:lang="lat">Orationes</title>
-         <editor>W. Rennie</editor>
+         <editor>William Rennie</editor>
          <imprint>
           <publisher>Clarendon Press</publisher>
           <pubPlace>Oxford</pubPlace>

--- a/data/tlg0014/tlg063/tlg0014.tlg063.perseus-grc2.xml
+++ b/data/tlg0014/tlg063/tlg0014.tlg063.perseus-grc2.xml
@@ -6,7 +6,7 @@
 <titleStmt>
       <title xml:lang="grc">Δημοσθένους ἐπιστολαὶ</title>
       <author>Demosthenes</author>
-      <editor>W. Rennie</editor>
+      <editor>William Rennie</editor>
                   <sponsor>Perseus Project, Tufts University</sponsor>
                   <principal>Gregory Crane</principal>
                   <respStmt>
@@ -30,7 +30,7 @@
                         <monogr>
                               <author>Demosthenes</author>
                               <title xml:lang="lat">Orationes</title>
-                              <editor>W. Rennie</editor>
+                              <editor>William Rennie</editor>
                               <imprint>
                                     <publisher>Clarendon Press</publisher>
                                     <pubPlace>Oxford</pubPlace>


### PR DESCRIPTION
Spelling out all editor and translator names in the TEI-XML files.