### PR TITLE
tlg0020_all_files

### DIFF
--- a/data/tlg0020/__cts__.xml
+++ b/data/tlg0020/__cts__.xml
@@ -3,6 +3,5 @@
         
    <ti:groupname xml:lang="eng">Hesiod</ti:groupname>
         
-   <ti:groupname>Hesiod</ti:groupname>
     
 </ti:textgroup>

--- a/data/tlg0020/tlg001/__cts__.xml
+++ b/data/tlg0020/tlg001/__cts__.xml
@@ -2,16 +2,15 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0020" projid="greekLit:tlg001" urn="urn:cts:greekLit:tlg0020.tlg001" xml:lang="grc">
    <ti:title xml:lang="eng">Theogony</ti:title>
    <ti:edition projid="greekLit:perseus-grc2" urn="urn:cts:greekLit:tlg0020.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0020.tlg001" xml:lang="grc">
-      <ti:label xml:lang="eng">Theogony, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator; Evelyn-White, Hugh G. (Hugh Gerard), d.
-                    1924, editor</ti:description>
+      <ti:label xml:lang="eng">Theogony</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica.
+         Evelyn-White, Hugh G., editor. London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:edition>
    <ti:translation projid="greekLit:perseus-eng2" urn="urn:cts:greekLit:tlg0020.tlg001.perseus-eng2" workUrn="urn:cts:greekLit:tlg0020.tlg001" xml:lang="eng">
-      <ti:label xml:lang="eng">Theogony, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator</ti:description>
+      <ti:label xml:lang="grc">Θεογονία</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica.
+         Evelyn-White, Hugh G., editor. London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:translation>    
 </ti:work>

--- a/data/tlg0020/tlg001/tlg0020.tlg001.perseus-eng2.xml
+++ b/data/tlg0020/tlg001/tlg0020.tlg001.perseus-eng2.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Theogony (English). Machine readable text</title>
+            <title>Theogony</title>     
             <author>Hesiod</author>
+              <editor role="translator">Hugh G. Evelyn-White</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -16,7 +18,6 @@
             </respStmt>
             <funder n="AnnCPB"> The Annenberg CPB Project</funder>
          </titleStmt>
-         <extent>about 75Kb</extent>
          <publicationStmt>
             <publisher>Trustees of Tufts University</publisher>
             <pubPlace>Medford, MA</pubPlace>
@@ -30,14 +31,20 @@
             <biblStruct>
                <monogr>
                   <author>Hesiod</author>
-                  <title>The Homeric Hymns and Homerica with an English Translation by
-                                   Hugh G. Evelyn-White. Theogony.</title>
+                  <title>The Homeric Hymns and Homerica</title>
+                    <editor role="translator">Hugh G. Evelyn-White</editor>
                   <imprint>
-                     <publisher>Cambridge, MA.,Harvard University Press; London,
-                                        William Heinemann Ltd.</publisher>
+                      <pubPlace>London</pubPlace>
+                     <publisher>William Heinemann Ltd.</publisher>
+                       <pubPlace>New York</pubPlace>
+                       <publisher>The Macmillan Co.</publisher>
                      <date>1914</date>
                   </imprint>
                </monogr>
+                 <series>
+                      <title>Loeb Classical Library</title>
+                 </series>
+                 <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/78/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>
@@ -105,7 +112,7 @@ Milestone     Original             Change
          <change when="2015-04-14" who="Stella Dee">converted to CTS EpiDoc</change>
       </revisionDesc>
    </teiHeader>
-   <text xml:lang="eng">
+   <text>
       <body>
          <div type="translation" n="urn:cts:greekLit:tlg0020.tlg001.perseus-eng2" xml:lang="eng">
             <l n="1">

--- a/data/tlg0020/tlg001/tlg0020.tlg001.perseus-grc2.xml
+++ b/data/tlg0020/tlg001/tlg0020.tlg001.perseus-grc2.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
+    <teiHeader xml:lang="eng">
         <fileDesc>
             <titleStmt>
-                <title>Theogony (Greek). Machine readable text</title>
+                <title xml:lang="grc">Θεογονία</title>
                 <author>Hesiod</author>
+                <editor>Hugh G. Evelyn-White</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
                 <principal>Gregory Crane</principal>
                 <respStmt>
@@ -16,28 +18,29 @@
                 </respStmt>
                 <funder n="org:AnnCPB">The Annenberg CPB/Project</funder>
             </titleStmt>
