### PR TITLE
tlg0010.tlg001_first_files

### DIFF
--- a/data/tlg0010/tlg001/__cts__.xml
+++ b/data/tlg0010/tlg001/__cts__.xml
@@ -5,9 +5,9 @@
       
    <ti:edition projid="greekLit:perseus-grc2" urn="urn:cts:greekLit:tlg0010.tlg001.perseus-grc2" workUrn="urn:cts:greekLit:tlg0010.tlg001" xml:lang="grc">
         
-      <ti:label xml:lang="eng">Against Euthynus</ti:label>
+      <ti:label xml:lang="grc">προς ευθύνουν</ti:label>
         
-      <ti:description xml:lang="eng">Isocrates. Isocrates with an English Translation in three volumes, by Larue Van Hook, Ph.D., LL.D. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd. 1945-1968.</ti:description>
+      <ti:description xml:lang="eng">Isocrates, vol. 3. Van Hook, Larue, editor. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd., 1945 (printing).</ti:description>
         
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
       
@@ -17,8 +17,8 @@
         
       <ti:label xml:lang="eng">Against Euthynus</ti:label>
         
-      <ti:description xml:lang="eng">Isocrates. Isocrates with an English Translation in three volumes, by Larue Van Hook, Ph.D., LL.D. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd. 1945-1968.</ti:description>
-        
+      <ti:description xml:lang="eng">Isocrates, vol. 3. Van Hook, Larue, editor. Cambridge, MA, Harvard University Press; London, William Heinemann Ltd. 1945 (printing).</ti:description>
+      
       <ti:memberof collection="Perseus:collection:Greco-Roman"/>
       
    </ti:translation>

--- a/data/tlg0010/tlg001/tlg0010.tlg001.perseus-eng2.xml
+++ b/data/tlg0010/tlg001/tlg0010.tlg001.perseus-eng2.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+  <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Against Euthynus</title>
-            
+            <title>Against Euthynus</title>            
             <author>Isocrates</author>
-            <editor>Larue Van Hook</editor>
+            <editor role="translator">Larue Van Hook</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -27,16 +26,22 @@
          </publicationStmt>
 
          <sourceDesc>
-            <bibl>
-               <author>Isocrates</author>
-               <title>Isocrates with an English Translation in three volumes, by Larue Van Hook, Ph.D.,
-            LL.D.</title>
-               <publisher>Cambridge, MA, Harvard University Press; London, William Heinemann
-            Ltd.</publisher>
-              <biblScope unit="volume">3</biblScope>
-               <date type="print">1945</date>
-               <date type="reprint">1968</date>
-            </bibl>
+            <biblStruct>
+               <monogr>
+                  <author>Isocrates</author>
+                  <title>Isocrates</title>
+                  <editor>Larue Van Hook</editor>
+                  <imprint>             
+                     <pubPlace>Cambridge, MA</pubPlace>
+                     <pubPlace>London, UK</pubPlace>
+                     <publisher>Harvard University Press</publisher>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <biblScope unit="volume">3</biblScope>
+                     <date type="printing">1945</date>
+                  </imprint>
+               </monogr>  
+               <ref target="https://archive.org/details/isocrateswitheng03isocuoft/page/352/mode/2up">Internet Archive</ref>
+            </biblStruct>
          </sourceDesc>
       </fileDesc>
 

--- a/data/tlg0010/tlg001/tlg0010.tlg001.perseus-eng2.xml
+++ b/data/tlg0010/tlg001/tlg0010.tlg001.perseus-eng2.xml
@@ -40,7 +40,7 @@
                      <date type="printing">1945</date>
                   </imprint>
                </monogr>  
-               <ref target="https://archive.org/details/isocrateswitheng03isocuoft/page/352/mode/2up">Internet Archive</ref>
+               <ref target="https://archive.org/details/isocrateswitheng03isocuoft/page/254/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>
@@ -60,8 +60,8 @@
 
       <profileDesc>
          <langUsage>
-            <language ident="eng">English </language>
-            <language ident="grc">Greek </language>
+            <language ident="eng">English</language>
+            <language ident="grc">Greek</language>
          </langUsage>
 
          <textClass xml:id="gen.epideictic">

--- a/data/tlg0010/tlg001/tlg0010.tlg001.perseus-grc2.xml
+++ b/data/tlg0010/tlg001/tlg0010.tlg001.perseus-grc2.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+  <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Against Euthynus</title>
-            
+            <title xml:lang="grc">προς ευθύνουν</title>            
             <author>Isocrates</author>
             <editor>Larue Van Hook</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
@@ -27,16 +26,22 @@
          </publicationStmt>
 
          <sourceDesc>
-            <bibl>
-               <author>Isocrates</author>
-               <title>Isocrates with an English Translation in three volumes, by Larue Van Hook, Ph.D.,
-            LL.D.</title>
-               <publisher>Cambridge, MA, Harvard University Press; London, William Heinemann
-            Ltd.</publisher>
-               <biblScope unit="volume">3</biblScope>
-               <date type="print">1945</date>
-               <date type="reprint">1968</date>
-            </bibl>
+            <biblStruct>
+               <monogr>
+                  <author>Isocrates</author>
+                  <title>Isocrates</title>
+                  <editor>Larue Van Hook</editor>
+                  <imprint>             
+                     <pubPlace>Cambridge, MA</pubPlace>
+                     <pubPlace>London, UK</pubPlace>
+                     <publisher>Harvard University Press</publisher>
+                     <publisher>William Heinemann Ltd.</publisher>
+                     <biblScope unit="volume">3</biblScope>
+                     <date type="printing">1945</date>
+                  </imprint>
+               </monogr>  
+               <ref target="https://archive.org/details/isocrateswitheng03isocuoft/page/352/mode/2up">Internet Archive</ref>
+            </biblStruct>
          </sourceDesc>
       </fileDesc>
 
@@ -55,8 +60,8 @@
      
      <profileDesc>
         <langUsage>
-           <language ident="eng">English </language>
-           <language ident="grc">Greek </language>
+           <language ident="eng">English</language>
+           <language ident="grc">Greek</language>
         </langUsage>
 
       
@@ -149,6 +154,7 @@ Wrap letters in DIV1 so we can cite them as "L. 4.3" within doc.
     <respStmt><name>Stella Dee</name><resp>ed.</resp></respStmt>
     <item>split speeches and converted to unicode</item>
       </change></change>-->
+         <change when="2024-07-25" who="Alison Babeu">Updated header and bibliographic info</change>
       <change when="2014-10-01" who="Stella Dee">edited markup</change>
          <change when="2016-01-26" who="TDBuck">epidoc and CTS</change>
       </revisionDesc>


### PR DESCRIPTION
Updating Isocrates files to current cts_xml and bibliographic standards.
@lcerrato I did these first two files to see if these changes are acceptable. 

First twos file with a number of minor changes:
1) Added in a Greek oration title to Greek file and cts file
2)Updated descriptions in the cts_xml files
3) Updated headers and structured bibliographic information
4) Added page level links to the files. 

One curiosity of these files is that they all contain what appears to be the only remaining example of keywords
` <textClass xml:id="gen.epideictic">
            <keywords>
               <term>Epideictic</term>
            </keywords>
         </textClass>`
I'm not sure if these should be eliminated or if they can just remain. This is clearly an early conversion by Stella in 2013-4 and the change log is actually commented out. 