-            <extent>About 71Kb</extent>
             <publicationStmt>
                 <publisher>Trustees of Tufts University</publisher>
                 <pubPlace>Medford, MA</pubPlace>
                 <authority>Perseus Project</authority>
             </publicationStmt>
-            <notesStmt>
-                <note anchored="true" place="unspecified">Text keyboarded in the Philippines. Basic
-                    SGML tagging by Scott Ettinger.</note>
-            </notesStmt>
             <sourceDesc>
                 <biblStruct>
                     <monogr>
                         <author>Hesiod</author>
-                        <title>The Homeric Hymns and Homerica with an English Translation by Hugh G.
-                            Evelyn-White. Theogony.</title>
+                        <title>The Homeric Hymns and Homerica</title>
+                        <editor>Hugh G. Evelyn-White</editor>
                         <imprint>
-                            <publisher>Cambridge, MA.,Harvard University Press; London, William
-                                Heinemann Ltd.</publisher>
+                            <pubPlace>London</pubPlace>
+                            <publisher>William Heinemann Ltd.</publisher>
+                            <pubPlace>New York</pubPlace>
+                            <publisher>The Macmillan Co.</publisher>
                             <date>1914</date>
                         </imprint>
                     </monogr>
+                    <series>
+                        <title>Loeb Classical Library</title>
+                    </series>
+                    <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/78/mode/2up">Internet Archive</ref>
                 </biblStruct>
             </sourceDesc>
         </fileDesc>
@@ -60,32 +63,12 @@
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <!--
-<change>
-<date>7/91</date>
-<respStmt>
-<name>Bill Merrill</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Check tagging.</item>
-</change>
-<change>
-<date>8/91</date>
-<respStmt>
-<name>EM</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Revise DTDs and recheck texts.</item>
-</change>
-<change>
-<date>10/91</date>
-<respStmt>
-<name>David Smith</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Fix typos from failed morphology.</item>
-</change>-->
-            <change when="2015-04-14" who="Stella Dee">converted to CTS EpiDoc</change>
+            <change who="Scott Ettinger" notAfter="1991-07">Basic SGML tagging.</change>
+            <change notAfter="1991-07">Text keyboarded in the Philippines.</change>
+            <change who="Bill Merrill" when="1991-07">Check tagging.</change>
+            <change who="Elli Mylonas" when="1991-08">Revise DTDs and recheck texts.</change>
+            <change who="David Smith" when="1991-10">Fix typos from failed morphology.</change>
+            <change who="Stella Dee" when="2015-04-14">converted to CTS EpiDoc</change>
         </revisionDesc>
     </teiHeader>
     <text xml:lang="grc">

--- a/data/tlg0020/tlg002/__cts__.xml
+++ b/data/tlg0020/tlg002/__cts__.xml
@@ -2,16 +2,15 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0020" projid="greekLit:tlg002" urn="urn:cts:greekLit:tlg0020.tlg002" xml:lang="grc">
    <ti:title xml:lang="eng">Works and Days</ti:title>
    <ti:edition projid="greekLit:perseus-grc2" urn="urn:cts:greekLit:tlg0020.tlg002.perseus-grc2" workUrn="urn:cts:greekLit:tlg0020.tlg002" xml:lang="grc">
-      <ti:label xml:lang="eng">Works and Days, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator; Evelyn-White, Hugh G. (Hugh Gerard), d.
-                    1924, editor</ti:description>
+      <ti:label xml:lang="grc">Ἔργα καὶ Ἡμέραι</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica.
+         Evelyn-White, Hugh G., editor. London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:edition>
    <ti:translation projid="greekLit:perseus-eng2" urn="urn:cts:greekLit:tlg0020.tlg002.perseus-eng2" workUrn="urn:cts:greekLit:tlg0020.tlg002" xml:lang="eng">
-      <ti:label xml:lang="eng">Works and Days, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator</ti:description>
+      <ti:label xml:lang="eng">Works and Days</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica.
+         Evelyn-White, Hugh G., translator. London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:translation>    
 </ti:work>

--- a/data/tlg0020/tlg002/tlg0020.tlg002.perseus-eng2.xml
+++ b/data/tlg0020/tlg002/tlg0020.tlg002.perseus-eng2.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Works and Days (English). Machine readable text</title>
+            <title>Works and Days</title>
             <author>Hesiod</author>
+            <editor role="translator">Hugh G. Evelyn-White</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -17,7 +18,6 @@
             </respStmt>
             <funder n="AnnCPB"> The Annenberg CPB Project</funder>
          </titleStmt>
-         <extent>about 61Kb</extent>
          <publicationStmt>
             <publisher>Trustees of Tufts University</publisher>
             <pubPlace>Medford, MA</pubPlace>
@@ -30,12 +30,20 @@
             <biblStruct>
                <monogr>
                   <author>Hesiod</author>
-                  <title>The Homeric Hymns and Homerica with an English Translation by Hugh G. Evelyn-White. Works and Days.</title>
+                  <title>The Homeric Hymns and Homerica</title>
+                  <editor role="translator">Hugh G. Evelyn-White</editor>
                   <imprint>
-                     <publisher>Cambridge, MA.,Harvard University Press; London, William Heinemann Ltd.</publisher>
+                     <pubPlace>London</pubPlace>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <pubPlace>New York</pubPlace>
+                     <publisher>The Macmillan Co.</publisher>
                      <date>1914</date>
                   </imprint>
                </monogr>
+               <series>
+                  <title>Loeb Classical Library</title>
+               </series>
+               <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/n55/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/tlg0020/tlg002/tlg0020.tlg002.perseus-grc2.xml
+++ b/data/tlg0020/tlg002/tlg0020.tlg002.perseus-grc2.xml
@@ -2,7 +2,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Works and Days (Greek). Machine readable text</title>
+    <title xml:lang="grc">Ἔργα καὶ Ἡμέραι</title>
 <author>Hesiod</author>
 <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>
@@ -15,27 +15,30 @@
 </respStmt>
 <funder n="org:AnnCPB">The Annenberg CPB/Project</funder>
 </titleStmt>
-<extent>About 58Kb</extent>
 <publicationStmt>
 <publisher>Trustees of Tufts University</publisher>
 <pubPlace>Medford, MA</pubPlace>
 <authority>Perseus Project</authority>
 </publicationStmt>
-<notesStmt>
-<note anchored="true" place="unspecified">Text keyboarded in the Philippines.  Basic SGML tagging by Scott Ettinger.</note>
-</notesStmt>
 <sourceDesc>
-<biblStruct>
-<monogr>
-<author>Hesiod</author>
-<title>The Homeric Hymns and Homerica with an English Translation by Hugh G. Evelyn-White. Works and Days.</title>
-<imprint>
-<publisher>Cambridge, MA.,Harvard University Press; London, William Heinemann Ltd.</publisher>
-<date>1914</date>
-</imprint>
-</monogr>
-    <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/page/n55/mode/2up">Internet Archive</ref>
-</biblStruct>
+    <biblStruct>
+        <monogr>
+            <author>Hesiod</author>
+            <title>The Homeric Hymns and Homerica</title>
+            <editor role="translator">Hugh G. Evelyn-White</editor>
+            <imprint>
+                <pubPlace>London</pubPlace>
+                <publisher>William Heinemann Ltd.</publisher>
+                <pubPlace>New York</pubPlace>
+                <publisher>The Macmillan Co.</publisher>
+                <date>1914</date>
+            </imprint>
+        </monogr>
+        <series>
+            <title>Loeb Classical Library</title>
+        </series>
+        <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/n55/mode/2up">Internet Archive</ref>
+    </biblStruct>
 </sourceDesc>
 </fileDesc>
     <encodingDesc>
@@ -54,35 +57,16 @@
             <language ident="eng">English</language>
         </langUsage>
     </profileDesc>
-<revisionDesc>
-<!--<change>
-<date>7/91</date>
-<respStmt>
-<name>Bill Merrill</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Check tagging.</item>
-</change>
-<change>
-<date>8/91</date>
-<respStmt>
-<name>EM</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Revise DTDs and recheck texts.</item>
-</change>
-<change>
-<date>10/91</date>
-<respStmt>
-<name>David Smith</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Fix typos from failed morphology.</item>
-</change>-->
-    <change when="2016-02-18" who="TDBuck">converted to CTS EpiDoc</change>
-</revisionDesc>
+    <revisionDesc>
+        <change who="Scott Ettinger" notAfter="1991-07">Basic SGML tagging.</change>
+        <change notAfter="1991-07">Text keyboarded in the Philippines.</change>
+        <change who="Bill Merrill" when="1991-07">Check tagging.</change>
+        <change who="Elli Mylonas" when="1991-08">Revise DTDs and recheck texts.</change>
+        <change who="David Smith" when="1991-10">Fix typos from failed morphology.</change>
+        <change when="2016-02-18" who="TDBuck">converted to CTS EpiDoc</change>
+    </revisionDesc>
 </teiHeader>
-<text xml:id="stoa0045.stoa0">
+    <text>
 <body>
     <div n="urn:cts:greekLit:tlg0020.tlg002.perseus-grc2" type="edition" xml:lang="grc">
         

--- a/data/tlg0020/tlg003/__cts__.xml
+++ b/data/tlg0020/tlg003/__cts__.xml
@@ -2,16 +2,15 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:greekLit:tlg0020" projid="greekLit:tlg003" urn="urn:cts:greekLit:tlg0020.tlg003" xml:lang="grc">
    <ti:title xml:lang="eng">Shield of Heracles</ti:title>
    <ti:edition projid="greekLit:perseus-grc2" urn="urn:cts:greekLit:tlg0020.tlg003.perseus-grc2" workUrn="urn:cts:greekLit:tlg0020.tlg003" xml:lang="grc">
-      <ti:label xml:lang="eng">Shield of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator; Evelyn-White, Hugh G. (Hugh Gerard), d.
-                    1924, editor</ti:description>
+      <ti:label xml:lang="grc">Ἀσπὶς Ἡρακλέους</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica. Evelyn-White, Hugh G., editor. 
+         London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:edition>
    <ti:translation projid="greekLit:perseus-eng2" urn="urn:cts:greekLit:tlg0020.tlg003.perseus-eng2" workUrn="urn:cts:greekLit:tlg0020.tlg003" xml:lang="eng">
-      <ti:label xml:lang="eng">Shield of Heracles, Hesiod The Homeric hymns. And Homerica</ti:label>
-      <ti:description xml:lang="eng">Hesiod, creator; Homer, creator; Evelyn-White, Hugh G.
-                    (Hugh Gerard), d. 1924, translator</ti:description>
+      <ti:label xml:lang="eng">Shield of Heracles</ti:label>
+      <ti:description xml:lang="eng">Hesiod, The Homeric Hymns and Homerica. Evelyn-White, Hugh G., translator. 
+         London: William Heinmann; New York: The Macmillan Co., 1914.</ti:description>
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
    </ti:translation>    
 </ti:work>

--- a/data/tlg0020/tlg003/tlg0020.tlg003.perseus-eng2.xml
+++ b/data/tlg0020/tlg003/tlg0020.tlg003.perseus-eng2.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	  <teiHeader>
-
+	  <teiHeader xml:lang="eng">
       <fileDesc>
-
          <titleStmt>
-            <title>Shield of Heracles (English). Machine readable text</title>
+            <title>Shield of Heracles</title>
             <author>Hesiod</author>
 	           <sponsor>Perseus Project, Tufts University</sponsor>
 		          <principal>Gregory Crane</principal>
@@ -19,8 +17,6 @@
 		          </respStmt>
 		          <funder n="AnnCPB"> The Annenberg CPB Project</funder>
 	        </titleStmt>
-         <extent>about 34Kb</extent>
-
 	        <publicationStmt>
 		          <publisher>Trustees of Tufts University</publisher>
 		          <pubPlace>Medford, MA</pubPlace>
@@ -32,15 +28,22 @@
          </notesStmt>
          <sourceDesc>
             <biblStruct>
-	              <monogr>
-		                <author>Hesiod</author>
-                  <title>The Homeric Hymns and Homerica with an English Translation by Hugh G. Evelyn-White. Shield of Heracles</title>
-	
-		                <imprint>
-                     <publisher>Cambridge, MA.,Harvard University Press; London, William Heinemann Ltd.</publisher>
+               <monogr>
+                  <author>Hesiod</author>
+                  <title>The Homeric Hymns and Homerica</title>
+                  <editor role="translator">Hugh G. Evelyn-White</editor>
+                  <imprint>
+                     <pubPlace>London</pubPlace>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <pubPlace>New York</pubPlace>
+                     <publisher>The Macmillan Co.</publisher>
                      <date>1914</date>
                   </imprint>
-	              </monogr>
+               </monogr>
+               <series>
+                  <title>Loeb Classical Library</title>
+               </series>
+               <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/220/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
 

--- a/data/tlg0020/tlg003/tlg0020.tlg003.perseus-grc2.xml
+++ b/data/tlg0020/tlg003/tlg0020.tlg003.perseus-grc2.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?><?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-<teiHeader>
+<teiHeader xml:lang="eng">
 <fileDesc>
 <titleStmt>
-<title>Shield of Heracles (Greek). Machine readable text</title>
+    <title xml:lang="grc">Ἀσπὶς Ἡρακλέους</title>
 <author>Hesiod</author>
+    <editor>Hugh G. Evelyn-White</editor>
 <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>
 <respStmt>
@@ -15,26 +16,31 @@
 </respStmt>
 <funder n="org:AnnCPB">The Annenberg CPB/Project</funder>
 </titleStmt>
-<extent>About 33Kb</extent>
 <publicationStmt>
 <publisher>Trustees of Tufts University</publisher>
 <pubPlace>Medford, MA</pubPlace>
 <authority>Perseus Project</authority>
 </publicationStmt>
-<notesStmt>
-<note anchored="true" place="unspecified">Text keyboarded in the Philippines.  Basic SGML tagging by Bill Merrill.</note>
-</notesStmt>
+
 <sourceDesc>
-<biblStruct>
-<monogr>
-<author>Hesiod</author>
-<title>The Homeric Hymns and Homerica with an English Translation by Hugh G. Evelyn-White. Shield of Heracles</title>
-<imprint>
-<publisher>Cambridge, MA.,Harvard University Press; London, William Heinemann Ltd.</publisher>
-<date>1914</date>
-</imprint>
-</monogr>
-</biblStruct>
+    <biblStruct>
+        <monogr>
+            <author>Hesiod</author>
+            <title>The Homeric Hymns and Homerica</title>
+            <editor>Hugh G. Evelyn-White</editor>
+            <imprint>
+                <pubPlace>London</pubPlace>
+                <publisher>William Heinemann Ltd.</publisher>
+                <pubPlace>New York</pubPlace>
+                <publisher>The Macmillan Co.</publisher>
+                <date>1914</date>
+            </imprint>
+        </monogr>
+        <series>
+            <title>Loeb Classical Library</title>
+        </series>
+        <ref target="https://archive.org/details/hesiodhomerichym00hesiuoft/hesiodhomerichym00hesiuoft/page/220/mode/2up?view=theater">Internet Archive</ref>
+    </biblStruct>
 </sourceDesc>
 </fileDesc>
     <encodingDesc>
@@ -53,26 +59,16 @@
             <language ident="eng">English</language>
         </langUsage>
     </profileDesc>
-<revisionDesc>
-<!--<change>
-<date>8/91</date>
-<respStmt>
-<name>EM</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Revise DTDs and recheck texts.</item>
-</change>
-<change>
-<date>10/91</date>
-<respStmt>
-<name>David Smith</name>
-<resp>(n/a)</resp>
-</respStmt>
-<item>Fix typos from failed morphology.</item>
-</change>--> <change when="2016-02-18" who="TDBuck">converted to CTS EpiDoc</change>
-</revisionDesc>
+    <revisionDesc>
+        <change who="Scott Ettinger" notAfter="1991-07">Basic SGML tagging.</change>
+        <change notAfter="1991-07">Text keyboarded in the Philippines.</change>
+        <change who="Bill Merrill" when="1991-07">Check tagging.</change>
+        <change who="Elli Mylonas" when="1991-08">Revise DTDs and recheck texts.</change>
+        <change who="David Smith" when="1991-10">Fix typos from failed morphology.</change>
+        <change when="2016-02-18" who="TDBuck">converted to CTS EpiDoc</change>
+    </revisionDesc>
 </teiHeader>
-<text xml:id="stoa0045.stoa0">
+    <text  xml:lang="grc">
 <body>
     <div n="urn:cts:greekLit:tlg0020.tlg003.perseus-grc2" type="edition" xml:lang="grc">
 <milestone ed="P" n="1" unit="card"/>


### PR DESCRIPTION
Per discussion in issue https://github.com/PerseusDL/canonical-greekLit/pull/1597 I'm opening separate issues for Hesiod and the Homeric Hymns.

These files have bibliographic changes, updated schema, and a handful of header changes (note files in Greek editions added into updated change logs)
Removed extent.