### PR TITLE
Add paratexts to Heraclidae (tlg0006-tlg004)

### DIFF
--- a/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
+++ b/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
@@ -26,10 +26,12 @@
                 <date type="release">2020</date>
                 <idno type="filename">tlg0006.tlg004.perseus-grc2.xml</idno>
                 <availability>
-                    <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International License</licence>
+                    <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available
+                        under a Creative Commons Attribution-ShareAlike 4.0 International
+                        License</licence>
                 </availability>
             </publicationStmt>
-            
+
             <sourceDesc>
                 <biblStruct>
                     <monogr>
@@ -43,1860 +45,3250 @@
                         </imprint>
                         <biblScope unit="volume">1</biblScope>
                     </monogr>
-                    <ref target="https://archive.org/details/euripidisfabulae01euriuoft/page/n163">The Internet Archive</ref>
+                    <ref target="https://archive.org/details/euripidisfabulae01euriuoft/page/n163"
+                        >The Internet Archive</ref>
                 </biblStruct>
             </sourceDesc>
         </fileDesc>
-        
+
         <encodingDesc>
-            <editorialDecl><p>Greek produced via Lace 0.5.10. Lace copyright 2013-2020, Bruce Robertson, Dept. of Classics, Mount Allison University. Developed through the support of the <ref target="https://nbif.ca/en">NBIF</ref>.</p></editorialDecl>
+            <editorialDecl>
+                <p>Greek produced via Lace 0.5.10. Lace copyright 2013-2020, Bruce Robertson, Dept.
+                    of Classics, Mount Allison University. Developed through the support of the <ref
+                        target="https://nbif.ca/en">NBIF</ref>.</p>
+            </editorialDecl>
             <refsDecl n="CTS">
-                <cRefPattern n="line" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:l[@n='$1'])">
+                <cRefPattern n="line" matchPattern="(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:l[@n='$1'])">
                     <p>This pointer pattern extracts line</p>
                 </cRefPattern>
-            </refsDecl> 
+            </refsDecl>
         </encodingDesc>
-        
+
         <profileDesc>
             <langUsage>
                 <language ident="grc">Greek</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
-            <change when="2020-03-13" who="Lisa Cerrato">rescanned Murray via Lace; diff file against perseus version; added to structure</change>
+            <change when="2020-03-13" who="Lisa Cerrato">rescanned Murray via Lace; diff file
+                against perseus version; added to structure</change>
         </revisionDesc>
     </teiHeader>
-    
     <text xml:lang="grc">
+        <front>
+            <div type="textpart" subtype="argument">
+                <head>ΥΠΟΘΕΣΙΣ ΗΡΑΚΛΕΙΔΩΝ</head>
+                <p>Ἰόλαος υἱὸς μὲν ἦν Ιφικλέους, ἀδελφιδοῦς δὲ Ἡρακλέους· ἐν νεότητι<lb/>δ’ ἐκείνῳ
+                    συστρατευσάμενος ἐν γήρα τοῖς ἐξ ἐκείνου βοηθὸς εὔνους<lb/>παρέστη. τῶν γὰρ
+                    παίδων ἐξ ἁπάσης ἐλαυνομένων γῆς ὑπ’ Εὐρυσθέως,<lb/>ἔχων αὐτοὺς ἦλθεν εἰς Ἀθήνας
+                    κἀκεῖ προσφυγὼν τοῖς θεοῖς ἔσχε τὴν<lb/>ἀσφάλειαν Δημοφῶντος τῆς πόλεως
+                    κρατοῦντος. Κοπρέως δὲ τοῦ<lb/>Εὐρυσθέως κήρυκος ἀποσπᾶν θέλοντος τοὺς ἱκέτας
+                    εκώλυσεν αὐτόν· ὃ<lb/>δὲ ἀπῆλθε πόλεμον ἀπειλήσας προσδέχεσθαι. Δημοφῶν δὲ
+                    τούτου<lb/>μὲν ὠλιγώρει· χρησμῶν δὲ αὐτῷ νικηφόρων γενηθέντων, ἐὰν Δήμητρι<lb/>τὴν
+                    εὐγενεστάτην παρθένων σφάξῃ, τοῖς λογίοις βαρέως ἔσχεν· οὔτε γὰρ<lb/>ἰδίαν οὔτε
+                    τῶν πολιτῶν τινος θυγατέρα χάριν τῶν ἱκετῶν ἀποκτεῖναι<lb/>δίκαιον ἡγεῖται. τὴν
+                    μαντείαν δὲ προγνοῦσα μία τῶν Ἡρακλέους<lb/>παίδων, Μακαρία, τὸν θάνατον ἑκουσίως
+                    ὑπέστη. ταύτην μὲν οὖν<lb/>εὐγενῶς ἀποθανοῦσαν ἐτίμησαν· αὐτοὶ δὲ τοὺς πολεμίους
+                    ἐπιγνόντες παρόντας εἰς τὴν μάχην ὥρμησαν.....</p>
+            </div>
+            <castList>
+                <head>τὰ τοῦ δράματος πρόσωπα</head>
+                <castItem>
+                    <role>Ἰόλαος</role>
+                </castItem>
+                <castItem>
+                    <role>Κῆρυξ</role>
+                </castItem>
+                <castGroup>
+                    <role>Χορός</role>
+                </castGroup>
+                <castItem>
+                    <role>Δημοφῶν</role>
+                </castItem>
+                <castItem>
+                    <role>Μακαρία Παρθένος</role>
+                </castItem>
+                <castItem>
+                    <role>Θεράπων</role>
+                </castItem>
+                <castItem>
+                    <role>Ἀλκμήνη</role>
+                </castItem>
+                <castItem>
+                    <role>
+                        <del>Ἀγγελος</del>
+                    </role>
+                </castItem>
+                <castItem>
+                    <role>Ἐυρυσθεύς</role>
+                </castItem>
+            </castList>
+        </front>
         <body>
             <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2">
-                <milestone n="1" unit="card" resp="perseus"/> 
-               
-                <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" resp="perseus" style="hidden" n="0"/>
-                <note resp="editor" place="inline">
-                    <p>τὰ τοῦ δράματος πρόσωπα</p>
-                    <p>Ἰόλαος</p>
-                    <p>Κῆρυξ</p>
-                    <p>Χορός</p>
-                    <p>Δημοφῶν</p>
-                    <p>Μακαρία Παρθένος</p>
-                    <p>Θεράπων</p>
-                    <p>Ἀλκμήνη</p>
-                    <p><del>Ἀγγελος</del></p>
-                    <p>Ἐυρυσθεύς</p>
-                </note>
-                
-                
-<div type="textpart" subtype="episode">
-                    
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1">Πάλαι ποτʼ ἐστὶ τοῦτʼ ἐμοὶ δεδογμένον· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="2">ὁ μὲν δίκαιος τοῖς πέλας πέφυκʼ ἀνήρ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="3">ὃ δʼ ἐς τὸ κέρδος λῆμʼ ἔχων ἀνειμένον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="4">πόλει τʼ ἄχρηστος καὶ συναλλάσσειν βαρύς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="5">αὑτῷ δʼ ἄριστος· οἶδα δʼ οὐ λόγῳ μαθών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="6" rend="indent">ἐγὼ γὰρ αἰδοῖ καὶ τὸ συγγενὲς σέβων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="7">ἐξὸν κατʼ Ἄργος ἡσύχως ναίειν, πόνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="8">πλείστων μετέσχον εἷς ἀνὴρ Ἡρακλέει, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="9">ὅτʼ ἦν μεθʼ ἡμῶν· νῦν δʼ, ἐπεὶ κατʼ οὐρανὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="10">ναίει, τὰ κείνου τέκνʼ ἔχων ὑπὸ πτεροῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="11">σῴζω τάδʼ αὐτὸς δεόμενος σωτηρίας. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="12">ἐπεὶ γὰρ αὐτῶν γῆς ἀπηλλάχθη πατήρ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="13">πρῶτον μὲν ἡμᾶς ἤθελʼ Εὐρυσθεὺς κτανεῖν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="14">ἀλλʼ ἐξέδραμεν· καὶ πόλις μὲν οἴχεται, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="15">ψυχὴ δʼ ἐσώθη. φεύγομεν δʼ ἀλώμενοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="16">ἄλλην ἀπʼ ἄλλης ἐξορίζοντες πόλιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="17">πρὸς τοῖς γὰρ ἄλλοις καὶ τόδʼ Εὐρυσθεὺς κακοῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="18">ὕβρισμʼ ἐς ἡμᾶς ἠξίωσεν ὑβρίσαι· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="19">πέμπων ὅπου γῆς πυνθάνοιθʼ ἱδρυμένους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="20">κήρυκας ἐξαιτεῖ τε κἀξείργει χθονός, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="21">πόλιν προτείνων Ἄργος οὐ σμικρὸν φίλην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="22">ἐχθράν τε θέσθαι, χαὑτὸν εὐτυχοῦνθʼ ἅμα.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="23">οἳ δʼ ἀσθενῆ μὲν τἀπ’ ἐμοῦ δεδορκότες, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="24">σμικροὺς δὲ τούσδε καὶ πατρὸς τητωμένους, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="25">τοὺς κρείσσονας σέβοντες ἐξείργουσι γῆς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="26">ἐγὼ δὲ σὺν φεύγουσι συμφεύγω τέκνοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="27">καὶ σὺν κακῶς πράσσουσι συμπράσσω κακῶς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="28">ὀκνῶν προδοῦναι, μή τις ὧδ’ εἴπῃ βροτῶν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="29">Ἴδεσθ’, ἐπειδὴ παισὶν οὐκ ἔστιν πατήρ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="30">Ἰόλαος οὐκ ἤμυνε συγγενὴς γεγώς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="31">πάσης δὲ χώρας Ἑλλάδος τητώμενοι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="32">Μαραθῶνα καὶ σύγκληρον ἐλθόντες χθόνα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="33">ἱκέται καθεζόμεσθα βώμιοι θεῶν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="34">προσωφελῆσαι· πεδία γὰρ τῆσδε χθονὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="35">δισσοὺς κατοικεῖν Θησέως παῖδας λόγος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="36">κλήρῳ λαχόντας ἐκ γένους Πανδίονος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="37">τοῖσδʼ ἐγγὺς ὄντας· ὧν ἕκατι τέρμονας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="38">κλεινῶν Ἀθηνῶν τόνδʼ ἀφικόμεσθʼ ὅρον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="39">δυοῖν γερόντοιν δὲ στρατηγεῖται φυγή· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="40">ἐγὼ μὲν ἀμφὶ τοῖσδε καλχαίνων τέκνοις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="41">ἣ δʼ αὖ τὸ θῆλυ παιδὸς Ἀλκμήνη γένος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="42">ἔσωθε ναοῦ τοῦδʼ ὑπηγκαλισμένη </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="43">σῴζει· νέας γὰρ παρθένους αἰδούμεθα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="44">ὄχλῳ πελάζειν κἀπιβωμιοστατεῖν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="45">Ὕλλος δʼ ἀδελφοί θʼ οἷσι πρεσβεύει γένος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="46">ζητοῦσʼ ὅπου γῆς πύργον οἰκιούμεθα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="47">ἢν τῆσδʼ ἀπωθώμεσθα πρὸς βίαν χθονός. </l>
-    <milestone n="48" unit="card" resp="perseus"/>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="48" rend="indent">ὦ τέκνα τέκνα, δεῦρο, λαμβάνεσθʼ ἐμῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="49">πέπλων· ὁρῶ κήρυκα τόνδʼ Εὐρυσθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="50">στείχοντʼ ἐφʼ ἡμᾶς, οὗ διωκόμεσθʼ ὕπο </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="51">πάσης ἀλῆται γῆς ἀπεστερημένοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="52">ὦ μῖσος, εἴθʼ ὄλοιο χὡ πέμψας <add>σ’</add> ἀνήρ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="53">ὡς πολλὰ δὴ καὶ τῶνδε γενναίῳ πατρὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="54">ἐκ τοῦδε ταὐτοῦ στόματος ἤγγειλας κακά. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="55">ἦ που καθῆσθαι τήνδʼ ἕδραν καλὴν δοκεῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="56">πόλιν τʼ ἀφῖχθαι σύμμαχον, κακῶς φρονῶν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="57">οὐ γάρ τις ἔστιν ὃς πάροιθʼ αἱρήσεται </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="58">τὴν σὴν ἀχρεῖον δύναμιν ἀντʼ Εὐρυσθέως.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="59">χώρει· τί μοχθεῖς ταῦτʼ; ἀνίστασθαί σε χρὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="60">ἐς Ἄργος, οὗ σε λεύσιμος μένει δίκη.</l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="61">οὐ δῆτʼ, ἐπεί μοι βωμὸς ἀρκέσει θεοῦ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="62">ἐλευθέρα τε γαῖʼ ἐν ᾗ βεβήκαμεν.</l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="63">βούλῃ πόνον μοι τῇδε προσθεῖναι χερί; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="64">οὔτοι βίᾳ γέ μʼ οὐδὲ τούσδʼ ἄξεις λαβών.</l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="65">γνώσῃ σύ· μάντις δʼ ἦσθʼ ἄρʼ οὐ καλὸς τάδε.</l></sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="66">οὐκ ἂν γένοιτο τοῦτʼ ἐμοῦ ζῶντός ποτε. </l>    
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="67">ἄπαιρʼ· ἐγὼ δὲ τούσδε, κἂν σὺ μὴ θέλῃς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="68">ἄξω νομίζων, οὗπέρ εἰσʼ, Εὐρυσθέως. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="69">ὦ τὰς Ἀθήνας δαρὸν οἰκοῦντες χρόνον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="70">ἀμύνεθʼ· ἱκέται δʼ ὄντες ἀγοραίου Διὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="71">βιαζόμεσθα καὶ στέφη μιαίνεται — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="72">πόλει τʼ ὄνειδος καὶ θεῶν ἀτιμία. </l>
-</sp></div>
-
-<milestone n="73" unit="card" resp="perseus"/>
-
-
-<div type="textpart" subtype="choral">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="73"> — ἔα ἔα· τίς ἡ βοὴ βωμοῦ πέλας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="74">ἕστηκε; ποίαν συμφορὰν δείξει τάχα; </l>
-</sp>
-    
-<div type="textpart" subtype="strophe" n="1">
-    <sp><speaker>Χορός</speaker>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="75"> — ἴδετε τὸν γέροντʼ ἀμαλὸν ἐπὶ πέδῳ </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="76">χύμενον· ὦ τάλας.</l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="76a"><gap reason="lost" rend=" . . . . . . . . "/></l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="77"> — πρὸς τοῦ ποτʼ ἐν γῇ πτῶμα δύστηνον πίτνεις; </l>
-</sp>
-    
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="78">ὅδʼ, ὦ ξένοι, με σοὺς ἀτιμάζων θεοὺς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="79">ἕλκει βιαίως Ζηνὸς ἐκ προβωμίων. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="80">σὺ δʼ ἐκ τίνος γῆς, ὦ γέρον, τετράπτολιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="81">ξύνοικον ἦλθες λαόν; ἢ πέρα- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="82">θεν ἁλίῳ πλάτᾳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="83">κατέχετʼ ἐκλιπόντες Εὐβοῖδʼ ἀκτάν; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="84">οὐ νησιώτην, ὦ ξένοι, τρίβω βίον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="85">ἀλλʼ ἐκ Μυκηνῶν σὴν ἀφίγμεθα χθόνα. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="86">ὄνομα τί σε, γέρον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="87">Μυκηναῖος ὠνόμαζεν λεώς; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="88">τὸν Ἡράκλειον ἴστε που παραστάτην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="89">Ἰόλαον· οὐ γὰρ σῶμʼ ἀκήρυκτον τόδε. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="90">οἶδʼ εἰσακούσας καὶ πρίν· ἀλλὰ τοῦ ποτὲ </l> 
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="91">ἐν χερὶ σᾷ κομίζεις κόρους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="92">νεοτρεφεῖς; φράσον. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="93">Ἡρακλέους οἵδʼ εἰσὶ παῖδες, ὦ ξένοι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="94">ἱκέται σέθεν τε καὶ πόλεως ἀφιγμένοι. </l>
-</sp></div>
-
-<milestone n="95" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="95">τί χρέος; ἢ λόγων πόλεος, ἔνεπέ μοι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="96">μελόμενοι τυχεῖν; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="97">μήτʼ ἐκδοθῆναι μήτε πρὸς βίαν θεῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="98">τῶν σῶν ἀποσπασθέντες εἰς  Ἄργος μολεῖν. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="99">ἀλλʼ οὔτι τοῖς σοῖς δεσπόταις τάδʼ ἀρκέσει, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="100">οἳ σοῦ κρατοῦντες ἐνθάδʼ εὑρίσκουσί σε.</l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="101">εἰκὸς θεῶν ἱκτῆρας αἰδεῖσθαι, ξένε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="102">καὶ μὴ βιαίῳ χερὶ δαιμόνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="103">ἀπολείπειν <del>σʼ</del> ἕδη· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="104">πότνια γὰρ Δίκα τάδʼ οὐ πείσεται. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="105">ἔκπεμπέ νυν γῆς τούσδε τοὺς Εὐρυσθέως, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="106">κοὐδὲν βιαίῳ τῇδε χρήσομαι χερί. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="107">ἄθεον ἱκεσίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="108">μεθεῖναι πόλει ξένων προστροπάν. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="109">καλὸν δέ γʼ ἔξω πραγμάτων ἔχειν πόδα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="110">εὐβουλίας τυχόντα τῆς ἀμείνονος. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="110a"><gap reason="lost" rend=" . . . . . . "/></l>
-</sp></div></div>
-
-<milestone n="111" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="episode">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="111">οὐκοῦν τυράννῳ τῆσδε γῆς φράσαντά σε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="112">χρῆν ταῦτα τολμᾶν, ἀλλὰ μὴ βίᾳ ξένους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="113">θεῶν ἀφέλκειν, γῆν σέβοντʼ ἐλευθέραν. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="114">τίς δʼ ἐστὶ χώρας τῆσδε καὶ πόλεως ἄναξ; </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="115">ἐσθλοῦ πατρὸς παῖς Δημοφῶν ὁ Θησέως.</l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="116">πρὸς τοῦτον ἁγὼν ἆρα τοῦδε τοῦ λόγου </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="117">μάλιστʼ ἂν εἴη· τἄλλα δʼ εἴρηται μάτην. </l>
- </sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="118">καὶ μὴν ὅδʼ αὐτὸς ἔρχεται σπουδὴν ἔχων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="119">Ἀκάμας τʼ ἀδελφός, τῶνδʼ ἐπήκοοι λόγων. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="120">ἐπείπερ ἔφθης πρέσβυς ὢν νεωτέρους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="121">βοηδρομήσας τήνδʼ ἐπʼ ἐσχάραν Διός, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="122">λέξον, τίς ὄχλον τόνδʼ ἀθροίζεται τύχη; </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="123">ἱκέται κάθηνται παῖδες οἵδʼ Ἡρακλέους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="124">βωμὸν καταστέψαντες, ὡς ὁρᾷς, ἄναξ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="125">πατρός τε πιστὸς Ἰόλεως παραστάτης. </l>
- </sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="126">τί δῆτʼ ἰυγμῶν ἥδʼ ἐδεῖτο συμφορά; </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="127">βίᾳ νιν οὗτος τῆσδʼ ἀπʼ ἐσχάρας ἄγειν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="128">ζητῶν βοὴν ἔστησε κἄσφηλεν γόνυ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="129">γέροντος, ὥστε μʼ ἐκβαλεῖν οἴκτῳ δάκρυ. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="130">καὶ μὴν στολήν γʼ Ἕλληνα καὶ ῥυθμὸν πέπλων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="131">ἔχει, τὰ δʼ ἔργα βαρβάρου χερὸς τάδε. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="132">σὸν δὴ τὸ φράζειν ἐστί, μὴ μέλλειν τ’, ἐμοὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="133">ποίας ἀφῖξαι δεῦρο γῆς ὅρους λιπών; </l>
-</sp>
-
-<milestone n="134" unit="card" resp="perseus"/>
-
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="134">Ἀργεῖός εἰμι· τοῦτο γὰρ θέλεις μαθεῖν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="135">ἐφʼ οἷσι δʼ ἥκω καὶ παρʼ οὗ λέγειν θέλω.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="136">πέμπει Μυκηνῶν δεῦρό μʼ Εὐρυσθεὺς ἄναξ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="137">ἄξοντα τούσδε· πολλὰ δʼ ἦλθον, ὦ ξένε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="138">δίκαιʼ ὁμαρτῇ δρᾶν τε καὶ λέγειν ἔχων. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="139" rend="indent">Ἀργεῖος ὢν γὰρ αὐτὸς Ἀργείους ἄγω </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="140">ἐκ τῆς ἐμαυτοῦ τούσδε δραπέτας ἔχων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="141">νόμοισι τοῖς ἐκεῖθεν ἐψηφισμένους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="142">θανεῖν· δίκαιοι δʼ ἐσμὲν οἰκοῦντες πόλιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="143">αὐτοὶ καθʼ αὑτῶν κυρίους κραίνειν δίκας. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="144">πολλῶν δὲ κἄλλων ἑστίας ἀφιγμένοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="145">ἐν τοῖσιν αὐτοῖς τοισίδʼ ἕσταμεν λόγοις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="146">κοὐδεὶς ἐτόλμησʼ ἴδια προσθέσθαι κακά. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="147">ἀλλʼ ἤ τινʼ ἐς σὲ μωρίαν ἐσκεμμένοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="148">δεῦρʼ ἦλθον ἢ κίνδυνον ἐξ ἀμηχάνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="149">ῥίπτοντες, εἴτʼ οὖν εἴτε μὴ γενήσεται· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="150">οὐ γὰρ φρενήρη γʼ ὄντα σʼ ἐλπίζουσί που </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="151">μόνον τοσαύτης ἣν ἐπῆλθον Ἑλλάδος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="152">τὰς τῶνδʼ ἀβούλους συμφορὰς κατοικτιεῖν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="153" rend="indent">φέρʼ ἀντίθες γάρ· τούσδε τʼ ἐς γαῖαν παρεὶς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="154">ἡμᾶς τʼ ἐάσας ἐξάγειν, τί κερδανεῖς; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="155">τὰ μὲν παρʼ ἡμῶν τοιάδʼ ἔστι σοι λαβεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="156">Ἄργους τοσήνδε χεῖρα τήν τʼ Εὐρυσθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="157">ἰσχὺν ἅπασαν τῇδε προσθέσθαι πόλει. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="158">ἢν δʼ ἐς λόγους τε καὶ τὰ τῶνδʼ οἰκτίσματα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="159">βλέψας πεπανθῇς, ἐς πάλην καθίσταται </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="160">δορὸς τὸ πρᾶγμα· μὴ γὰρ ὡς μεθήσομεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="161">δόξῃς ἀγῶνα τόνδʼ ἄτερ χαλυβδικοῦ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="162">τί δῆτα φήσεις, ποῖα πεδίʼ ἀφαιρεθείς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="163">τί ῥυσιασθείς, πόλεμον Ἀργείοις ἔχειν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="164">ποίοις δʼ ἀμύνων συμμάχοις, τίνος δʼ ὕπερ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="165">θάψεις νεκροὺς πεσόντας; ἦ κακὸν λόγον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="166">κτήσῃ πρὸς ἀστῶν, εἰ γέροντος οὕνεκα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="167">τύμβου, τὸ μηδὲν ὄντος, ὡς εἰπεῖν ἔπος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="168">παίδων <add>τε</add> τῶνδʼ, ἐς ἄντλον ἐμβήσῃ πόδα. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="169" rend="indent">ἐρεῖς τὸ λῷστον ἐλπίδʼ εὑρήσειν μόνον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="170">καὶ τοῦτο πολλῷ τοῦ παρόντος ἐνδεές· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="171">κακῶς γὰρ Ἀργείοισιν οἵδ’ ὡπλισμένοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="172">μάχοιντʼ ἂν ἡβήσαντες, εἴ <add>τι</add> τοῦτό σε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="173">ψυχὴν ἐπαίρει· χοὑν μέσῳ πολὺς χρόνος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="174">ἐν ᾧ διεργασθεῖτʼ ἄν. ἀλλʼ ἐμοὶ πιθοῦ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="175">δοὺς μηδέν, ἀλλὰ τἄμ’ ἐῶν ἄγειν ἐμὲ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="176">κτῆσαι Μυκήνας, μηδʼ ὅπερ φιλεῖτε δρᾶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="177">πάθῃς σὺ τοῦτο, τοὺς ἀμείνονας παρὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="178">φίλους ἑλέσθαι, τοὺς κακίονας λάβῃς. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="179">τίς ἂν δίκην κρίνειεν ἢ γνοίη λόγον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="180">πρὶν ἂν παρʼ ἀμφοῖν μῦθον ἐκμάθῃ σαφῶς;</l>
-</sp>
-
-<milestone n="181" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="181">ἄναξ — ὑπάρχει μὲν τόδʼ ἐν τῇ σῇ χθονί — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="182">εἰπεῖν ἀκοῦσαί τʼ ἐν μέρει πάρεστί μοι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="183">κοὐδείς μʼ ἀπώσει πρόσθεν, ὥσπερ ἄλλοθεν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="184" rend="indent">ἡμῖν δὲ καὶ τῷδʼ οὐδέν ἐστιν ἐν μέρει· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="185">ἐπεὶ γὰρ Ἄργους οὐ μέτεσθʼ ἡμῖν ἔτι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="186">ψήφῳ δοκῆσαν, ἀλλὰ φεύγομεν πάτραν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="187">πῶς ἂν δικαίως ὡς Μυκηναίους ἄγοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="188">ὧδʼ ὄντας ἡμᾶς, οὓς ἀπήλασαν χθονός; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="189">ξένοι γάρ ἐσμεν. ἢ τὸν Ἑλλήνων ὅρον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="190">φεύγειν δικαιοῦθʼ ὅστις ἂν τἄργος φύγῃ; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="191">οὔκουν Ἀθήνας γʼ· οὐ γὰρ Ἀργείων φόβῳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="192">τοὺς Ἡρακλείους παῖδας ἐξελῶσι γῆς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="193">οὐ γάρ τι Τραχίς ἐστιν οὐδʼ Ἀχαιικὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="194">πόλισμʼ, ὅθεν σὺ τούσδε, τῇ δίκῃ μὲν οὔ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="195">τὸ δʼ Ἄργος ὀγκῶν, οἷάπερ καὶ νῦν λέγεις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="196">ἤλαυνες ἱκέτας βωμίους καθημένους. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="197">εἰ γὰρ τόδʼ ἔσται καὶ λόγους κρινοῦσι σούς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="198">οὐκ οἶδʼ Ἀθήνας τάσδʼ ἐλευθέρας ἔτι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="199">ἀλλʼ οἶδʼ ἐγὼ τὸ τῶνδε λῆμα καὶ φύσιν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="200">θνῄσκειν θελήσουσʼ· ἡ γὰρ αἰσχύνη <add>πάρος</add> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="201">τοῦ ζῆν παρʼ ἐσθλοῖς ἀνδράσιν νομίζεται. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="202" rend="indent">πόλιν μὲν ἀρκεῖ· καὶ γὰρ οὖν ἐπίφθονον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="203">λίαν ἐπαινεῖν ἐστι, πολλάκις δὲ δὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="204">καὐτὸς βαρυνθεὶς οἶδʼ ἄγαν αἰνούμενος. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="205">σοὶ δʼ ὡς ἀνάγκη τούσδε βούλομαι φράσαι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="206">σῴζειν, ἐπείπερ τῆσδε προστατεῖς χθονός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="207">Πιτθεὺς μέν ἐστι Πέλοπος, ἐκ δὲ Πιτθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="208">Αἴθρα, πατὴρ δʼ ἐκ τῆσδε γεννᾶται σέθεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="209">Θησεύς. πάλιν δὲ τῶνδʼ ἄνειμί σοι γένος. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="210">Ἡρακλέης ἦν Ζηνὸς Ἀλκμήνης τε παῖς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="211">κείνη δὲ Πέλοπος θυγατρός. αὐτανεψίων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="212">πατὴρ ἂν εἴη σός τε χὡ τούτων γεγώς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="213" rend="indent">γένους μὲν ἥκεις ὧδε τοῖσδε, Δημοφῶν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="214">ἃ δʼ ἐκτὸς ἤδη τοῦ προσήκοντός σε δεῖ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="215">τεῖσαι λέγω σοι παισί· φημὶ γάρ ποτε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="216">σύμπλους γενέσθαι τῶνδʼ ὑπασπίζων πατρὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="217">ζωστῆρα Θησεῖ τὸν πολυκτόνον μέτα· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="218">Ἅιδου τʼ ἐρυμνῶν ἐξανήγαγεν μυχῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="219">πατέρα σόν· Ἑλλὰς πᾶσα τοῦτο μαρτυρεῖ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="220">ὧν ἀντιδοῦναί σʼ οἵδʼ ἀπαιτοῦσιν χάριν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="221">μήτʼ ἐκδοθῆναι μήτε πρὸς βίαν θεῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="222">τῶν σῶν ἀποσπασθέντες ἐκπεσεῖν χθονός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="223">σοὶ γὰρ τόδʼ αἰσχρὸν <sic>χωρίς, ἔν τε πόλει κακόν,</sic></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="224">ἱκέτας ἀλήτας συγγενεῖς, οἴμοι,  κακῶς — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="225">βλέψον πρὸς αὐτοὺς βλέψον· — ἕλκεσθαι βίᾳ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="226">ἀλλʼ ἄντομαί σε καὶ καταστέφω χεροῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="227">καὶ <gap reason="ellipsis" rend=" . . . "/> πρὸς γενείου, μηδαμῶς ἀτιμάσῃς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="228">τοὺς Ἡρακλείους παῖδας ἐς χέρας λαβών· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="229">γενοῦ δὲ τοῖσδε συγγενής, γενοῦ φίλος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="230">πατὴρ ἀδελφὸς δεσπότης· ἅπαντα γὰρ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="231">ταῦτʼ ἐστὶ κρείσσω πλὴν ὑπʼ Ἀργείοις πεσεῖν. </l>
-</sp>
-
-<milestone n="232" unit="card" resp="perseus"/>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="232">ᾤκτιρʼ ἀκούσας τούσδε συμφορᾶς, ἄναξ.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="233">τὴν δʼ εὐγένειαν τῆς τύχης νικωμένην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="234">νῦν δὴ μάλιστʼ ἐσεῖδον· οἵδε γὰρ πατρὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="235">ἐσθλοῦ γεγῶτες δυστυχοῦσʼ ἀναξίως. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="236">τρισσαί μʼ ἀναγκάζουσι συμφορᾶς ὁδοί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="237">Ἰόλαε, τοὺς σοὺς μὴ παρώσασθαι ξένους· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="238">τὸ μὲν μέγιστον Ζεὺς ἐφʼ οὗ σὺ βώμιος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="239">θακεῖς νεοσσῶν τήνδʼ ἔχων πανήγυριν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="240">τὸ συγγενές τε καὶ τὸ προυφείλειν καλῶς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="241">πράσσειν παρʼ ἡμῶν τούσδε πατρῴαν χάριν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="242">τό τʼ αἰσχρόν, οὗπερ δεῖ μάλιστα φροντίσαι· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="243">εἰ γὰρ παρήσω τόνδε συλᾶσθαι βίᾳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="244">ξένου πρὸς ἀνδρὸς βωμόν, οὐκ ἐλευθέραν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="245">οἰκεῖν δοκήσω γαῖαν, Ἀργείων δʼ ὄκνῳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="246">ἱκέτας προδοῦναι· καὶ τάδʼ ἀγχόνης πέλας. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="247">ἀλλʼ ὤφελες μὲν εὐτυχέστερος μολεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="248">ὅμως δὲ καὶ νῦν μὴ τρέσῃς ὅπως σέ τις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="249">σὺν παισὶ βωμοῦ τοῦδʼ ἀποσπάσει βίᾳ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="250" rend="indent">σὺ δʼ Ἄργος ἐλθὼν ταῦτά τʼ Εὐρυσθεῖ φράσον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="251">πρὸς τοῖσδέ τʼ, εἴ τι τοισίδʼ ἐγκαλεῖ ξένοις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="252">δίκης κυρήσειν· τούσδε δʼ οὐκ ἄξεις ποτέ. </l>
-</sp>
-
-<milestone n="253" unit="card" resp="perseus"/>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="253">οὐκ ἢν δίκαιον ᾖ τι καὶ νικῶ λόγῳ; </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="254">καὶ πῶς δίκαιον τὸν ἱκέτην ἄγειν βίᾳ; </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="255">οὐκ οὖν ἐμοὶ τόδʼ αἰσχρόν, ἀλλʼ <add>οὐ</add> σοὶ βλάβος; </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="256">ἐμοί γʼ, ἐάν σοι τούσδʼ ἐφέλκεσθαι μεθῶ. </l>   
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="257">σὺ δʼ ἐξόριζε, κᾆτʼ ἐκεῖθεν ἄξομεν. </l>
-    
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="258">σκαιὸς πέφυκας τοῦ θεοῦ πλείω φρονῶν. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="259">δεῦρʼ, ὡς ἔοικε, τοῖς κακοῖσι φευκτέον. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="260">ἅπασι κοινὸν ῥῦμα δαιμόνων ἕδρα. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="261">ταῦτʼ οὐ δοκήσει τοῖς Μυκηναίοις ἴσως. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="262">οὐκ οὖν ἐγὼ τῶν ἐνθάδʼ εἰμὶ κύριος; </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="263">βλάπτων <add>γʼ</add> ἐκείνους μηδέν, ἢν σὺ σωφρονῇς.</l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="264">βλάπτεσθʼ, ἐμοῦ γε μὴ μιαίνοντος θεούς. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="265">οὐ βούλομαί σε πόλεμον Ἀργείοις ἔχειν.</l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="266">κἀγὼ τοιοῦτος· τῶνδε δʼ οὐ μεθήσομαι. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="267">ἄξω γε μέντοι τοὺς ἐμοὺς ἐγὼ λαβών. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="268">οὐκ ἆρ’ ἐς Ἄργος ῥᾳδίως ἄπει πάλιν. </l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="269">πειρώμενος δὴ τοῦτό γʼ αὐτίκʼ εἴσομαι. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="270">κλαίων ἄρʼ ἅψῃ τῶνδε κοὐκ ἐς ἀμβολάς.</l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="271">μὴ πρὸς θεῶν κήρυκα τολμήσῃς θενεῖν.</l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="272">εἰ μή γʼ ὁ κῆρυξ σωφρονεῖν μαθήσεται.</l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="273">ἄπελθε· καὶ σὺ τοῦδε μὴ θίγῃς, ἄναξ.</l>
-</sp>
-
-<sp><speaker>Κῆρυξ</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="274">στείχω· μιᾶς γὰρ χειρὸς ἀσθενὴς μάχη. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="275">ἥξω δὲ πολλὴν Ἄρεος Ἀργείου λαβὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="276">πάγχαλκον αἰχμὴν δεῦρο. μυρίοι δέ με </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="277">μένουσιν ἀσπιστῆρες Εὐρυσθεύς τʼ ἄναξ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="278">αὐτὸς στρατηγῶν· Ἀλκάθου δʼ ἐπʼ ἐσχάτοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="279">καραδοκῶν τἀνθένδε τέρμασιν μένει. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="280">λαμπρὸς δʼ ἀκούσας σὴν ὕβριν φανήσεται </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="281">σοὶ καὶ πολίταις γῇ τε τῇδε καὶ φυτοῖς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="282">μάτην γὰρ ἥβην ὧδέ γʼ ἂν κεκτῄμεθα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="283">πολλὴν ἐν Ἄργει, μή σε τιμωρούμενοι. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="284">φθείρου· τὸ σὸν γὰρ Ἄργος οὐ δέδοικʼ ἐγώ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="285">ἐνθένδε δʼ οὐκ ἔμελλες αἰσχύνας ἐμὲ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="286">ἄξειν βίᾳ τούσδʼ· οὐ γὰρ Ἀργείων πόλει </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="287">ὑπήκοον τήνδʼ ἀλλʼ ἐλευθέραν ἔχω. </l>
-</sp>
-
-<milestone n="288" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="anapests">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="288">ὥρα προνοεῖν, πρὶν ὅροις πελάσαι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="289">στρατὸν Ἀργείων· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="290">μάλα δʼ ὀξὺς Ἄρης ὁ Μυκηναίων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="291">ἐπὶ τοῖσι δὲ δὴ μᾶλλον ἔτʼ ἢ πρίν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="292">πᾶσι γὰρ οὗτος κήρυξι νόμος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="293">δὶς τόσα πυργοῦν τῶν γιγνομένων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="294">πόσα νιν λέξειν βασιλεῦσι δοκεῖς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="295">ὡς δείνʼ ἔπαθεν καὶ παρὰ μικρὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="296">ψυχὴν ἦλθεν διακναῖσαι; </l>
-</sp>
-
-<milestone n="297" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="297">οὐκ ἔστι τοῦδε παισὶ κάλλιον γέρας, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="298">ἢ πατρὸς ἐσθλοῦ κἀγαθοῦ πεφυκέναι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="299"><del>γαμεῖν τʼ ἀπʼ ἐσθλῶν· ὃς δὲ νικηθεὶς πόθῳ</del> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="300"><del rend="merge">κακοῖς ἐκοινώνησεν, οὐκ ἐπαινέσω,</del> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="301"><del rend="merge">τέκνοις ὄνειδος οὕνεχʼ ἡδονῆς λιπεῖν.</del> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="302">τὸ δυστυχὲς γὰρ ηὑγένει’ ἀμύνεται </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="303">τῆς δυσγενείας μᾶλλον· ἡμεῖς γὰρ κακῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="304">ἐς τοὔσχατον πεσόντες ηὕρομεν φίλους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="305">καὶ ξυγγενεῖς τούσδʼ, οἳ τοσῆσδʼ οἰκουμένης </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="306">Ἑλληνίδος γῆς τῶνδε προύστησαν μόνοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="307">δότ’, ὦ τέκνʼ, αὐτοῖς χεῖρα δεξιάν, δότε· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="308">ὑμεῖς τε παισί, καὶ πέλας προσέλθετε. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="309">ὦ παῖδες, ἐς μὲν πεῖραν ἤλθομεν φίλων· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="310">ἢν δʼ οὖν ποθʼ ὑμῖν νόστος ἐς πάτραν φανῇ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="311">καὶ δώματʼ οἰκήσητε καὶ τιμὰς πατρός </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="311a"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="312">σωτῆρας αἰεὶ καὶ φίλους νομίζετε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="313">καὶ μήποτʼ ἐς γῆν ἐχθρὸν αἴρεσθαι δόρυ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="314">μέμνησθέ μοι τήνδʼ, ἀλλὰ φιλτάτην πόλιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="315">πασῶν νομίζετʼ. ἄξιοι δʼ ὑμῖν σέβειν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="316">οἳ γῆν τοσήνδε καὶ Πελασγικὸν λεὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="317">ἡμῶν ἀπηλλάξαντο πολεμίους ἔχειν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="318">πτωχοὺς ἀλήτας εἰσορῶντες· ἀλλʼ ὅμως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="319">οὐκ ἐξέδωκαν οὐδʼ ἀπήλασαν χθονός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="320">ἐγὼ δὲ καὶ ζῶν καὶ θανών, ὅταν θάνω,</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="321">πολλῷ σʼ ἐπαίνῳ Θησέως, ὦ τᾶν, πέλας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="322">ὑψηλὸν ἀρῶ καὶ λέγων τάδʼ εὐφρανῶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="323">ὡς εὖ τʼ ἐδέξω καὶ τέκνοισιν ἤρκεσας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="324">τοῖς Ἡρακλείοις, εὐγενὴς δʼ ἀνʼ Ἑλλάδα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="325">σῴζεις πατρῴαν δόξαν, ἐξ ἐσθλῶν δὲ φὺς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="326">οὐδὲν κακίων τυγχάνεις γεγὼς πατρός, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="327">παύρων μετʼ ἄλλων· ἕνα γὰρ ἐν πολλοῖς ἴσως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="328">εὕροις ἂν ὅστις ἐστὶ μὴ χείρων πατρός. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="329">ἀεί ποθʼ ἥδε γαῖα τοῖς ἀμηχάνοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="330">σὺν τῷ δικαίῳ βούλεται προσωφελεῖν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="331">τοιγὰρ πόνους δὴ μυρίους ὑπὲρ φίλων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="332">ἤνεγκε, καὶ νῦν τόνδʼ ἀγῶνʼ ὁρῶ πέλας. </l>
-</sp>
-
-<milestone n="333" unit="card" resp="perseus"/>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="333">σοί τʼ εὖ λέλεκται, καὶ τὰ τῶνδʼ αὐχῶ, γέρον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="334">τοιαῦτʼ ἔσεσθαι· μνημονεύσεται χάρις. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="335">κἀγὼ μὲν ἀστῶν σύλλογον ποήσομαι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="336">τάξω δʼ, ὅπως ἂν τὸν Μυκηναίων στρατὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="337">πολλῇ δέχωμαι χειρί· πρῶτα μὲν σκοποὺς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="338">πέμψω πρὸς αὐτόν, μὴ λάθῃ με προσπεσών· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="339">ταχὺς γὰρ Ἄργει πᾶς ἀνὴρ βοηδρόμος· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="340">μάντεις δʼ ἀθροίσας θύσομαι. σὺ δʼ ἐς  δόμους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="341">σὺν παισὶ χώρει, Ζηνὸς ἐσχάραν λιπών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="342">εἰσὶν γὰρ οἵ σου, κἂν ἐγὼ θυραῖος ὦ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="343">μέριμναν ἕξουσʼ. ἀλλʼ ἴθʼ ἐς δόμους, γέρον. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="344">οὐκ ἂν λίποιμι βωμόν· ἑζώμεσθα δὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="345">ἱκέται μένοντες ἐνθάδʼ εὖ πρᾶξαι πόλιν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="346">ὅταν δʼ ἀγῶνος τοῦδʼ ἀπαλλαχθῇς καλῶς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="347">ἴμεν πρὸς οἴκους. θεοῖσι δʼ οὐ κακίοσιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="348">χρώμεσθα συμμάχοισιν Ἀργείων, ἄναξ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="349">τῶν μὲν γὰρ Ἥρα προστατεῖ, Διὸς δάμαρ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="350">ἡμῶν δʼ Ἀθηνᾶ. φημὶ δʼ εἰς εὐπραξίαν</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="351">καὶ τοῦθʼ ὑπάρχειν, θεῶν ἀμεινόνων τυχεῖν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="352">νικωμένη γὰρ Παλλὰς οὐκ ἀνέξεται. </l>
-</sp></div></div>
-
-<milestone n="353" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="choral">
-<div type="textpart" subtype="strophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="353">Εἰ σὺ μέγʼ αὐχεῖς, ἕτεροι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="354">σοῦ πλέον οὐ μέλονται, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="355"><add>ὦ</add> ξεῖν’ Ἀργόθεν ἐλθών, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="356">μεγαληγορίαισι δʼ ἐμὰς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="357">φρένας οὐ φοβήσεις. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="358">μήπω ταῖς μεγάλαισιν οὕ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="359">τω καὶ καλλιχόροις Ἀθή- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="360">ναις εἴη· σὺ δʼ ἄφρων, ὅ τʼ Ἄρ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="361">γει Σθενέλου τύραννος. </l>
-</sp></div>
-
-<milestone n="362" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="362">ὃς πόλιν ἐλθὼν ἑτέραν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="363">οὐδὲν ἐλάσσονʼ  Ἄργους, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="364">θεῶν ἱκτῆρας ἀλάτας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="365">καὶ ἐμᾶς χθονὸς ἀντομένους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="366">ξένος ὢν βιαίως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="367">ἕλκεις, οὐ βασιλεῦσιν εἴ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="368">ξας, οὐκ ἄλλο δίκαιον εἰ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="369">πών· ποῦ ταῦτα καλῶς ἂν εἴ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="370">η παρά γʼ εὖ φρονοῦσιν; </l>
-</sp></div>
-
-<milestone n="371" unit="card" resp="perseus"/>
-
-
-<div type="textpart" subtype="epode">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="371">Εἰρήνα μὲν ἐμοί γʼ ἀρέ-</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="372">σκει· σὺ δʼ, ὦ κακόφρων ἄναξ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="373">λέγω, εἰ πόλιν ἥξεις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="374">οὐχ οὕτως ἃ δοκεῖς κυρή- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="375">σεις· οὐ σοὶ μόνῳ ἔγχος οὐδʼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="376">ἰτέα κατάχαλκός <del>ἐστιν.</del> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="377">ἀλλʼ οὐ, πολέμων ἐραστάς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="378">μή μοι δορὶ συνταράξεις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="379">τὰν εὖ χαρίτων ἔχουσαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="380">πόλιν, ἀλλʼ ἀνάσχου. </l></sp></div></div>
-
-<milestone n="381" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="episode">
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="381">ὦ παῖ, τί μοι σύννοιαν ὄμμασιν φέρων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="382">ἥκεις; νέον τι πολεμίων λέξεις πέρι; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="383">μέλλουσιν ἢ πάρεισιν ἢ τί πυνθάνῃ; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="384">οὐ γάρ τι μὴ ψεύσῃς γε κήρυκος λόγους· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="385">ὁ γὰρ στρατηγὸς εὐτυχὴς τὰ πρὸς θεῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="386">εἶσιν, σάφʼ οἶδα, καὶ μάλʼ οὐ σμικρὸν φρονῶν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="387">ἐς τὰς Ἀθήνας. ἀλλὰ τῶν φρονημάτων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="388">ὁ Ζεὺς κολαστὴς τῶν ἄγαν ὑπερφρόνων. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="389">ἥκει στράτευμʼ Ἀργεῖον Εὐρυσθεύς τʼ ἄναξ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="390">ἐγώ νιν αὐτὸς εἶδον. ἄνδρα γὰρ χρεών, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="391">ὅστις στρατηγεῖν φησʼ ἐπίστασθαι καλῶς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="392">οὐκ ἀγγέλοισι τοὺς ἐναντίους ὁρᾶν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="393">πεδία μὲν οὖν γῆς ἐς τάδʼ οὐκ ἐφῆκέ πω </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="394">στρατόν, λεπαίαν δʼ ὀφρύην καθήμενος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="395">σκοπεῖ — δόκησιν δὴ τόδʼ ἂν λέγοιμί σοι — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="396"><sic>ποίᾳ προσάξει στρατόπεδον τὰ νῦν δορὸς</sic> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="397"><sic rend="merge">ἐν ἀσφαλεῖ τε τῆσδʼ ἱδρύσεται χθονός.</sic> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="398">καὶ τἀμὰ μέντοι πάντʼ ἄραρʼ ἤδη καλῶς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="399">πόλις τʼ ἐν ὅπλοις, σφάγιά θʼ ἡτοιμασμένα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="400">ἕστηκεν οἷς χρὴ ταῦτα τέμνεσθαι θεῶν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="402">τροπαῖά τʼ ἐχθρῶν καὶ πόλει σωτήρια, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="401">θυηπολεῖται δʼ ἄστυ μάντεων ὕπο. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="403">χρησμῶν δʼ ἀοιδοὺς πάντας εἰς ἓν ἁλίσας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="404">ἤλεγξα καὶ βέβηλα καὶ κεκρυμμένα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="405">λόγια παλαιά, τῇδε γῇ σωτήρια. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="406">καὶ τῶν μὲν ἄλλων διάφορʼ ἐστὶ θεσφάτοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="407">πόλλʼ· ἓν δὲ πᾶσι γνῶμα ταὐτὸν ἐμπρέπει· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="408">σφάξαι κελεύουσίν με παρθένον Κόρῃ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="409">Δήμητρος, ἥτις ἐστὶ πατρὸς εὐγενοῦς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="410" rend="indent">ἐγὼ δʼ ἔχω μέν, ὡς ὁρᾷς, προθυμίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="411">τοσήνδʼ ἐς ὑμᾶς· παῖδα δʼ οὔτʼ ἐμὴν κτενῶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="412">οὔτʼ ἄλλον ἀστῶν τῶν ἐμῶν ἀναγκάσω </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="413">ἄκονθʼ· ἑκὼν δὲ τίς κακῶς οὕτω φρονεῖ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="414">ὅστις τὰ φίλτατʼ ἐκ χερῶν δώσει τέκνα; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="415">καὶ νῦν πικρὰς ἂν συστάσεις ἂν εἰσίδοις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="416">τῶν μὲν λεγόντων ὡς δίκαιον ἦν ξένοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="417">ἱκέταις ἀρήγειν, τῶν δὲ μωρίαν ἐμὴν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="418">κατηγορούντων· εἰ δὲ δὴ δράσω τόδε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="419">οἰκεῖος ἤδη πόλεμος ἐξαρτύεται. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="420">ταῦτʼ οὖν ὅρα σὺ καὶ συνεξεύρισχʼ ὅπως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="421">αὐτοί τε σωθήσεσθε καὶ πέδον τόδε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="422">κἀγὼ πολίταις μὴ διαβληθήσομαι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="423">οὐ γὰρ τυραννίδʼ ὥστε βαρβάρων ἔχω· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="424">ἀλλʼ, ἢν δίκαια δρῶ, δίκαια πείσομαι. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="425">ἀλλʼ ἦ πρόθυμον οὖσαν οὐκ ἐᾷ θεὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="426">ξένοις ἀρήγειν τήνδε χρῄζουσιν πόλιν; </l>
-</sp>
-
-<milestone n="427" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="427">ὦ τέκνʼ, ἔοιγμεν ναυτίλοισιν, οἵτινες </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="428">χειμῶνος ἐκφυγόντες ἄγριον μένος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="429">ἐς χεῖρα γῇ συνῆψαν, εἶτα χερσόθεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="430">πνοιαῖσιν ἠλάθησαν ἐς πόντον πάλιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="431">οὕτω δὲ χἡμεῖς τῆσδʼ ἀπωθούμεσθα γῆς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="432">ἤδη πρὸς ἀκταῖς ὄντες ὡς σεσῳσμένοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="433">οἴμοι· τί δῆτʼ ἔτερψας ὦ τάλαινά με </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="434">ἐλπὶς τότʼ, οὐ μέλλουσα διατελεῖν χάριν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="435">συγγνωστὰ γάρ τοι καὶ τὰ τοῦδʼ, εἰ μὴ θέλει </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="436">κτείνειν πολιτῶν παῖδας· αἰνέσαι δʼ ἔχω </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="437">καὶ τἀνθάδ’· εἰ θεοῖσι δὴ δοκεῖ τάδε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="438">πράσσειν ἔμʼ, οὔτοι σή γʼ ἀπόλλυται χάρις. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="439" rend="indent">ὦ παῖδες, ὑμῖν δʼ οὐκ ἔχω τί χρήσομαι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="440">ποῖ τρεψόμεσθα; τίς γὰρ ἄστεπτος θεῶν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="441">ποῖον δὲ γαίας ἕρκος οὐκ ἀφίγμεθα; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="442">ὀλούμεθʼ, ὦ τέκνʼ· ἐκδοθησόμεσθα δή. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="443">κἀμοῦ μὲν οὐδὲν εἴ με χρὴ θανεῖν μέλει, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="444">πλὴν εἴ τι τέρψω τοὺς ἐμοὺς ἐχθροὺς θανών· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="445">ὑμᾶς δὲ κλαίω καὶ κατοικτίρω, τέκνα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="446">καὶ τὴν γεραιὰν μητέρʼ Ἀλκμήνην πατρός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="447">ὦ δυστάλαινα τοῦ μακροῦ βίου σέθεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="448">τλήμων δὲ κἀγὼ πολλὰ μοχθήσας μάτην. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="449">χρῆν χρῆν ἄρʼ ἡμᾶς ἀνδρὸς εἰς ἐχθροῦ χέρας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="450">πεσόντας αἰσχρῶς καὶ κακῶς λιπεῖν βίον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="451" rend="indent">ἀλλʼ οἶσθ’ ὅ μοι σύμπραξον; οὐχ ἅπασα γὰρ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="452">πέφευγεν ἐλπὶς τῶνδέ μοι σωτηρίας· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="453">ἔμʼ ἔκδος Ἀργείοισιν ἀντὶ τῶνδʼ, ἄναξ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="454">καὶ μήτε κινδύνευε, σωθήτω τέ μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="455">τέκνʼ· οὐ φιλεῖν δεῖ τὴν ἐμὴν ψυχήν· ἴτω. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="456">μάλιστα δʼ Εὐρυσθεύς με βούλοιτʼ ἂν λαβὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="457">τὸν Ἡράκλειον σύμμαχον καθυβρίσαι· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="458">σκαιὸς γὰρ ἁνήρ. τοῖς σοφοῖς δʼ εὐκτὸν σοφῷ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="459">ἔχθραν συνάπτειν, μὴ ἀμαθεῖ φρονήματι· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="460">πολλῆς γὰρ αἰδοῦς καὶ δίκης τις ἂν τύχοι. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="461">ὦ πρέσβυ, μή νυν τήνδʼ ἐπαιτιῶ πόλιν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="462">τάχʼ ἂν γὰρ ἡμῖν ψευδὲς ἀλλʼ ὅμως κακὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="463">γένοιτʼ ὄνειδος ὡς ξένους προυδώκαμεν. </l>
-</sp>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="464">γενναῖα μὲν τάδʼ εἶπας, ἀλλʼ ἀμήχανα. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="465">οὐ σοῦ χατίζων δεῦρʼ ἄναξ στρατηλατεῖ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="466">τί γὰρ γέροντος ἀνδρὸς Εὐρυσθεῖ πλέον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="467">θανόντος; ἀλλὰ τούσδε βούλεται κτανεῖν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="468">δεινὸν γὰρ ἐχθροῖς βλαστάνοντες εὐγενεῖς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="469">νεανίαι τε καὶ πατρὸς μεμνημένοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="470">λύμας· ἃ κεῖνον πάντα προσκοπεῖν χρεών.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="471">ἀλλʼ, εἴ τινʼ ἄλλην οἶσθα καιριωτέραν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="472">βουλήν, ἑτοίμαζʼ, ὡς ἔγωγʼ ἀμήχανος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="473">χρησμῶν ἀκούσας εἰμὶ καὶ φόβου πλέως. </l>
-</sp>
-
-<milestone n="474" unit="card" resp="perseus"/>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="474">ξένοι, θράσος μοι μηδὲν ἐξόδοις ἐμαῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="475">προσθῆτε· πρῶτον γὰρ τόδʼ ἐξαιτήσομαι· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="476">γυναικὶ γὰρ σιγή τε καὶ τὸ σωφρονεῖν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="477">κάλλιστον, εἴσω θʼ ἥσυχον μένειν δόμων. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="478">τῶν σῶν δʼ ἀκούσασʼ, Ἰόλεως, στεναγμάτων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="479">ἐξῆλθον, οὐ ταχθεῖσα πρεσβεύειν γένους. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="480">ἀλλʼ, εἰμὶ γάρ πως πρόσφορος, μέλει δέ μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="481">μάλιστ’ ἀδελφῶν, τῶνδε κἀμαυτῆς πέρι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="482">θέλω πυθέσθαι, μὴ ’πὶ τοῖς πάλαι κακοῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="483">προσκείμενόν τι πῆμα σὴν δάκνει φρένα. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="484">ὦ παῖ, μάλιστα σʼ οὐ νεωστὶ δὴ τέκνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="485">τῶν Ἡρακλείων ἐνδίκως αἰνεῖν ἔχω. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="486">ἡμῖν δὲ δόξας εὖ προχωρῆσαι δρόμος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="487">πάλιν μεθέστηκʼ αὖθις ἐς τἀμήχανον· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="488">χρησμῶν γὰρ ᾠδούς φησι σημαίνειν ὅδε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="489">οὐ ταῦρον οὐδὲ μόσχον, ἀλλὰ παρθένον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="490">σφάξαι Κόρῃ Δήμητρος ἥτις εὐγενής, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="491">εἰ χρὴ μὲν ἡμᾶς, χρὴ δὲ τήνδʼ εἶναι πόλιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="492">ταῦτʼ οὖν ἀμηχανοῦμεν· οὔτε γὰρ τέκνα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="493">σφάξειν ὅδʼ αὑτοῦ φησιν οὔτʼ ἄλλου τινός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="494">κἀμοὶ λέγει μὲν οὐ σαφῶς, λέγει δέ πως, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="495">εἰ μή τι τούτων ἐξαμηχανήσομεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="496">ἡμᾶς μὲν ἄλλην γαῖαν εὑρίσκειν τινά, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="497">αὐτὸς δὲ σῶσαι τήνδε βούλεται χθόνα. </l>
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="498">ἐν τῷδε κἀχόμεσθα σωθῆναι λόγῳ; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="499">ἐν τῷδε, τἄλλα γʼ εὐτυχῶς πεπραγότες. </l>
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="500">μή νυν τρέσῃς ἔτʼ ἐχθρὸν Ἀργεῖον δόρυ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="501">ἐγὼ γὰρ αὐτὴ πρὶν κελευσθῆναι, γέρον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="502">θνῄσκειν ἑτοίμη καὶ παρίστασθαι σφαγῇ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="503">τί φήσομεν γάρ, εἰ πόλις μὲν ἀξιοῖ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="504">κίνδυνον ἡμῶν οὕνεκʼ αἴρεσθαι μέγαν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="505">αὐτοὶ δὲ προστιθέντες ἄλλοισιν πόνους, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="506">παρόν σφε σῷσαι, φευξόμεσθα μὴ θανεῖν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="507">οὐ δῆτʼ, ἐπεί τοι καὶ γέλωτος ἄξια, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="508">στένειν μὲν ἱκέτας δαιμόνων καθημένους, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="509">πατρὸς δʼ ἐκείνου φύντας οὗ πεφύκαμεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="510">κακοὺς ὁρᾶσθαι· ποῦ τάδʼ ἐν χρηστοῖς πρέπει; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="511">κάλλιον, οἶμαι, τῆσδʼ — ἃ μὴ τύχοι ποτέ — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="512">πόλεως ἁλούσης, χεῖρας εἰς ἐχθρῶν πεσεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="513"><sic>κἄπειτα τινὰ</sic> πατρὸς οὖσαν εὐγενοῦς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="514">παθοῦσαν Ἅιδην μηδὲν ἧσσον εἰσιδεῖν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="515">ἀλλʼ ἐκπεσοῦσα τῆσδʼ ἀλητεύσω χθονός; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="516">κοὐκ αἰσχυνοῦμαι δῆτ’, ἐὰν δή τις λέγῃ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="517">Τί δεῦρʼ ἀφίκεσθʼ ἱκεσίοισι σὺν κλάδοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="518">αὐτοὶ φιλοψυχοῦντες; ἔξιτε χθονός· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="519">κακοὺς γὰρ ἡμεῖς οὐ προσωφελήσομεν. </l>
-<milestone n="520" unit="card" resp="perseus"/>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="520" rend="indent">ἀλλʼ οὐδὲ μέντοι, τῶνδε μὲν τεθνηκότων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="521">αὐτὴ δὲ σωθεῖσʼ, ἐλπίδʼ εὖ πράξειν ἔχω· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="522">— πολλοὶ γὰρ ἤδη τῇδε προύδοσαν φίλους. — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="523">τίς γὰρ κόρην ἔρημον ἢ δάμαρτʼ ἔχειν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="524">ἢ παιδοποιεῖν ἐξ ἐμοῦ βουλήσεται; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="525">οὐκ οὖν θανεῖν ἄμεινον ἢ τούτων τυχεῖν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="526">ἀναξίαν; ἄλλῃ δὲ κἂν πρέποι τινὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="527">μᾶλλον τάδʼ, ἥτις μὴ ’πίσημος ὡς ἐγώ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="528" rend="indent">ἡγεῖσθʼ ὅπου δεῖ σῶμα κατθανεῖν τόδε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="529">καὶ στεμματοῦτε καὶ κατάρχεσθʼ, εἰ δοκεῖ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="530">νικᾶτε δʼ ἐχθρούς· ἥδε γὰρ ψυχὴ πάρα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="531">ἑκοῦσα κοὐκ ἄκουσα· κἀξαγγέλλομαι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="532">θνῄσκειν ἀδελφῶν τῶνδε κἀμαυτῆς ὕπερ.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="533">εὕρημα γάρ τοι μὴ φιλοψυχοῦσʼ ἐγὼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="534">κάλλιστον ηὕρηκ’, εὐκλεῶς λιπεῖν βίον. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="535">φεῦ φεῦ, τί λέξω παρθένου μέγαν λόγον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="536">κλύων, ἀδελφῶν ἣ πάρος θέλει θανεῖν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="537">τούτων τίς ἂν λέξειε γενναίους λόγους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="538">μᾶλλον, τίς ἂν δράσειεν ἀνθρώπων ἔτι; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="539">ὦ τέκνον, οὐκ ἔστʼ ἄλλοθεν τὸ σὸν κάρα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="540">ἀλλʼ ἐξ ἐκείνου σπέρμα τῆς θείας φρενὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="541">πέφυκας Ἡράκλειος· οὐδʼ αἰσχύνομαι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="542">τοῖς σοῖς λόγοισι, τῇ τύχῃ δʼ ἀλγύνομαι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="543">ἀλλʼ ᾗ γένοιτʼ ἂν ἐνδικωτέρως φράσω· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="544">πάσας ἀδελφὰς τῆσδε δεῦρο χρὴ καλεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="545">κᾆθʼ ἡ λαχοῦσα θνῃσκέτω γένους ὕπερ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="546">σὲ δʼ οὐ δίκαιον κατθανεῖν ἄνευ πάλου. </l>
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="547">οὐκ ἂν θάνοιμι τῇ τύχῃ λαχοῦσʼ ἐγώ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="548">χάρις γὰρ οὐ πρόσεστι· μὴ λέξῃς, γέρον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="549">ἀλλʼ, εἰ μὲν ἐνδέχεσθε καὶ βούλεσθέ μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="550">χρῆσθαι προθύμως, τὴν ἐμὴν ψυχὴν ἐγὼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="551">δίδωμʼ ἑκοῦσα τοῖσδʼ, ἀναγκασθεῖσα δʼ οὔ. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="552">φεῦ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="553">ὅδʼ αὖ λόγος σοι τοῦ πρὶν εὐγενέστερος· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="554">κἀκεῖνος ἦν ἄριστος· ἀλλʼ ὑπερφέρεις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="555">τόλμῃ τε τόλμαν καὶ λόγῳ χρηστῷ λόγον.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="556">οὐ μὴν κελεύω γʼ οὐδʼ ἀπεννέπω, τέκνον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="557">θνῄσκειν σʼ· ἀδελφοὺς δʼ ὠφελεῖς θανοῦσα σούς. </l>
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="558">σοφῶς κελεύεις· μὴ τρέσῃς μιάσματος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="559">τοὐμοῦ μετασχεῖν, ἀλλʼ ἐλευθέρως θάνω. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="560" rend="indent">ἕπου δέ, πρέσβυ· σῇ γὰρ ἐνθανεῖν χερὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="561">θέλω· πέπλοις δὲ σῶμʼ ἐμὸν κρύψον παρών· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="562">ἐπεὶ σφαγῆς γε πρὸς τὸ δεινὸν εἶμʼ ἐγώ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="563">εἴπερ πέφυκα πατρὸς οὗπερ εὔχομαι. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="564">οὐκ ἂν δυναίμην σῷ παρεστάναι μόρῳ. </l> 
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="565">σὺ δʼ ἀλλὰ τοῦδε χρῇζε, μή μʼ ἐν ἀρσένων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="566">ἀλλʼ ἐν γυναικῶν, χερσὶν ἐκπνεῦσαι βίον. </l></sp>
-
-<milestone n="567" unit="card" resp="perseus"/>
-
-<sp><speaker>Δημοφῶν</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="567">ἔσται τάδʼ, ὦ τάλαινα παρθένων, ἐπεὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="568">κἀμοὶ τόδʼ αἰσχρόν, μή σε κοσμεῖσθαι καλῶς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="569">πολλῶν ἕκατι, τῆς τε σῆς εὐψυχίας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="570">καὶ τοῦ δικαίου· τλημονεστάτην δὲ σὲ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="571">πασῶν γυναικῶν εἶδον ὀφθαλμοῖς ἐγώ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="572">ἀλλʼ, εἴ τι βούλῃ, τούσδε τὸν γέροντά τε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="573">χώρει προσειποῦσʼ ὑστάτοις προσφθέγμασιν. </l>
-</sp>
-
-<sp><speaker>Μακαρία</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="574">ὦ χαῖρε, πρέσβυ, χαῖρε καὶ δίδασκέ μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="575">τοιούσδε τούσδε παῖδας, ἐς τὸ πᾶν σοφούς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="576">ὥσπερ σύ, μηδὲν μᾶλλον· ἀρκέσουσι γάρ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="577">πειρῶ δὲ σῶσαι μὴ θανεῖν, πρόθυμος ὤν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="578">σοὶ παῖδές ἐσμεν, σαῖν χεροῖν τεθράμμεθα. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="579">ὁρᾷς δὲ κἀμὲ τὴν ἐμὴν ὥραν γάμου </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="580">διδοῦσαν ἀντὶ τῶνδε κατθανουμένην. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="581">ὑμεῖς τʼ, ἀδελφῶν ἡ παροῦσʼ ὁμιλία, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="582">εὐδαιμονοῖτε, καὶ γένοιθʼ ὑμῖν ὅσων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="583">ἡμὴ πάροιθε καρδία σφαγήσεται. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="584">καὶ τὸν γέροντα τήν τʼ ἔσω γραῖαν δόμων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="585">τιμᾶτε πατρὸς μητέρʼ Ἀλκμήνην ἐμοῦ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="586">ξένους τε τούσδε. κἂν ἀπαλλαγὴ πόνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="587">καὶ νόστος ὑμῖν εὑρεθῇ ποτʼ ἐκ θεῶν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="588">μέμνησθε τὴν σώτειραν ὡς θάψαι χρεών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="589">κάλλιστά τοι δίκαιον· οὐ γὰρ ἐνδεὴς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="590">ὑμῖν παρέστην, ἀλλὰ προύθανον γένους.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="591">τάδʼ ἀντὶ παίδων ἐστί μοι κειμήλια </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="592">καὶ παρθενείας, εἴ τι δὴ κάτω χθονός· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="593">εἴη γε μέντοι μηδέν. εἰ γὰρ ἕξομεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="594">κἀκεῖ μερίμνας οἱ θανούμενοι βροτῶν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="595">οὐκ οἶδ’ ὅποι τις τρέψεται· τὸ γὰρ θανεῖν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="596">κακῶν μέγιστον φάρμακον νομίζεται. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="597">ἀλλʼ, ὦ μέγιστον ἐκπρέπουσʼ εὐψυχίᾳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="598">πασῶν γυναικῶν, ἴσθι, τιμιωτάτη </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="599">καὶ ζῶσʼ ὑφʼ ἡμῶν καὶ θανοῦσʼ ἔσῃ πολύ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="600">καὶ χαῖρε· δυσφημεῖν γὰρ ἅζομαι θεάν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="601">ᾗ σὸν κατῆρκται σῶμα, Δήμητρος κόρην. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="602" rend="indent">ὦ παῖδες, οἰχόμεσθα· λύεται μέλη </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="603">λύπῃ· λάβεσθε κεἰς ἕδραν μʼ ἐρείσατε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="604">αὐτοῦ πέπλοισι τοῖσδε κρύψαντες, τέκνα. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="605">ὡς οὔτε τούτοις ἥδόμαι πεπραγμένοις, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="606">χρησμοῦ τε μὴ κρανθέντος οὐ βιώσιμον· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="607">μείζων γὰρ ἄτη· συμφορὰ δὲ καὶ τάδε. </l></sp></div>
-
-<milestone n="608" unit="card" resp="perseus"/>
-
-
-<div type="textpart" subtype="choral">
-<div type="textpart" subtype="strophe" n="1">
-    <sp><speaker>Χορός</speaker>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="608">οὔτινά φημι θεῶν ἄτερ ὄλβιον, οὐ βαρύποτμον, </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="609">ἄνδρα γενέσθαι· </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="610">οὐδὲ τὸν αὐτὸν ἀεὶ βεβάναι δόμον </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="611">εὐτυχίᾳ· παρὰ δʼ ἄλλαν ἄλλα </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="612">μοῖρα διώκει. </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="613">τὸν μὲν ἀφʼ ὑψηλῶν βραχὺν ᾤκισε, </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="614">τὸν δʼ ἀλέταν εὐδαίμονα τεύχει. </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="615">μόρσιμα δʼ οὔτι φυγεῖν θέμις, οὐ σοφί- </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="616">ᾳ τις ἀπώσεται, ἀλλὰ μάταν ὁ πρό- </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="617">θυμος ἀεὶ πόνον ἕξει. </l>
-    </sp></div>
-
-<milestone n="618" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="618">ἀλλὰ σὺ μὴ προπίτνων τὰ θεῶν φέρε, μηδʼ ὑπεράλγει </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="620">φροντίδα λύπᾳ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="621">εὐδόκιμον γὰρ ἔχει θανάτου μέρος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="622">ἁ μελέα πρό τʼ ἀδελφῶν καὶ γᾶς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="623">οὐδʼ ἀκλεής νιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="624">δόξα πρὸς ἀνθρώπων ὑποδέξεται· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="625">ἁ δʼ ἀρετὰ βαίνει διὰ μόχθων. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="626">ἄξια μὲν πατρός, ἄξια δʼ εὐγενί- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="627">ας τάδε γίγνεται· εἰ δὲ σέβεις θανά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="628">τους ἀγαθῶν, μετέχω σοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629"><gap reason="lost" rend=" . . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629a"><gap reason="lost" rend=" . . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629b"><gap reason="lost" rend=" . . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629c"><gap reason="lost" rend=" . . . . . . . "/></l>
-</sp></div></div>
-
-<milestone n="630" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="episode">
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="630">ὦ τέκνα, χαίρετʼ· Ἰόλεως δὲ ποῦ γέρων; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="631">μήτηρ τε πατρὸς τῆσδʼ ἕδρας ἀποστατεῖ; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="632">πάρεσμεν, οἵα δή γʼ ἐμοῦ παρουσία. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="633">τί χρῆμα κεῖσαι καὶ κατηφὲς ὄμμʼ ἔχεις; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="634">φροντίς τις ἦλθʼ οἰκεῖος, ᾗ συνειχόμην. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="635">ἔπαιρέ νυν σεαυτόν, ὄρθωσον κάρα. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="636">γέροντές ἐσμεν κοὐδαμῶς ἐρρώμεθα. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="637">ἥκω γε μέντοι χάρμα σοι φέρων μέγα. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="638">τίς δʼ εἶ σύ; ποῦ σοι συντυχὼν ἀμνημονῶ; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="639">Ὕλλου πενέστης· οὔ με γιγνώσκεις ὁρῶν; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="640">ὦ φίλταθʼ, ἥκεις ἆρα σωτὴρ νῷν βλάβης; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="641">μάλιστα· καὶ πρός γʼ εὐτυχεῖς τὰ νῦν τάδε. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="642">ὦ μῆτερ ἐσθλοῦ παιδός, Ἀλκμήνην λέγω, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="643">ἔξελθʼ, ἄκουσον τοῦδε φιλτάτους λόγους. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="644">πάλαι γὰρ ὠδίνουσα τῶν ἀφιγμένων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="645">ψυχὴν ἐτήκου νόστος εἰ γενήσεται. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="646">τί χρῆμʼ ἀϋτῆς πᾶν τόδʼ ἐπλήσθη στέγος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="647">Ἰόλαε; μῶν τίς σʼ αὖ βιάζεται παρὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="648">κῆρυξ ἀπʼ Ἄργους; ἀσθενὴς μὲν ἥ γʼ ἐμὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="649">ῥώμη, τοσόνδε δʼ εἰδέναι σʼ ἐχρῆν, ξένε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="650">οὐκ ἔστʼ ἄγειν σε τούσδʼ ἐμοῦ ζώσης ποτέ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="651">ἦ τἄρ’ ἐκείνου μὴ νομιζοίμην ἐγὼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="652">μήτηρ ἔτʼ· εἰ δὲ τῶνδε προσθίξῃ χερί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="653">δυοῖν γερόντοιν οὐ καλῶς ἀγωνιῇ. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="654">θάρσει, γεραιά, μὴ τρέσῃς· οὐκ Ἀργόθεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="655">κῆρυξ ἀφῖκται πολεμίους λόγους ἔχων.</l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="656">τί γὰρ βοὴν ἔστησας ἄγγελον φόβου; </l> 
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="657">σέ, πρόσθε ναοῦ τοῦδʼ ὅπως βαίης πέλας. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="658">οὐκ ἴσμεν ἡμεῖς ταῦτα· τίς γάρ ἐσθʼ ὅδε; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="659">ἥκοντα παῖδα παιδὸς ἀγγέλλει σέθεν. </l>
-</sp>
-
-<milestone n="660" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἀλκμήνη</speaker>   
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="660">ὦ χαῖρε καὶ σὺ τοῖσδε τοῖς ἀγγέλμασιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="661">ἀτὰρ τί χώρᾳ τῇδε προσβαλὼν πόδα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="662">ποῦ νῦν ἄπεστι; τίς νιν εἶργε συμφορὰ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="663">σὺν σοὶ φανέντα δεῦρʼ ἐμὴν τέρψαι φρένα; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="664">στρατὸν καθίζει τάσσεταί θʼ ὃν ἦλθʼ ἔχων. </l>   
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="665">τοῦδʼ οὐκέθʼ ἡμῖν τοῦ λόγου μέτεστι δή.</l> 
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="666">μέτεστιν· ἡμῶν δʼ ἔργον ἱστορεῖν τάδε. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="667">τί δῆτα βούλῃ τῶν πεπραγμένων μαθεῖν; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="668">πόσον τι πλῆθος συμμάχων πάρεστʼ ἔχων; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="669">πολλούς· ἀριθμὸν δʼ ἄλλον οὐκ ἔχω φράσαι. </l>
-</sp>
-    
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="670">ἴσασιν, οἶμαι, ταῦτʼ· Ἀθηναίων πρόμοι; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="671">ἴσασι· καὶ δὴ λαιὸν ἕστηκεν κέρας. </l> 
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="672">ἤδη γὰρ ὡς ἐς ἔργον ὥπλισται στρατός; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="673">καὶ δὴ παρῆκται σφάγια τάξεων ἑκάς. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="674">πόσον τι δʼ ἔστʼ ἄπωθεν Ἀργεῖον δόρυ; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="675">ὥστʼ ἐξορᾶσθαι τὸν στρατηγὸν ἐμφανῶς. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="676">τί δρῶντα; μῶν τάσσοντα πολεμίων στίχας; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="677">ᾐκάζομεν ταῦτʼ· οὐ γὰρ ἐξηκούομεν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="678">ἀλλʼ εἶμ’· ἐρήμους δεσπότας τοὐμὸν μέρος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="679">οὐκ ἂν θέλοιμι πολεμίοισι συμβαλεῖν. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="680">κἄγωγε σὺν σοί· ταὐτὰ γὰρ φροντίζομεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="681">φίλοις παρόντες, ὡς ἔοιγμεν, ὠφελεῖν. </l>  
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="682">ἥκιστα πρὸς σοῦ μῶρον ἦν εἰπεῖν ἔπος. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="683">καὶ μὴ μετασχεῖν γʼ ἀλκίμου μάχης φίλοις. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="684">οὐκ ἔστʼ ἐν ὄψει τραῦμα μὴ δρώσης χερός. </l>
- </sp>
-
-<sp><speaker>Ἰόλαος</speaker> 
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="685">τί δʼ; οὐ σθένοιμι κἂν ἐγὼ δι’ ἀσπίδος; </l></sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="686">σθένοις ἄν, ἀλλὰ πρόσθεν αὐτὸς ἂν πέσοις. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker> 
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="687">οὐδεὶς ἔμʼ ἐχθρῶν προσβλέπων ἀνέξεται. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="688">οὐκ ἔστιν, ὦ τᾶν, ἥ ποτʼ ἦν ῥώμη σέθεν. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="689">ἀλλʼ οὖν μαχοῦνται γʼ ἀριθμὸν οὐκ ἐλάσσοσι. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="690">σμικρὸν τὸ σὸν σήκωμα προστίθης φίλοις.</l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-   <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="691">μή τοί μʼ ἔρυκε δρᾶν παρεσκευασμένον. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="692">δρᾶν μὲν σύ γʼ οὐχ οἷός τε, βούλεσθαι δʼ ἴσως. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="693">ὡς μὴ μενοῦντα τἄλλα σοι λέγειν πάρα. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="694">πῶς οὖν ὁπλίταις τευχέων ἄτερ φανῇ; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="695">ἔστʼ ἐν δόμοισιν ἔνδον αἰχμάλωθʼ ὅπλα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="696">τοῖς δʼ οὖσι χρησόμεσθα· κἀποδώσομεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="697">ζῶντες, θανόντας δʼ οὐκ ἀπαιτήσει θεός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="698">ἀλλʼ εἴσιθʼ εἴσω κἀπὸ πασσάλων ἑλὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="699">ἔνεγχ’ ὁπλίτην κόσμον ὡς τάχιστά μοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="700">αἰσχρὸν γὰρ οἰκούρημα γίγνεται τόδε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="701">τοὺς μὲν μάχεσθαι, τοὺς δὲ δειλίᾳ μένειν. </l>
-</sp>
-
-<milestone n="702" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="anapests">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="702">λῆμα μὲν οὔπω στόρνυσι χρόνος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="703">τὸ σόν, ἀλλʼ ἡβᾷ, σῶμα δὲ φροῦδον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="704">τί πονεῖς ἄλλως ἃ σὲ μὲν βλάψει, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="705">σμικρὰ δʼ ὀνήσει πόλιν ἡμετέραν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="706">χρὴ γνωσιμαχεῖν τὴν ἡλικίαν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="707">τὰ δʼ ἀμήχανʼ ἐᾶν· οὐκ ἔστιν ὅπως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="708">ἥβην κτήσῃ πάλιν αὖθις. </l>
-</sp>
-
-<milestone n="709" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="709">τί χρῆμα μέλλεις σῶν φρενῶν οὐκ ἔνδον ὢν </l>
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="710">λιπεῖν μʼ ἔρημον σὺν τέκνοις ἐμοῖς; <gap reason="ellipsis" rend=" . . "/></l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="711">ἀνδρῶν γὰρ ἀλκή· σοὶ δὲ χρῆν τούτων μέλειν. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="712">τί δʼ; ἢν θάνῃς σύ, πῶς ἐγὼ σωθήσομαι; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="713">παιδὸς μελήσει παισὶ τοῖς λελειμμένοις. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="714">ἢν δʼ οὖν, ὃ μὴ γένοιτο, χρήσωνται τύχῃ; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="715">οἵδ’ οὐ προδώσουσίν σε, μὴ τρέσῃς, ξένοι. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-   <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="716">τοσόνδε γάρ τοι θάρσος, οὐδὲν ἄλλʼ ἔχω. </l>
- </sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="717">καὶ Ζηνὶ τῶν σῶν, οἶδʼ ἐγώ, μέλει πόνων. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="718">φεῦ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="718a">Ζεὺς ἐξ ἐμοῦ μὲν οὐκ ἀκούσεται κακῶς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="719">εἰ δʼ ἐστὶν ὅσιος αὐτὸς οἶδεν εἰς ἐμέ. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="720">ὅπλων μὲν ἤδη τήνδʼ ὁρᾷς παντευχίαν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="721">φθάνοις δʼ ἂν οὐκ ἂν τοῖσδε συγκρύπτων δέμας· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="722">ὡς ἐγγὺς ἁγών, καὶ μάλιστʼ Ἄρης στυγεῖ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="723">μέλλοντας· εἰ δὲ τευχέων φοβῇ βάρος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="724">νῦν μὲν πορεύου γυμνός, ἐν δὲ τάξεσιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="725">κόσμῳ πυκάζου τῷδʼ· ἐγὼ δʼ οἴσω τέως.</l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="726">καλῶς ἔλεξας· ἀλλʼ ἐμοὶ πρόχειρʼ ἔχων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="727">τεύχη κόμιζε, χειρὶ δʼ ἔνθες ὀξύην, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="728">λαιόν τʼ ἔπαιρε πῆχυν, εὐθύνων πόδα. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="729">ἦ παιδαγωγεῖν γὰρ τὸν ὁπλίτην χρεών; </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="730">ὄρνιθος οὕνεκʼ ἀσφαλῶς πορευτέον. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="731">εἴθʼ ἦσθα δυνατὸς δρᾶν ὅσον πρόθυμος εἶ. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="732">ἔπειγε· λειφθεὶς δεινὰ πείσομαι μάχης. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="733">σύ τοι βραδύνεις, οὐκ ἐγὼ δοκῶ τι δρᾶν. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="734">οὔκουν ὁρᾷς μου κῶλον ὡς ἐπείγεται; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="735">ὁρῶ δοκοῦντα μᾶλλον ἢ σπεύδοντά σε. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="736">οὐ ταῦτα λέξεις, ἡνίκʼ ἂν λεύσσῃς μʼ ἐκεῖ. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="737">τί δρῶντα; βουλοίμην δʼ ἂν εὐτυχοῦντά γε. </l>
-  </sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="738">διʼ ἀσπίδος θείνοντα πολεμίων τινά. </l>  
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="739">εἰ δή ποθʼ ἥξομέν γε· τοῦτο γὰρ φόβος. </l>
-</sp>
-
-<sp><speaker>Ἰόλαος</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="740">φεῦ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="740a">εἴθʼ, ὦ βραχίων, οἷον ἡβήσαντά σε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="741">μεμνήμεθʼ ἡμεῖς, ἡνίκα ξὺν Ἡρακλεῖ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="742">Σπάρτην ἐπόρθεις, σύμμαχος γένοιό μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="743">τοιοῦτος· οἵαν ἂν τροπὴν Εὐρυσθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="744">θείμην· ἐπεί τοι καὶ κακὸς μένειν δόρυ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="745">ἔστιν δʼ ἐν ὄλβῳ καὶ τόδʼ οὐκ ὀρθῶς ἔχον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="746">εὐψυχίας δόκησις· οἰόμεσθα γὰρ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="747">τὸν εὐτυχοῦντα πάντʼ ἐπίστασθαι καλῶς. </l>
-</sp></div></div>
-
-<milestone n="748" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="choral">
-<div type="textpart" subtype="strophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="748">Γᾶ καὶ παννύχιος σελά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="749">να καὶ λαμπρόταται θεοῦ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="750">φαεσίμβροτοι αὐγαί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="751">ἀγγελίαν μοι ἐνέγκαιτʼ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="752">ἰαχήσατε δʼ οὐρανῷ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="753">καὶ παρὰ θρόνον ἀρχέταν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="754">γλαυκᾶς ἐν Ἀθάνας. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="755">μέλλω τᾶς πατριώτιδος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="756">γᾶς, μέλλω καὶ ὑπὲρ δόμων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="757">ἱκέτας ὑποδεχθεὶς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="758">κίνδυνον πολιῷ τεμεῖν σιδάρῳ. </l>
-</sp></div>
-
-<milestone n="759" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="759">δεινὸν μὲν πόλιν ὡς Μυκή- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="760">νας εὐδαίμονα καὶ δορὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="761">πολυαίνετον ἀλκᾷ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="762">μῆνιν ἐμᾷ χθονὶ κεύθειν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="763">κακὸν δʼ, ὦ πόλις, εἰ ξένους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="764">ἱκτῆρας παραδώσομεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="765">κελεύμασιν Ἄργους. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="766">Ζεύς μοι σύμμαχος, οὐ φοβοῦ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="767">μαι, Ζεύς μοι χάριν ἐνδίκως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="768">ἔχει· οὔποτε θνατῶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="769">ἥσσους <add>δαίμονες</add> ἔκ γʼ ἐμοῦ φανοῦνται. </l>
-</sp></div>
-
-<milestone n="770" unit="card" resp="perseus"/>
-    
-<div type="textpart" subtype="strophe" n="2">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="770">ἀλλʼ, ὦ πότνια — σὸν γὰρ οὖ-</l> 
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="771">δας <del>γᾶς</del>, σὸν καὶ πόλις, ἇς σὺ μά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="772">τηρ δέσποινά τε καὶ φύλαξ — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="773">πόρευσον ἄλλᾳ τὸν οὐ δικαίως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="774">τᾷδʼ ἐπάγοντα δορυσσοῦν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="775">στρατὸν Ἀργόθεν· οὐ γὰρ ἐμᾷ γʼ ἀρετᾷ </l>
-     <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="776">δίκαιός εἰμʼ ἐκπεσεῖν μελάθρων. </l>
-</sp></div>
-
-<milestone n="777" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="2">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="777">ἐπεί σοι πολύθυτος ἀεὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="778">τιμὰ κραίνεται, οὐδὲ λά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="779">θει μηνῶν φθινὰς ἁμέρα, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="780">νέων τʼ ἀοιδαὶ χορῶν τε μολπαί. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="781">ἀνεμόεντι δʼ ἐπʼ ὄχθῳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="782">ὀλολύγματα παννυχίοις ὑπὸ παρ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="783">θένων ἰαχεῖ ποδῶν κρότοισιν. </l>
-</sp></div></div>
-
-<milestone n="784" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="episode">
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="784">δέσποινα, μύθους σοί τε συντομωτάτους </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="785"><sic>κλύειν ἐμοί τε τῷδε καλλίστους φέρω.</sic> </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="786">νικῶμεν ἐχθροὺς καὶ τροπαῖʼ ἱδρύεται </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="787">παντευχίαν ἔχοντα πολεμίων σέθεν. </l> 
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="788">ὦ φίλταθʼ, ἥδε σʼ ἡμέρα διήλασεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="789">ἐλευθερῶσαι τοῖσδε τοῖς ἀγγέλμασιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="790">μιᾶς δʼ ἔμʼ οὔπω συμφορᾶς ἐλευθεροῖς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="791">φόβος γὰρ εἴ μοι ζῶσιν οὓς ἐγὼ θέλω. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="792">ζῶσιν μέγιστόν γʼ εὐκλεεῖς κατὰ στρατόν. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="793">ὁ μὲν γέρων οὐκ ἔστιν Ἰόλεως ὅδε; </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="794">μάλιστα, πράξας δʼ ἐκ θεῶν κάλλιστα δή. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="795">τί δʼ ἔστι; μῶν τι κεδνὸν ἠγωνίζετο; </l></sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="796">νέος μεθέστηκʼ ἐκ γέροντος αὖθις αὖ. </l>  
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="797">θαυμάστʼ ἔλεξας· ἀλλά σʼ εὐτυχῆ φίλων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="798">μάχης ἀγῶνα πρῶτον ἀγγεῖλαι θέλω. </l></sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="799">εἷς μου λόγος σοι πάντα σημανεῖ τάδε. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="800">ἐπεὶ γὰρ ἀλλήλοισιν ὁπλίτην στρατὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="801">κατὰ στόμʼ ἐκτείνοντες ἀντετάξαμεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="802">ἐκβὰς τεθρίππων Ὕλλος ἁρμάτων πόδα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="803">ἔστη μέσοισιν ἐν μεταιχμίοις δορός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="804">κἄπειτ’ ἔλεξεν· Ὦ στρατήγʼ ὃς Ἀργόθεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805">ἥκεις, τί τήνδε γαῖαν οὐκ εἰάσαμεν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805a"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805b"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="806">καὶ τὰς Μυκήνας οὐδὲν ἐργάσῃ κακὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="807">ἀνδρὸς στερήσας· ἀλλʼ ἐμοὶ μόνος μόνῳ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="808">μάχην συνάψας, ἢ κτανὼν ἄγου λαβὼν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="809">τοὺς Ἡρακλείους παῖδας ἢ θανὼν ἐμοὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="810">τιμὰς πατρῴους καὶ δόμους ἔχειν ἄφες. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="811">στρατὸς δʼ ἐπῄνεσ’, ἔς τʼ ἀπαλλαγὰς πόνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="812">καλῶς λελέχθαι μῦθον ἔς τʼ εὐψυχίαν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="813">ὃ δʼ οὔτε τοὺς κλύοντας αἰδεσθεὶς λόγων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="814">οὔτʼ αὐτὸς αὑτοῦ δειλίαν στρατηγὸς ὢν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="815">ἐλθεῖν ἐτόλμησʼ ἐγγὺς ἀλκίμου δορός, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="816">ἀλλʼ ἦν κάκιστος· εἶτα τοιοῦτος γεγὼς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="817">τοὺς Ἡρακλείους ἦλθε δουλώσων γόνους. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="818">Ὕλλος μὲν οὖν ἀπῴχετ’ ἐς τάξιν πάλιν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="819">μάντεις δʼ, ἐπειδὴ μονομάχου διʼ ἀσπίδος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="820">διαλλαγὰς ἔγνωσαν οὐ τελουμένας, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="821">ἔσφαζον, οὐκ ἔμελλον, ἀλλʼ ἀφίεσαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="822">λαιμῶν <sic>βροτείων</sic> εὐθὺς οὔριον φόνον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="823">οἳ δʼ ἅρματʼ εἰσέβαινον, οἳ δʼ ὑπʼ ἀσπίδων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="824">πλευροῖς ἔκρυπτον πλεύρʼ· Ἀθηναίων δʼ ἄναξ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="825">στρατῷ παρήγγελλ’ οἷα χρὴ τὸν εὐγενῆ· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="826">Ὦ ξυμπολῖται, τῇ τε βοσκούσῃ χθονὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="827">καὶ τῇ τεκούσῃ νῦν τινʼ ἀρκέσαι χρεών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="828">ὃ δʼ αὖ τό τʼ Ἄργος μὴ καταισχῦναι θέλειν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="829">καὶ τὰς Μυκήνας συμμάχους ἐλίσσετο. </l>
-<milestone n="830" unit="card" resp="perseus"/>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="830">ἐπεὶ δʼ ἐσήμηνʼ ὄρθιον Τυρσηνικῇ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="831">σάλπιγγι καὶ συνῆψαν ἀλλήλοις μάχην, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="832">πόσον τινʼ αὐχεῖς πάταγον ἀσπίδων βρέμειν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="833">πόσον τινὰ στεναγμὸν οἰμωγήν θʼ ὁμοῦ; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="834">τὰ πρῶτα μέν νυν πίτυλος Ἀργείου δορὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="835">ἐρρήξαθʼ ἡμᾶς· εἶτʼ ἐχώρησαν πάλιν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="836">τὸ δεύτερον δὲ ποὺς ἐπαλλαχθεὶς ποδί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="837">ἀνὴρ δʼ ἐπʼ ἀνδρὶ στάς, ἐκαρτέρει μάχη· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="838">πολλοὶ δʼ ἔπιπτον. ἦν δὲ τοῦ κελεύματος· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="839">Ὦ τὰς Ἀθήνας — Ὦ τὸν Ἀργείων γύην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="840">σπείροντες — οὐκ ἀρήξετʼ αἰσχύνην πόλει; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="841">μόλις δὲ πάντα δρῶντες οὐκ ἄτερ πόνων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="842">ἐτρεψάμεσθʼ Ἀργεῖον ἐς φυγὴν δόρυ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="843" rend="indent">κἀνταῦθʼ ὁ πρέσβυς Ὕλλον ἐξορμώμενον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="844">ἰδών, ὀρέξας ἱκέτευσε δεξιὰν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="845">Ἰόλαος ἐμβῆσαί νιν ἵππειον δίφρον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="846">λαβὼν δὲ χερσὶν ἡνίας Εὐρυσθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="847">πώλοις ἐπεῖχε. τἀπὸ τοῦδʼ ἤδη κλύων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="848">λέγοιμʼ ἂν ἄλλων, δεῦρο δʼ αὐτὸς εἰσιδών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="849">Παλληνίδος γὰρ σεμνὸν ἐκπερῶν πάγον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="850">δίας Ἀθάνας, ἅρμʼ ἰδὼν Εὐρυσθέως, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="851">ἠράσαθʼ Ἥβῃ Ζηνί θʼ, ἡμέραν μίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="852">νέος γενέσθαι κἀποτείσασθαι δίκην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="853">ἐχθρούς. κλύειν δὴ θαύματος πάρεστί σοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="854">δισσὼ γὰρ ἀστέρʼ ἱππικοῖς ἐπὶ ζυγοῖς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="855">σταθέντʼ ἔκρυψαν ἅρμα λυγαίῳ νέφει· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="856">σὸν δὴ λέγουσι παῖδά γʼ οἱ σοφώτεροι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="857">Ἥβην θʼ· ὃ δʼ ὄρφνης ἐκ δυσαιθρίου νέων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="858">βραχιόνων ἔδειξεν ἡβητὴν τύπον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="859">αἱρεῖ δʼ ὁ κλεινὸς  Ἰόλεως Εὐρυσθέως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="860">τέτρωρον ἅρμα πρὸς πέτραις Σκιρωνίσιν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="861">δεσμοῖς τε δήσας χεῖρας ἀκροθίνιον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="862">κάλλιστον ἥκει τὸν στρατηλάτην ἄγων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="863">τὸν ὄλβιον πάροιθε. τῇ δὲ νῦν τύχῃ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="864">βροτοῖς ἅπασι λαμπρὰ κηρύσσει μαθεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="865">τὸν εὐτυχεῖν δοκοῦντα μὴ ζηλοῦν, πρὶν ἂν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="866">θανόντʼ ἴδῃ τις· ὡς ἐφήμεροι τύχαι. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="867">ὦ Ζεῦ τροπαῖε, νῦν ἐμοὶ δεινοῦ φόβου </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="868">ἐλεύθερον πάρεστιν ἦμαρ εἰσιδεῖν. </l>
-</sp>
-
-<milestone n="869" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="869">ὦ Ζεῦ, χρόνῳ μὲν τἄμ’ ἐπεσκέψω κακά, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="870">χάριν δʼ ὅμως σοι τῶν πεπραγμένων ἔχω· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="871">καὶ παῖδα τὸν ἐμὸν πρόσθεν οὐ δοκοῦσʼ ἐγὼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="872">θεοῖς ὁμιλεῖν νῦν ἐπίσταμαι σαφῶς. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="873" rend="indent">ὦ τέκνα, νῦν δὴ νῦν ἐλεύθεροι πόνων, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="874">ἐλεύθεροι δὲ τοῦ κακῶς ὀλουμένου </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="875">Εὐρυσθέως ἔσεσθε καὶ πόλιν πατρὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="876">ὄψεσθε, κλήρους δʼ ἐμβατεύσετε χθονὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="877">καὶ θεοῖς πατρῴοις θύσεθʼ, ὧν ἀπειργμένοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="878">ξένοι πλανήτην εἴχετʼ ἄθλιον βίον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="879" rend="indent">ἀτὰρ τί κεύθων Ἰόλεως σοφόν ποτε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="880">Εὐρυσθέως ἐφείσαθʼ ὥστε μὴ κτανεῖν; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="881">λέξον· παρʼ ἡμῖν μὲν γὰρ οὐ σοφὸν τόδε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="882">ἐχθροὺς λαβόντα μὴ ἀποτείσασθαι δίκην. </l>
-</sp>
-
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="883">τὸ σὸν προτιμῶν, ὥς νιν ὀφθαλμοῖς ἴδοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="884"><sic>κρατοῦντα</sic> καὶ σῇ δεσποτούμενον χερί. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="885">οὐ μὴν ἑκόντα γʼ αὐτόν, ἀλλὰ πρὸς βίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="886">ἔζευξʼ ἀνάγκῃ· καὶ γὰρ οὐκ ἐβούλετο </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="887">ζῶν ἐς σὸν ἐλθεῖν ὄμμα καὶ δοῦναι δίκην. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="888">ἀλλʼ, ὦ γεραιά, χαῖρε καὶ μέμνησό μοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="889">ὃ πρῶτον εἶπας, ἡνίκʼ ἠρχόμην λόγου, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="890">ἐλευθερώσειν μʼ· ἐν δὲ τοῖς τοιοῖσδε χρὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="891">ἀψευδὲς εἶναι τοῖσι γενναίοις στόμα. </l>
-</sp></div>
-
-<milestone n="892" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="choral">
-<div type="textpart" subtype="strophe" n="1">
-    <sp><speaker>Χορός</speaker>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="892">Ἐμοὶ χορὸς μὲν ἡδύς, εἰ λίγεια λω- </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="893">τοῦ χάρις <sic>ενι δαι</sic>· </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="894">εἴη δʼ εὔχαρις Ἀφροδί- </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="895">τα· τερπνὸν δέ τι καὶ φίλων ἆρʼ </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="896">εὐτυχίαν ἰδέσθαι </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="897">τῶν πάρος οὐ δοκούντων. </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="898">πολλὰ γὰρ </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="899">τίκτει Μοῖρα τελεσσιδώ- </l>
-        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="900">τειρʼ Αἰών τε Χρόνου παῖς.</l></sp></div>
-
-<milestone n="901" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="1">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="901">ἔχεις ὁδόν τινʼ, ὦ πόλις, δίκαιον — οὐ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="902">χρή ποτε τοῦδʼ ἀφέσθαι, — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="903">τιμᾶν θεούς· ὁ <add>δὲ</add> μή σε φά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="904">σκων ἐγγὺς μανιῶν ἐλαύνει, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="905">δεικνυμένων ἐλέγχων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="906">τῶνδʼ· ἐπίσημα γάρ τοι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="907">θεὸς παραγ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="908">γέλλει, τῶν ἀδίκων παραι- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="909">ρῶν φρονήματος αἰεί. </l>
-</sp></div>
-
-<milestone n="910" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="strophe" n="2">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="910">ἔστιν ἐν οὐρανῷ βεβα- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="911">κὼς τεὸς γόνος, ὦ γεραι- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="912">ά· φεύγει λόγον ὡς τὸν Ἅι- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="913">δα δόμον κατέβα, πυρὸς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="914">δεινᾷ φλογὶ σῶμα δαισθείς· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="915">Ἥβας τʼ ἐρατὸν χροΐζει </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="916">λέχος χρυσέαν κατʼ αὐλάν. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="917">ὦ Ὑμέναιε, δισσοὺς παῖ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="918">δας Διὸς ἠξίωσας. </l></sp></div>
-
-<milestone n="919" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="antistrophe" n="2">
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="919">συμφέρεται τὰ πολλὰ πολ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="920">λοῖς· καὶ γὰρ πατρὶ τῶνδʼ Ἀθά- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="921">ναν λέγουσʼ ἐπίκουρον εἶ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="922">ναι, καὶ τούσδε θεᾶς πόλις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="923">καὶ λαὸς ἔσωσε κείνας· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="924">ἔσχεν δʼ ὕβριν ἀνδρὸς ᾧ θυ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="925">μὸς ἦν πρὸ δίκας βίαιος. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="926">μήποτʼ ἐμοὶ φρόνημα ψυ- </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="927">χά τʼ ἀκόρεστος εἴη. </l>
-</sp></div></div>
-
-<milestone n="928" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="episode">
-<sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="928">δέσποινʼ, ὁρᾷς μέν, ἀλλʼ ὅμως εἰρήσεται, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="929">Εὐρυσθέα σοι τόνδʼ ἄγοντες ἥκομεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="930">ἄελπτον ὄψιν, τῷδέ τʼ οὐχ ἧσσον τύχην· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="931">οὐ γάρ ποτʼ ηὔχει χεῖρας ἵξεσθαι σέθεν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="932">ὅτʼ ἐκ Μυκηνῶν πολυπόνῳ σὺν ἀσπίδι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="933">ἔστειχε μείζω τῆς δίκης φρονῶν, πόλιν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="934">πέρσων Ἀθηνᾶς. ἀλλὰ τὴν ἐναντίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="935">δαίμων ἔθηκε, καὶ μετέστησεν τύχην. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="936">Ὕλλος μὲν οὖν ὅ τʼ ἐσθλὸς Ἰόλεως βρέτας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="937">Διὸς τροπαίου καλλίνικον ἵστασαν· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="938">ἐμοὶ δὲ πρὸς σὲ τόνδʼ ἐπιστέλλουσʼ ἄγειν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="939">τέρψαι θέλοντες σὴν φρένʼ· ἐκ γὰρ εὐτυχοῦς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="940">ἥδιστον ἐχθρὸν ἄνδρα δυστυχοῦνθʼ ὁρᾶν.</l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="941">ὦ μῖσος, ἥκεις; εἷλέ σʼ ἡ Δίκη χρόνῳ; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="942">πρῶτον μὲν οὖν μοι δεῦρʼ ἐπίστρεψον κάρα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="943">καὶ τλῆθι τοὺς σοὺς προσβλέπειν ἐναντίον </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="944">ἐχθρούς· κρατῇ γὰρ νῦν γε κοὐ κρατεῖς ἔτι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="945">ἐκεῖνος εἶ σύ — βούλομαι γὰρ εἰδέναι — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="946">ὃς πολλὰ μὲν τὸν ὄνθʼ ὅπου ’στὶ νῦν ἐμὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="947">παῖδʼ ἠξίωσας, ὦ πανοῦργʼ, ἐφυβρίσαι; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="948">τί γὰρ σὺ κεῖνον οὐκ ἔτλης καθυβρίσαι; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="949">ὃς καὶ παρʼ Ἅιδην ζῶντά νιν κατήγαγες, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="950">ὕδρας λέοντάς τʼ ἐξαπολλύναι λέγων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="951">ἔπεμπες. ἄλλα δʼ οἷ’ ἐμηχανῶ κακὰ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="952">σιγῶ· μακρὸς γὰρ μῦθος ἂν γένοιτό μοι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="953">κοὐκ ἤρκεσέν σοι ταῦτα τολμῆσαι μόνον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="954">ἀλλʼ ἐξ ἁπάσης κἀμὲ καὶ τέκνʼ Ἑλλάδος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="955">ἤλαυνες ἱκέτας δαιμόνων καθημένους, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="956">τοὺς μὲν γέροντας, τοὺς δὲ νηπίους ἔτι. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="957">ἀλλʼ ηὗρες ἄνδρας καὶ πόλισμʼ ἐλεύθερον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="958">οἵ σʼ οὐκ ἔδεισαν. δεῖ σε κατθανεῖν κακῶς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="959">καὶ κερδανεῖς ἅπαντα· χρῆν γὰρ οὐχ ἅπαξ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="960">θνῄσκειν σὲ πολλὰ πήματʼ ἐξειργασμένον. </l>
-</sp>
-
-    <sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="961">οὐκ ἔστʼ ἀνυστὸν τόνδε σοι κατακτανεῖν. </l>
-    </sp>
-
-    <sp><speaker>Θεράπων</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="962">ἄλλως ἄρʼ αὐτὸν αἰχμάλωτον εἵλομεν; </l>
-    </sp>
-
-    <sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="963">εἴργει δὲ δὴ τίς τόνδε μὴ θνῄσκειν νόμος; </l>
-    </sp>
-
-    <sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="964">τοῖς τῆσδε χώρας προστάταισιν οὐ δοκεῖ. </l>
-    </sp>
-
-    <sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="965">τί δὴ τόδʼ; ἐχθροὺς τοισίδʼ οὐ καλὸν κτανεῖν;</l></sp>
-
-    <sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="966">οὐχ ὅντινʼ ἄν γε ζῶνθʼ ἕλωσιν ἐν μάχῃ. </l> 
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="967">καὶ ταῦτα δόξανθʼ  Ὕλλος ἐξηνέσχετο; </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="968">χρῆν δʼ αὐτόν, οἶμαι, τῇδʼ ἀπιστῆσαι χθονί; </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="969">χρῆν τόνδε μὴ ζῆν μηδʼ ὁρᾶν <sic>φάος ἔτι.</sic> </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="970">τότʼ ἠδικήθη πρῶτον οὐ θανὼν ὅδε. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="971">οὐκ οὖν ἔτʼ ἐστὶν ἐν καλῷ δοῦναι δίκην; </l>
-</sp>
-    
- <sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="972">οὐκ ἔστι τοῦτον ὅστις ἂν κατακτάνοι. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="973">ἔγωγε· καίτοι φημὶ κἄμʼ εἶναί τινα. </l>
- </sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="974">πολλὴν ἄρʼ ἕξεις μέμψιν, εἰ δράσεις τόδε. </l>
-</sp>
-
-<milestone n="975" unit="card" resp="perseus"/>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="975">φιλῶ πόλιν τήνδʼ· οὐδὲν ἀντιλεκτέον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="976">τοῦτον δʼ, ἐπείπερ χεῖρας ἦλθεν εἰς ἐμάς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="977">οὐκ ἔστι θνητῶν ὅστις ἐξαιρήσεται. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="978">πρὸς ταῦτα τὴν θρασεῖαν ὅστις ἂν θέλῃ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="979">καὶ τὴν φρονοῦσαν μεῖζον ἢ γυναῖκα χρὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="980">λέξει· τὸ δʼ ἔργον τοῦτʼ ἐμοὶ πεπράξεται. </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="981">δεινόν τι καὶ συγγνωστόν, ὦ γύναι, σʼ ἔχει </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="982">νεῖκος πρὸς ἄνδρα τόνδε, γιγνώσκω καλῶς. </l>
-</sp>
-
-<sp><speaker>Ἐυρυσθεύς</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="983">γύναι, σάφʼ ἴσθι μή με θωπεύσοντά σε, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="984">μηδʼ ἄλλο μηδὲν τῆς ἐμῆς  ψυχῆς πέρι </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="985">λέξονθʼ ὅθεν χρὴ δειλίαν ὀφλεῖν τινα. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="986">ἐγὼ δὲ νεῖκος οὐχ ἑκὼν τόδʼ ἠράμην· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="987">ᾔδη γε σοὶ μὲν αὐτανέψιος γεγώς, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="988">τῷ σῷ δὲ παιδὶ συγγενὴς Ἡρακλέει. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="989">ἀλλʼ εἴτʼ ἔχρῃζον εἴτε μή — θεὸς γὰρ ἦν — </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="990">Ἥρα με κάμνειν τήνδʼ ἔθηκε τὴν νόσον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="991">ἐπεὶ δʼ ἐκείνῳ δυσμένειαν ἠράμην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="992">κἄγνων ἀγῶνα τόνδʼ ἀγωνιούμενος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="993">πολλῶν σοφιστὴς πημάτων ἐγιγνόμην </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="994">καὶ πόλλʼ ἔτικτον νυκτὶ συνθακῶν ἀεί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="995">ὅπως διώσας καὶ κατακτείνας ἐμοὺς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="996">ἐχθροὺς τὸ λοιπὸν μὴ συνοικοίην φόβῳ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="997">εἰδὼς μὲν οὐκ ἀριθμὸν ἀλλʼ ἐτητύμως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="998">ἄνδρʼ ὄντα τὸν σὸν παῖδα· καὶ γὰρ ἐχθρὸς ὢν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="999">ἀκούσεται <add>’μοί</add> γʼ ἐσθλὰ χρηστὸς ὢν ἀνήρ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1000">κείνου δʼ ἀπαλλαχθέντος οὐκ ἐχρῆν μʼ ἄρα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1001">μισούμενον πρὸς τῶνδε καὶ ξυνειδότα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1002">ἔχθραν πατρῴαν, πάντα κινῆσαι πέτρον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1003">κτείνοντα κἀκβάλλοντα καὶ τεχνώμενον; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1004">τοιαῦτα δρῶντι τἄμʼ ἐγίγνετʼ ἀσφαλῆ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1005">οὔκουν σύ γʼ ἀναλαβοῦσα τὰς ἐμὰς τύχας </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1006">ἐχθροῦ λέοντος δυσγενῆ βλαστήματα </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1007">ἤλαυνες ἂν κακοῖσιν, ἀλλὰ σωφρόνως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1008">εἴασας οἰκεῖν Ἄργος;  οὔτινʼ ἂν πίθοις. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1009">νῦν οὖν ἐπειδή μʼ οὐ διώλεσαν τότε </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1010">πρόθυμον ὄντα, τοῖσιν Ἑλλήνων νόμοις </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1011">οὐχ ἁγνός εἰμι τῷ κτανόντι κατθανών· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1012">πόλις τʼ ἀφῆκε σωφρονοῦσα, τὸν θεὸν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1013">μεῖζον τίουσα τῆς ἐμῆς ἔχθρας πολύ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1014">προσεῖπας, ἀντήκουσας· ἐντεῦθεν δὲ χρὴ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1015">τὸν προστρόπαιον τόν τε γενναῖον καλεῖν.</l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1016">οὕτω γε μέντοι τἄμ’ ἔχεις· θανεῖν μὲν οὐ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017">χρῄζω, λιπὼν δʼ ἂν οὐδὲν ἀχθοίμην βίον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017a"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017b"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017c"><gap reason="lost" rend=" . . . . . . "/></l></sp>
-
-<milestone n="1018" unit="card" resp="perseus"/>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1018">παραινέσαι σοι σμικρόν, Ἀλκμήνη, θέλω, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1019">τὸν ἄνδρʼ ἀφεῖναι τόνδʼ, ἐπεὶ δοκεῖ πόλει. </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1020">τί δʼ, ἢν θάνῃ τε καὶ πόλει πιθώμεθα; </l>
-</sp>
-
-<sp><speaker>Χορός</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1021">τὰ λῷστ’ ἂν εἴη· πῶς τάδʼ οὖν γενήσεται; </l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1022">ἐγὼ διδάξω ῥᾳδίως· κτανοῦσα γὰρ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1023">τόνδʼ εἶτα νεκρὸν τοῖς μετελθοῦσιν φίλων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1024">δώσω· τὸ γὰρ σῶμʼ οὐκ ἀπιστήσω χθονί, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1025">οὗτος δὲ δώσει τὴν δίκην θανὼν ἐμοί. </l>
-</sp>
-
-<sp><speaker>Ἐυρυσθεύς</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1026">κτεῖνʼ, οὐ παραιτοῦμαί σε· τήνδε δὲ πτόλιν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1027">ἐπεί μʼ ἀφῆκε καὶ κατῃδέσθη κτανεῖν, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1028">χρησμῷ παλαιῷ Λοξίου δωρήσομαι, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1029">ὃς ὠφελήσει μείζονʼ ἢ δοκεῖν χρόνῳ. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1030">θανόντα γάρ με θάψεθʼ οὗ τὸ μόρσιμον, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1031">δίας πάροιθε παρθένου Παλληνίδος· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1032">καὶ σοὶ μὲν εὔνους καὶ πόλει σωτήριος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1033">μέτοικος αἰεὶ κείσομαι κατὰ χθονός, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1034">τοῖς τῶνδε δʼ ἐκγόνοισι πολεμιώτατος, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1035">ὅταν μόλωσι δεῦρο σὺν πολλῇ χερὶ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1036">χάριν προδόντες τήνδε. τοιούτων ξένων </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1037">προύστητε. πῶς οὖν ταῦτʼ ἐγὼ πεπυσμένος </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1038">δεῦρʼ ἦλθον, ἀλλʼ οὐ χρησμὸν ἠρόμην θεοῦ; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1039">Ἥραν νομίζων θεσφάτων κρείσσω πολὺ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1040">κοὐκ ἂν προδοῦναί μʼ. ἀλλὰ μήτε μοι χοὰς </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1041">μήθʼ αἷμʼ ἐάσῃς εἰς ἐμὸν στάξαι τόπον. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1042">κακὸν γὰρ αὐτοῖς νόστον ἀντὶ τῶνδʼ ἐγὼ </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1043">δώσω· διπλοῦν δὲ κέρδος ἕξετʼ ἐξ ἐμοῦ, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1044">ὑμᾶς τʼ ὀνήσω τούσδε τε βλάψω θανών.</l>
-</sp>
-
-<sp><speaker>Ἀλκμήνη</speaker>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1045">τί δῆτα μέλλετʼ, εἰ πόλει σωτηρίαν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1046">κατεργάσασθαι τοῖσί τʼ ἐξ ἡμῶν χρεών, </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1047">κτείνειν τὸν ἄνδρα τόνδʼ, ἀκούοντες τάδε; </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1048">δείκνυσι γὰρ κέλευθον ἀσφαλεστάτην· </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1049">ἐχθρὸς μὲν ἁνήρ, ὠφελεῖ δὲ κατθανών. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1050">κομίζετʼ αὐτόν, δμῶες· εἶτα χρὴ κυσὶν </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1051">δοῦναι κτανόντας· μὴ γὰρ ἐλπίσῃς ὅπως </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052">αὖθις πατρῴας ζῶν ἔμʼ ἐκβαλεῖς χθονός. </l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052a"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052b"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052c"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052d"><gap reason="lost" rend=" . . . . . . "/></l>
-    <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052e"><gap reason="lost" rend=" . . . . . . "/></l>
-</sp>
-
-<milestone n="1053" unit="card" resp="perseus"/>
-
-<div type="textpart" subtype="anapests">
-    <sp><speaker>Ἡμιχόριον</speaker>
-      <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1053">ταὐτὰ δοκεῖ μοι. στείχετʼ, ὀπαδοί. </l>
-      <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1054">τὰ γὰρ ἐξ ἡμῶν </l>
-      <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1055">καθαρῶς ἔσται βασιλεῦσιν. </l></sp>
-</div>
-</div>
-</div>
-</body>
-</text>
+                <milestone n="1" unit="card" resp="perseus"/>
+
+                <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" resp="perseus"
+                    style="hidden" n="0"/>
+
+                <div type="textpart" subtype="episode">
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1">Πάλαι ποτʼ
+                            ἐστὶ τοῦτʼ ἐμοὶ δεδογμένον· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="2">ὁ μὲν
+                            δίκαιος τοῖς πέλας πέφυκʼ ἀνήρ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="3">ὃ δʼ ἐς τὸ
+                            κέρδος λῆμʼ ἔχων ἀνειμένον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="4">πόλει τʼ
+                            ἄχρηστος καὶ συναλλάσσειν βαρύς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="5">αὑτῷ δʼ
+                            ἄριστος· οἶδα δʼ οὐ λόγῳ μαθών. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="6"
+                            rend="indent">ἐγὼ γὰρ αἰδοῖ καὶ τὸ συγγενὲς σέβων, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="7">ἐξὸν κατʼ
+                            Ἄργος ἡσύχως ναίειν, πόνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="8">πλείστων
+                            μετέσχον εἷς ἀνὴρ Ἡρακλέει, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="9">ὅτʼ ἦν μεθʼ
+                            ἡμῶν· νῦν δʼ, ἐπεὶ κατʼ οὐρανὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="10">ναίει, τὰ
+                            κείνου τέκνʼ ἔχων ὑπὸ πτεροῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="11">σῴζω τάδʼ
+                            αὐτὸς δεόμενος σωτηρίας. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="12">ἐπεὶ γὰρ
+                            αὐτῶν γῆς ἀπηλλάχθη πατήρ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="13">πρῶτον μὲν
+                            ἡμᾶς ἤθελʼ Εὐρυσθεὺς κτανεῖν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="14">ἀλλʼ
+                            ἐξέδραμεν· καὶ πόλις μὲν οἴχεται, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="15">ψυχὴ δʼ
+                            ἐσώθη. φεύγομεν δʼ ἀλώμενοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="16">ἄλλην ἀπʼ
+                            ἄλλης ἐξορίζοντες πόλιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="17">πρὸς τοῖς
+                            γὰρ ἄλλοις καὶ τόδʼ Εὐρυσθεὺς κακοῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="18">ὕβρισμʼ ἐς
+                            ἡμᾶς ἠξίωσεν ὑβρίσαι· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="19">πέμπων
+                            ὅπου γῆς πυνθάνοιθʼ ἱδρυμένους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="20">κήρυκας
+                            ἐξαιτεῖ τε κἀξείργει χθονός, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="21">πόλιν
+                            προτείνων Ἄργος οὐ σμικρὸν φίλην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="22">ἐχθράν τε
+                            θέσθαι, χαὑτὸν εὐτυχοῦνθʼ ἅμα.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="23">οἳ δʼ
+                            ἀσθενῆ μὲν τἀπ’ ἐμοῦ δεδορκότες, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="24">σμικροὺς
+                            δὲ τούσδε καὶ πατρὸς τητωμένους, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="25">τοὺς
+                            κρείσσονας σέβοντες ἐξείργουσι γῆς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="26">ἐγὼ δὲ σὺν
+                            φεύγουσι συμφεύγω τέκνοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="27">καὶ σὺν
+                            κακῶς πράσσουσι συμπράσσω κακῶς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="28">ὀκνῶν
+                            προδοῦναι, μή τις ὧδ’ εἴπῃ βροτῶν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="29">Ἴδεσθ’,
+                            ἐπειδὴ παισὶν οὐκ ἔστιν πατήρ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="30">Ἰόλαος οὐκ
+                            ἤμυνε συγγενὴς γεγώς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="31">πάσης δὲ
+                            χώρας Ἑλλάδος τητώμενοι, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="32">Μαραθῶνα
+                            καὶ σύγκληρον ἐλθόντες χθόνα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="33">ἱκέται
+                            καθεζόμεσθα βώμιοι θεῶν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="34"
+                            >προσωφελῆσαι· πεδία γὰρ τῆσδε χθονὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="35">δισσοὺς
+                            κατοικεῖν Θησέως παῖδας λόγος, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="36">κλήρῳ
+                            λαχόντας ἐκ γένους Πανδίονος, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="37">τοῖσδʼ
+                            ἐγγὺς ὄντας· ὧν ἕκατι τέρμονας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="38">κλεινῶν
+                            Ἀθηνῶν τόνδʼ ἀφικόμεσθʼ ὅρον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="39">δυοῖν
+                            γερόντοιν δὲ στρατηγεῖται φυγή· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="40">ἐγὼ μὲν
+                            ἀμφὶ τοῖσδε καλχαίνων τέκνοις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="41">ἣ δʼ αὖ τὸ
+                            θῆλυ παιδὸς Ἀλκμήνη γένος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="42">ἔσωθε ναοῦ
+                            τοῦδʼ ὑπηγκαλισμένη </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="43">σῴζει·
+                            νέας γὰρ παρθένους αἰδούμεθα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="44">ὄχλῳ
+                            πελάζειν κἀπιβωμιοστατεῖν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="45">Ὕλλος δʼ
+                            ἀδελφοί θʼ οἷσι πρεσβεύει γένος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="46">ζητοῦσʼ
+                            ὅπου γῆς πύργον οἰκιούμεθα, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="47">ἢν τῆσδʼ
+                            ἀπωθώμεσθα πρὸς βίαν χθονός. </l>
+                        <milestone n="48" unit="card" resp="perseus"/>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="48"
+                            rend="indent">ὦ τέκνα τέκνα, δεῦρο, λαμβάνεσθʼ ἐμῶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="49">πέπλων·
+                            ὁρῶ κήρυκα τόνδʼ Εὐρυσθέως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="50">στείχοντʼ
+                            ἐφʼ ἡμᾶς, οὗ διωκόμεσθʼ ὕπο </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="51">πάσης
+                            ἀλῆται γῆς ἀπεστερημένοι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="52">ὦ μῖσος,
+                            εἴθʼ ὄλοιο χὡ πέμψας <add>σ’</add> ἀνήρ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="53">ὡς πολλὰ
+                            δὴ καὶ τῶνδε γενναίῳ πατρὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="54">ἐκ τοῦδε
+                            ταὐτοῦ στόματος ἤγγειλας κακά. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="55">ἦ που
+                            καθῆσθαι τήνδʼ ἕδραν καλὴν δοκεῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="56">πόλιν τʼ
+                            ἀφῖχθαι σύμμαχον, κακῶς φρονῶν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="57">οὐ γάρ τις
+                            ἔστιν ὃς πάροιθʼ αἱρήσεται </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="58">τὴν σὴν
+                            ἀχρεῖον δύναμιν ἀντʼ Εὐρυσθέως.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="59">χώρει· τί
+                            μοχθεῖς ταῦτʼ; ἀνίστασθαί σε χρὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="60">ἐς Ἄργος,
+                            οὗ σε λεύσιμος μένει δίκη.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="61">οὐ δῆτʼ,
+                            ἐπεί μοι βωμὸς ἀρκέσει θεοῦ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="62">ἐλευθέρα
+                            τε γαῖʼ ἐν ᾗ βεβήκαμεν.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="63">βούλῃ
+                            πόνον μοι τῇδε προσθεῖναι χερί; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="64">οὔτοι βίᾳ
+                            γέ μʼ οὐδὲ τούσδʼ ἄξεις λαβών.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="65">γνώσῃ σύ·
+                            μάντις δʼ ἦσθʼ ἄρʼ οὐ καλὸς τάδε.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="66">οὐκ ἂν
+                            γένοιτο τοῦτʼ ἐμοῦ ζῶντός ποτε. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="67">ἄπαιρʼ·
+                            ἐγὼ δὲ τούσδε, κἂν σὺ μὴ θέλῃς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="68">ἄξω
+                            νομίζων, οὗπέρ εἰσʼ, Εὐρυσθέως. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="69">ὦ τὰς
+                            Ἀθήνας δαρὸν οἰκοῦντες χρόνον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="70">ἀμύνεθʼ·
+                            ἱκέται δʼ ὄντες ἀγοραίου Διὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="71">βιαζόμεσθα
+                            καὶ στέφη μιαίνεται — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="72">πόλει τʼ
+                            ὄνειδος καὶ θεῶν ἀτιμία. </l>
+                    </sp>
+                </div>
+
+                <milestone n="73" unit="card" resp="perseus"/>
+
+
+                <div type="textpart" subtype="choral">
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="73"> — ἔα ἔα·
+                            τίς ἡ βοὴ βωμοῦ πέλας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="74">ἕστηκε;
+                            ποίαν συμφορὰν δείξει τάχα; </l>
+                    </sp>
+
+                    <div type="textpart" subtype="strophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="75"> —
+                                ἴδετε τὸν γέροντʼ ἀμαλὸν ἐπὶ πέδῳ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="76"
+                                >χύμενον· ὦ τάλας.</l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="76a">
+                                <gap reason="lost" rend=" . . . . . . . . "/>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="77"> —
+                                πρὸς τοῦ ποτʼ ἐν γῇ πτῶμα δύστηνον πίτνεις; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="78">ὅδʼ, ὦ
+                                ξένοι, με σοὺς ἀτιμάζων θεοὺς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="79">ἕλκει
+                                βιαίως Ζηνὸς ἐκ προβωμίων. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="80">σὺ δʼ
+                                ἐκ τίνος γῆς, ὦ γέρον, τετράπτολιν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="81"
+                                >ξύνοικον ἦλθες λαόν; ἢ πέρα- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="82">θεν
+                                ἁλίῳ πλάτᾳ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="83"
+                                >κατέχετʼ ἐκλιπόντες Εὐβοῖδʼ ἀκτάν; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="84">οὐ
+                                νησιώτην, ὦ ξένοι, τρίβω βίον, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="85">ἀλλʼ
+                                ἐκ Μυκηνῶν σὴν ἀφίγμεθα χθόνα. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="86">ὄνομα
+                                τί σε, γέρον, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="87"
+                                >Μυκηναῖος ὠνόμαζεν λεώς; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="88">τὸν
+                                Ἡράκλειον ἴστε που παραστάτην </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="89"
+                                >Ἰόλαον· οὐ γὰρ σῶμʼ ἀκήρυκτον τόδε. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="90">οἶδʼ
+                                εἰσακούσας καὶ πρίν· ἀλλὰ τοῦ ποτὲ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="91">ἐν
+                                χερὶ σᾷ κομίζεις κόρους </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="92"
+                                >νεοτρεφεῖς; φράσον. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="93"
+                                >Ἡρακλέους οἵδʼ εἰσὶ παῖδες, ὦ ξένοι, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="94">ἱκέται
+                                σέθεν τε καὶ πόλεως ἀφιγμένοι. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="95" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="95">τί
+                                χρέος; ἢ λόγων πόλεος, ἔνεπέ μοι, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="96"
+                                >μελόμενοι τυχεῖν; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="97">μήτʼ
+                                ἐκδοθῆναι μήτε πρὸς βίαν θεῶν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="98">τῶν
+                                σῶν ἀποσπασθέντες εἰς Ἄργος μολεῖν. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Κῆρυξ</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="99">ἀλλʼ
+                                οὔτι τοῖς σοῖς δεσπόταις τάδʼ ἀρκέσει, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="100">οἳ
+                                σοῦ κρατοῦντες ἐνθάδʼ εὑρίσκουσί σε.</l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="101">εἰκὸς
+                                θεῶν ἱκτῆρας αἰδεῖσθαι, ξένε, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="102">καὶ
+                                μὴ βιαίῳ χερὶ δαιμόνων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="103"
+                                >ἀπολείπειν <del>σʼ</del> ἕδη· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="104"
+                                >πότνια γὰρ Δίκα τάδʼ οὐ πείσεται. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Κῆρυξ</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="105"
+                                >ἔκπεμπέ νυν γῆς τούσδε τοὺς Εὐρυσθέως, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="106"
+                                >κοὐδὲν βιαίῳ τῇδε χρήσομαι χερί. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="107">ἄθεον
+                                ἱκεσίαν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="108"
+                                >μεθεῖναι πόλει ξένων προστροπάν. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Κῆρυξ</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="109">καλὸν
+                                δέ γʼ ἔξω πραγμάτων ἔχειν πόδα, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="110"
+                                >εὐβουλίας τυχόντα τῆς ἀμείνονος. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="110a">
+                                <gap reason="lost" rend=" . . . . . . "/>
+                            </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="111" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="episode">
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="111">οὐκοῦν
+                            τυράννῳ τῆσδε γῆς φράσαντά σε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="112">χρῆν
+                            ταῦτα τολμᾶν, ἀλλὰ μὴ βίᾳ ξένους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="113">θεῶν
+                            ἀφέλκειν, γῆν σέβοντʼ ἐλευθέραν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="114">τίς δʼ
+                            ἐστὶ χώρας τῆσδε καὶ πόλεως ἄναξ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="115">ἐσθλοῦ
+                            πατρὸς παῖς Δημοφῶν ὁ Θησέως.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="116">πρὸς
+                            τοῦτον ἁγὼν ἆρα τοῦδε τοῦ λόγου </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="117">μάλιστʼ
+                            ἂν εἴη· τἄλλα δʼ εἴρηται μάτην. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="118">καὶ μὴν
+                            ὅδʼ αὐτὸς ἔρχεται σπουδὴν ἔχων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="119">Ἀκάμας τʼ
+                            ἀδελφός, τῶνδʼ ἐπήκοοι λόγων. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="120">ἐπείπερ
+                            ἔφθης πρέσβυς ὢν νεωτέρους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="121"
+                            >βοηδρομήσας τήνδʼ ἐπʼ ἐσχάραν Διός, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="122">λέξον,
+                            τίς ὄχλον τόνδʼ ἀθροίζεται τύχη; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="123">ἱκέται
+                            κάθηνται παῖδες οἵδʼ Ἡρακλέους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="124">βωμὸν
+                            καταστέψαντες, ὡς ὁρᾷς, ἄναξ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="125">πατρός τε
+                            πιστὸς Ἰόλεως παραστάτης. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="126">τί δῆτʼ
+                            ἰυγμῶν ἥδʼ ἐδεῖτο συμφορά; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="127">βίᾳ νιν
+                            οὗτος τῆσδʼ ἀπʼ ἐσχάρας ἄγειν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="128">ζητῶν
+                            βοὴν ἔστησε κἄσφηλεν γόνυ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="129">γέροντος,
+                            ὥστε μʼ ἐκβαλεῖν οἴκτῳ δάκρυ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="130">καὶ μὴν
+                            στολήν γʼ Ἕλληνα καὶ ῥυθμὸν πέπλων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="131">ἔχει, τὰ
+                            δʼ ἔργα βαρβάρου χερὸς τάδε. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="132">σὸν δὴ τὸ
+                            φράζειν ἐστί, μὴ μέλλειν τ’, ἐμοὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="133">ποίας
+                            ἀφῖξαι δεῦρο γῆς ὅρους λιπών; </l>
+                    </sp>
+
+                    <milestone n="134" unit="card" resp="perseus"/>
+
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="134">Ἀργεῖός
+                            εἰμι· τοῦτο γὰρ θέλεις μαθεῖν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="135">ἐφʼ οἷσι
+                            δʼ ἥκω καὶ παρʼ οὗ λέγειν θέλω.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="136">πέμπει
+                            Μυκηνῶν δεῦρό μʼ Εὐρυσθεὺς ἄναξ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="137">ἄξοντα
+                            τούσδε· πολλὰ δʼ ἦλθον, ὦ ξένε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="138">δίκαιʼ
+                            ὁμαρτῇ δρᾶν τε καὶ λέγειν ἔχων. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="139"
+                            rend="indent">Ἀργεῖος ὢν γὰρ αὐτὸς Ἀργείους ἄγω </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="140">ἐκ τῆς
+                            ἐμαυτοῦ τούσδε δραπέτας ἔχων, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="141">νόμοισι
+                            τοῖς ἐκεῖθεν ἐψηφισμένους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="142">θανεῖν·
+                            δίκαιοι δʼ ἐσμὲν οἰκοῦντες πόλιν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="143">αὐτοὶ
+                            καθʼ αὑτῶν κυρίους κραίνειν δίκας. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="144">πολλῶν δὲ
+                            κἄλλων ἑστίας ἀφιγμένοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="145">ἐν τοῖσιν
+                            αὐτοῖς τοισίδʼ ἕσταμεν λόγοις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="146">κοὐδεὶς
+                            ἐτόλμησʼ ἴδια προσθέσθαι κακά. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="147">ἀλλʼ ἤ
+                            τινʼ ἐς σὲ μωρίαν ἐσκεμμένοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="148">δεῦρʼ
+                            ἦλθον ἢ κίνδυνον ἐξ ἀμηχάνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="149"
+                            >ῥίπτοντες, εἴτʼ οὖν εἴτε μὴ γενήσεται· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="150">οὐ γὰρ
+                            φρενήρη γʼ ὄντα σʼ ἐλπίζουσί που </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="151">μόνον
+                            τοσαύτης ἣν ἐπῆλθον Ἑλλάδος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="152">τὰς τῶνδʼ
+                            ἀβούλους συμφορὰς κατοικτιεῖν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="153"
+                            rend="indent">φέρʼ ἀντίθες γάρ· τούσδε τʼ ἐς γαῖαν παρεὶς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="154">ἡμᾶς τʼ
+                            ἐάσας ἐξάγειν, τί κερδανεῖς; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="155">τὰ μὲν
+                            παρʼ ἡμῶν τοιάδʼ ἔστι σοι λαβεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="156">Ἄργους
+                            τοσήνδε χεῖρα τήν τʼ Εὐρυσθέως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="157">ἰσχὺν
+                            ἅπασαν τῇδε προσθέσθαι πόλει. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="158">ἢν δʼ ἐς
+                            λόγους τε καὶ τὰ τῶνδʼ οἰκτίσματα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="159">βλέψας
+                            πεπανθῇς, ἐς πάλην καθίσταται </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="160">δορὸς τὸ
+                            πρᾶγμα· μὴ γὰρ ὡς μεθήσομεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="161">δόξῃς
+                            ἀγῶνα τόνδʼ ἄτερ χαλυβδικοῦ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="162">τί δῆτα
+                            φήσεις, ποῖα πεδίʼ ἀφαιρεθείς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="163">τί
+                            ῥυσιασθείς, πόλεμον Ἀργείοις ἔχειν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="164">ποίοις δʼ
+                            ἀμύνων συμμάχοις, τίνος δʼ ὕπερ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="165">θάψεις
+                            νεκροὺς πεσόντας; ἦ κακὸν λόγον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="166">κτήσῃ
+                            πρὸς ἀστῶν, εἰ γέροντος οὕνεκα, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="167">τύμβου,
+                            τὸ μηδὲν ὄντος, ὡς εἰπεῖν ἔπος, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="168">παίδων
+                                <add>τε</add> τῶνδʼ, ἐς ἄντλον ἐμβήσῃ πόδα. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="169"
+                            rend="indent">ἐρεῖς τὸ λῷστον ἐλπίδʼ εὑρήσειν μόνον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="170">καὶ τοῦτο
+                            πολλῷ τοῦ παρόντος ἐνδεές· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="171">κακῶς γὰρ
+                            Ἀργείοισιν οἵδ’ ὡπλισμένοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="172">μάχοιντʼ
+                            ἂν ἡβήσαντες, εἴ <add>τι</add> τοῦτό σε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="173">ψυχὴν
+                            ἐπαίρει· χοὑν μέσῳ πολὺς χρόνος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="174">ἐν ᾧ
+                            διεργασθεῖτʼ ἄν. ἀλλʼ ἐμοὶ πιθοῦ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="175">δοὺς
+                            μηδέν, ἀλλὰ τἄμ’ ἐῶν ἄγειν ἐμὲ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="176">κτῆσαι
+                            Μυκήνας, μηδʼ ὅπερ φιλεῖτε δρᾶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="177">πάθῃς σὺ
+                            τοῦτο, τοὺς ἀμείνονας παρὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="178">φίλους
+                            ἑλέσθαι, τοὺς κακίονας λάβῃς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="179">τίς ἂν
+                            δίκην κρίνειεν ἢ γνοίη λόγον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="180">πρὶν ἂν
+                            παρʼ ἀμφοῖν μῦθον ἐκμάθῃ σαφῶς;</l>
+                    </sp>
+
+                    <milestone n="181" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="181">ἄναξ —
+                            ὑπάρχει μὲν τόδʼ ἐν τῇ σῇ χθονί — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="182">εἰπεῖν
+                            ἀκοῦσαί τʼ ἐν μέρει πάρεστί μοι, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="183">κοὐδείς
+                            μʼ ἀπώσει πρόσθεν, ὥσπερ ἄλλοθεν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="184"
+                            rend="indent">ἡμῖν δὲ καὶ τῷδʼ οὐδέν ἐστιν ἐν μέρει· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="185">ἐπεὶ γὰρ
+                            Ἄργους οὐ μέτεσθʼ ἡμῖν ἔτι, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="186">ψήφῳ
+                            δοκῆσαν, ἀλλὰ φεύγομεν πάτραν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="187">πῶς ἂν
+                            δικαίως ὡς Μυκηναίους ἄγοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="188">ὧδʼ ὄντας
+                            ἡμᾶς, οὓς ἀπήλασαν χθονός; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="189">ξένοι γάρ
+                            ἐσμεν. ἢ τὸν Ἑλλήνων ὅρον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="190">φεύγειν
+                            δικαιοῦθʼ ὅστις ἂν τἄργος φύγῃ; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="191">οὔκουν
+                            Ἀθήνας γʼ· οὐ γὰρ Ἀργείων φόβῳ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="192">τοὺς
+                            Ἡρακλείους παῖδας ἐξελῶσι γῆς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="193">οὐ γάρ τι
+                            Τραχίς ἐστιν οὐδʼ Ἀχαιικὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="194">πόλισμʼ,
+                            ὅθεν σὺ τούσδε, τῇ δίκῃ μὲν οὔ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="195">τὸ δʼ
+                            Ἄργος ὀγκῶν, οἷάπερ καὶ νῦν λέγεις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="196">ἤλαυνες
+                            ἱκέτας βωμίους καθημένους. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="197">εἰ γὰρ
+                            τόδʼ ἔσται καὶ λόγους κρινοῦσι σούς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="198">οὐκ οἶδʼ
+                            Ἀθήνας τάσδʼ ἐλευθέρας ἔτι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="199">ἀλλʼ οἶδʼ
+                            ἐγὼ τὸ τῶνδε λῆμα καὶ φύσιν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="200">θνῄσκειν
+                            θελήσουσʼ· ἡ γὰρ αἰσχύνη <add>πάρος</add>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="201">τοῦ ζῆν
+                            παρʼ ἐσθλοῖς ἀνδράσιν νομίζεται. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="202"
+                            rend="indent">πόλιν μὲν ἀρκεῖ· καὶ γὰρ οὖν ἐπίφθονον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="203">λίαν
+                            ἐπαινεῖν ἐστι, πολλάκις δὲ δὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="204">καὐτὸς
+                            βαρυνθεὶς οἶδʼ ἄγαν αἰνούμενος. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="205">σοὶ δʼ ὡς
+                            ἀνάγκη τούσδε βούλομαι φράσαι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="206">σῴζειν,
+                            ἐπείπερ τῆσδε προστατεῖς χθονός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="207">Πιτθεὺς
+                            μέν ἐστι Πέλοπος, ἐκ δὲ Πιτθέως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="208">Αἴθρα,
+                            πατὴρ δʼ ἐκ τῆσδε γεννᾶται σέθεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="209">Θησεύς.
+                            πάλιν δὲ τῶνδʼ ἄνειμί σοι γένος. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="210">Ἡρακλέης
+                            ἦν Ζηνὸς Ἀλκμήνης τε παῖς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="211">κείνη δὲ
+                            Πέλοπος θυγατρός. αὐτανεψίων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="212">πατὴρ ἂν
+                            εἴη σός τε χὡ τούτων γεγώς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="213"
+                            rend="indent">γένους μὲν ἥκεις ὧδε τοῖσδε, Δημοφῶν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="214">ἃ δʼ
+                            ἐκτὸς ἤδη τοῦ προσήκοντός σε δεῖ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="215">τεῖσαι
+                            λέγω σοι παισί· φημὶ γάρ ποτε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="216">σύμπλους
+                            γενέσθαι τῶνδʼ ὑπασπίζων πατρὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="217">ζωστῆρα
+                            Θησεῖ τὸν πολυκτόνον μέτα· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="218">Ἅιδου τʼ
+                            ἐρυμνῶν ἐξανήγαγεν μυχῶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="219">πατέρα
+                            σόν· Ἑλλὰς πᾶσα τοῦτο μαρτυρεῖ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="220">ὧν
+                            ἀντιδοῦναί σʼ οἵδʼ ἀπαιτοῦσιν χάριν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="221">μήτʼ
+                            ἐκδοθῆναι μήτε πρὸς βίαν θεῶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="222">τῶν σῶν
+                            ἀποσπασθέντες ἐκπεσεῖν χθονός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="223">σοὶ γὰρ
+                            τόδʼ αἰσχρὸν <sic>χωρίς, ἔν τε πόλει κακόν,</sic></l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="224">ἱκέτας
+                            ἀλήτας συγγενεῖς, οἴμοι, κακῶς — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="225">βλέψον
+                            πρὸς αὐτοὺς βλέψον· — ἕλκεσθαι βίᾳ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="226">ἀλλʼ
+                            ἄντομαί σε καὶ καταστέφω χεροῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="227">καὶ <gap
+                                reason="ellipsis" rend=" . . . "/> πρὸς γενείου, μηδαμῶς ἀτιμάσῃς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="228">τοὺς
+                            Ἡρακλείους παῖδας ἐς χέρας λαβών· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="229">γενοῦ δὲ
+                            τοῖσδε συγγενής, γενοῦ φίλος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="230">πατὴρ
+                            ἀδελφὸς δεσπότης· ἅπαντα γὰρ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="231">ταῦτʼ
+                            ἐστὶ κρείσσω πλὴν ὑπʼ Ἀργείοις πεσεῖν. </l>
+                    </sp>
+
+                    <milestone n="232" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="232">ᾤκτιρʼ
+                            ἀκούσας τούσδε συμφορᾶς, ἄναξ.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="233">τὴν δʼ
+                            εὐγένειαν τῆς τύχης νικωμένην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="234">νῦν δὴ
+                            μάλιστʼ ἐσεῖδον· οἵδε γὰρ πατρὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="235">ἐσθλοῦ
+                            γεγῶτες δυστυχοῦσʼ ἀναξίως. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="236">τρισσαί
+                            μʼ ἀναγκάζουσι συμφορᾶς ὁδοί, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="237">Ἰόλαε,
+                            τοὺς σοὺς μὴ παρώσασθαι ξένους· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="238">τὸ μὲν
+                            μέγιστον Ζεὺς ἐφʼ οὗ σὺ βώμιος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="239">θακεῖς
+                            νεοσσῶν τήνδʼ ἔχων πανήγυριν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="240">τὸ
+                            συγγενές τε καὶ τὸ προυφείλειν καλῶς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="241">πράσσειν
+                            παρʼ ἡμῶν τούσδε πατρῴαν χάριν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="242">τό τʼ
+                            αἰσχρόν, οὗπερ δεῖ μάλιστα φροντίσαι· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="243">εἰ γὰρ
+                            παρήσω τόνδε συλᾶσθαι βίᾳ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="244">ξένου
+                            πρὸς ἀνδρὸς βωμόν, οὐκ ἐλευθέραν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="245">οἰκεῖν
+                            δοκήσω γαῖαν, Ἀργείων δʼ ὄκνῳ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="246">ἱκέτας
+                            προδοῦναι· καὶ τάδʼ ἀγχόνης πέλας. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="247">ἀλλʼ
+                            ὤφελες μὲν εὐτυχέστερος μολεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="248">ὅμως δὲ
+                            καὶ νῦν μὴ τρέσῃς ὅπως σέ τις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="249">σὺν παισὶ
+                            βωμοῦ τοῦδʼ ἀποσπάσει βίᾳ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="250"
+                            rend="indent">σὺ δʼ Ἄργος ἐλθὼν ταῦτά τʼ Εὐρυσθεῖ φράσον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="251">πρὸς
+                            τοῖσδέ τʼ, εἴ τι τοισίδʼ ἐγκαλεῖ ξένοις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="252">δίκης
+                            κυρήσειν· τούσδε δʼ οὐκ ἄξεις ποτέ. </l>
+                    </sp>
+
+                    <milestone n="253" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="253">οὐκ ἢν
+                            δίκαιον ᾖ τι καὶ νικῶ λόγῳ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="254">καὶ πῶς
+                            δίκαιον τὸν ἱκέτην ἄγειν βίᾳ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="255">οὐκ οὖν
+                            ἐμοὶ τόδʼ αἰσχρόν, ἀλλʼ <add>οὐ</add> σοὶ βλάβος; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="256">ἐμοί γʼ,
+                            ἐάν σοι τούσδʼ ἐφέλκεσθαι μεθῶ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="257">σὺ δʼ
+                            ἐξόριζε, κᾆτʼ ἐκεῖθεν ἄξομεν. </l>
+
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="258">σκαιὸς
+                            πέφυκας τοῦ θεοῦ πλείω φρονῶν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="259">δεῦρʼ, ὡς
+                            ἔοικε, τοῖς κακοῖσι φευκτέον. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="260">ἅπασι
+                            κοινὸν ῥῦμα δαιμόνων ἕδρα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="261">ταῦτʼ οὐ
+                            δοκήσει τοῖς Μυκηναίοις ἴσως. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="262">οὐκ οὖν
+                            ἐγὼ τῶν ἐνθάδʼ εἰμὶ κύριος; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="263">βλάπτων
+                                <add>γʼ</add> ἐκείνους μηδέν, ἢν σὺ σωφρονῇς.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="264"
+                            >βλάπτεσθʼ, ἐμοῦ γε μὴ μιαίνοντος θεούς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="265">οὐ
+                            βούλομαί σε πόλεμον Ἀργείοις ἔχειν.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="266">κἀγὼ
+                            τοιοῦτος· τῶνδε δʼ οὐ μεθήσομαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="267">ἄξω γε
+                            μέντοι τοὺς ἐμοὺς ἐγὼ λαβών. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="268">οὐκ ἆρ’
+                            ἐς Ἄργος ῥᾳδίως ἄπει πάλιν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="269"
+                            >πειρώμενος δὴ τοῦτό γʼ αὐτίκʼ εἴσομαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="270">κλαίων
+                            ἄρʼ ἅψῃ τῶνδε κοὐκ ἐς ἀμβολάς.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="271">μὴ πρὸς
+                            θεῶν κήρυκα τολμήσῃς θενεῖν.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="272">εἰ μή γʼ
+                            ὁ κῆρυξ σωφρονεῖν μαθήσεται.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="273">ἄπελθε·
+                            καὶ σὺ τοῦδε μὴ θίγῃς, ἄναξ.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Κῆρυξ</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="274">στείχω·
+                            μιᾶς γὰρ χειρὸς ἀσθενὴς μάχη. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="275">ἥξω δὲ
+                            πολλὴν Ἄρεος Ἀργείου λαβὼν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="276">πάγχαλκον
+                            αἰχμὴν δεῦρο. μυρίοι δέ με </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="277">μένουσιν
+                            ἀσπιστῆρες Εὐρυσθεύς τʼ ἄναξ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="278">αὐτὸς
+                            στρατηγῶν· Ἀλκάθου δʼ ἐπʼ ἐσχάτοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="279">καραδοκῶν
+                            τἀνθένδε τέρμασιν μένει. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="280">λαμπρὸς
+                            δʼ ἀκούσας σὴν ὕβριν φανήσεται </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="281">σοὶ καὶ
+                            πολίταις γῇ τε τῇδε καὶ φυτοῖς· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="282">μάτην γὰρ
+                            ἥβην ὧδέ γʼ ἂν κεκτῄμεθα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="283">πολλὴν ἐν
+                            Ἄργει, μή σε τιμωρούμενοι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="284">φθείρου·
+                            τὸ σὸν γὰρ Ἄργος οὐ δέδοικʼ ἐγώ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="285">ἐνθένδε
+                            δʼ οὐκ ἔμελλες αἰσχύνας ἐμὲ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="286">ἄξειν βίᾳ
+                            τούσδʼ· οὐ γὰρ Ἀργείων πόλει </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="287">ὑπήκοον
+                            τήνδʼ ἀλλʼ ἐλευθέραν ἔχω. </l>
+                    </sp>
+
+                    <milestone n="288" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="anapests">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="288">ὥρα
+                                προνοεῖν, πρὶν ὅροις πελάσαι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="289"
+                                >στρατὸν Ἀργείων· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="290">μάλα
+                                δʼ ὀξὺς Ἄρης ὁ Μυκηναίων, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="291">ἐπὶ
+                                τοῖσι δὲ δὴ μᾶλλον ἔτʼ ἢ πρίν. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="292">πᾶσι
+                                γὰρ οὗτος κήρυξι νόμος, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="293">δὶς
+                                τόσα πυργοῦν τῶν γιγνομένων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="294">πόσα
+                                νιν λέξειν βασιλεῦσι δοκεῖς, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="295">ὡς
+                                δείνʼ ἔπαθεν καὶ παρὰ μικρὸν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="296">ψυχὴν
+                                ἦλθεν διακναῖσαι; </l>
+                        </sp>
+
+                        <milestone n="297" unit="card" resp="perseus"/>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="297">οὐκ
+                                ἔστι τοῦδε παισὶ κάλλιον γέρας, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="298">ἢ
+                                πατρὸς ἐσθλοῦ κἀγαθοῦ πεφυκέναι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="299">
+                                <del>γαμεῖν τʼ ἀπʼ ἐσθλῶν· ὃς δὲ νικηθεὶς πόθῳ</del>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="300">
+                                <del rend="merge">κακοῖς ἐκοινώνησεν, οὐκ ἐπαινέσω,</del>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="301">
+                                <del rend="merge">τέκνοις ὄνειδος οὕνεχʼ ἡδονῆς λιπεῖν.</del>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="302">τὸ
+                                δυστυχὲς γὰρ ηὑγένει’ ἀμύνεται </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="303">τῆς
+                                δυσγενείας μᾶλλον· ἡμεῖς γὰρ κακῶν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="304">ἐς
+                                τοὔσχατον πεσόντες ηὕρομεν φίλους </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="305">καὶ
+                                ξυγγενεῖς τούσδʼ, οἳ τοσῆσδʼ οἰκουμένης </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="306"
+                                >Ἑλληνίδος γῆς τῶνδε προύστησαν μόνοι. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="307">δότ’,
+                                ὦ τέκνʼ, αὐτοῖς χεῖρα δεξιάν, δότε· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="308">ὑμεῖς
+                                τε παισί, καὶ πέλας προσέλθετε. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="309">ὦ
+                                παῖδες, ἐς μὲν πεῖραν ἤλθομεν φίλων· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="310">ἢν δʼ
+                                οὖν ποθʼ ὑμῖν νόστος ἐς πάτραν φανῇ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="311">καὶ
+                                δώματʼ οἰκήσητε καὶ τιμὰς πατρός </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="311a">
+                                <gap reason="lost" rend=" . . . . . . "/>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="312"
+                                >σωτῆρας αἰεὶ καὶ φίλους νομίζετε, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="313">καὶ
+                                μήποτʼ ἐς γῆν ἐχθρὸν αἴρεσθαι δόρυ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="314"
+                                >μέμνησθέ μοι τήνδʼ, ἀλλὰ φιλτάτην πόλιν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="315">πασῶν
+                                νομίζετʼ. ἄξιοι δʼ ὑμῖν σέβειν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="316">οἳ
+                                γῆν τοσήνδε καὶ Πελασγικὸν λεὼν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="317">ἡμῶν
+                                ἀπηλλάξαντο πολεμίους ἔχειν, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="318"
+                                >πτωχοὺς ἀλήτας εἰσορῶντες· ἀλλʼ ὅμως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="319">οὐκ
+                                ἐξέδωκαν οὐδʼ ἀπήλασαν χθονός. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="320">ἐγὼ
+                                δὲ καὶ ζῶν καὶ θανών, ὅταν θάνω,</l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="321">πολλῷ
+                                σʼ ἐπαίνῳ Θησέως, ὦ τᾶν, πέλας </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="322"
+                                >ὑψηλὸν ἀρῶ καὶ λέγων τάδʼ εὐφρανῶ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="323">ὡς εὖ
+                                τʼ ἐδέξω καὶ τέκνοισιν ἤρκεσας </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="324">τοῖς
+                                Ἡρακλείοις, εὐγενὴς δʼ ἀνʼ Ἑλλάδα </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="325"
+                                >σῴζεις πατρῴαν δόξαν, ἐξ ἐσθλῶν δὲ φὺς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="326">οὐδὲν
+                                κακίων τυγχάνεις γεγὼς πατρός, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="327"
+                                >παύρων μετʼ ἄλλων· ἕνα γὰρ ἐν πολλοῖς ἴσως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="328"
+                                >εὕροις ἂν ὅστις ἐστὶ μὴ χείρων πατρός. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="329">ἀεί
+                                ποθʼ ἥδε γαῖα τοῖς ἀμηχάνοις </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="330">σὺν
+                                τῷ δικαίῳ βούλεται προσωφελεῖν. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="331"
+                                >τοιγὰρ πόνους δὴ μυρίους ὑπὲρ φίλων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="332"
+                                >ἤνεγκε, καὶ νῦν τόνδʼ ἀγῶνʼ ὁρῶ πέλας. </l>
+                        </sp>
+
+                        <milestone n="333" unit="card" resp="perseus"/>
+
+                        <sp>
+                            <speaker>Δημοφῶν</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="333">σοί
+                                τʼ εὖ λέλεκται, καὶ τὰ τῶνδʼ αὐχῶ, γέρον, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="334"
+                                >τοιαῦτʼ ἔσεσθαι· μνημονεύσεται χάρις. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="335">κἀγὼ
+                                μὲν ἀστῶν σύλλογον ποήσομαι, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="336">τάξω
+                                δʼ, ὅπως ἂν τὸν Μυκηναίων στρατὸν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="337">πολλῇ
+                                δέχωμαι χειρί· πρῶτα μὲν σκοποὺς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="338">πέμψω
+                                πρὸς αὐτόν, μὴ λάθῃ με προσπεσών· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="339">ταχὺς
+                                γὰρ Ἄργει πᾶς ἀνὴρ βοηδρόμος· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="340"
+                                >μάντεις δʼ ἀθροίσας θύσομαι. σὺ δʼ ἐς δόμους </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="341">σὺν
+                                παισὶ χώρει, Ζηνὸς ἐσχάραν λιπών. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="342">εἰσὶν
+                                γὰρ οἵ σου, κἂν ἐγὼ θυραῖος ὦ, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="343"
+                                >μέριμναν ἕξουσʼ. ἀλλʼ ἴθʼ ἐς δόμους, γέρον. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="344">οὐκ
+                                ἂν λίποιμι βωμόν· ἑζώμεσθα δὴ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="345"
+                                >ἱκέται μένοντες ἐνθάδʼ εὖ πρᾶξαι πόλιν· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="346">ὅταν
+                                δʼ ἀγῶνος τοῦδʼ ἀπαλλαχθῇς καλῶς, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="347">ἴμεν
+                                πρὸς οἴκους. θεοῖσι δʼ οὐ κακίοσιν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="348"
+                                >χρώμεσθα συμμάχοισιν Ἀργείων, ἄναξ· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="349">τῶν
+                                μὲν γὰρ Ἥρα προστατεῖ, Διὸς δάμαρ, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="350">ἡμῶν
+                                δʼ Ἀθηνᾶ. φημὶ δʼ εἰς εὐπραξίαν</l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="351">καὶ
+                                τοῦθʼ ὑπάρχειν, θεῶν ἀμεινόνων τυχεῖν· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="352"
+                                >νικωμένη γὰρ Παλλὰς οὐκ ἀνέξεται. </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="353" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="choral">
+                    <div type="textpart" subtype="strophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="353">Εἰ σὺ
+                                μέγʼ αὐχεῖς, ἕτεροι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="354">σοῦ
+                                πλέον οὐ μέλονται, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="355"
+                                    ><add>ὦ</add> ξεῖν’ Ἀργόθεν ἐλθών, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="356"
+                                >μεγαληγορίαισι δʼ ἐμὰς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="357"
+                                >φρένας οὐ φοβήσεις. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="358">μήπω
+                                ταῖς μεγάλαισιν οὕ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="359">τω
+                                καὶ καλλιχόροις Ἀθή- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="360">ναις
+                                εἴη· σὺ δʼ ἄφρων, ὅ τʼ Ἄρ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="361">γει
+                                Σθενέλου τύραννος. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="362" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="362">ὃς
+                                πόλιν ἐλθὼν ἑτέραν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="363">οὐδὲν
+                                ἐλάσσονʼ Ἄργους, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="364">θεῶν
+                                ἱκτῆρας ἀλάτας </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="365">καὶ
+                                ἐμᾶς χθονὸς ἀντομένους </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="366">ξένος
+                                ὢν βιαίως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="367"
+                                >ἕλκεις, οὐ βασιλεῦσιν εἴ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="368">ξας,
+                                οὐκ ἄλλο δίκαιον εἰ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="369">πών·
+                                ποῦ ταῦτα καλῶς ἂν εἴ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="370">η
+                                παρά γʼ εὖ φρονοῦσιν; </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="371" unit="card" resp="perseus"/>
+
+
+                    <div type="textpart" subtype="epode">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="371"
+                                >Εἰρήνα μὲν ἐμοί γʼ ἀρέ-</l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="372">σκει·
+                                σὺ δʼ, ὦ κακόφρων ἄναξ, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="373">λέγω,
+                                εἰ πόλιν ἥξεις, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="374">οὐχ
+                                οὕτως ἃ δοκεῖς κυρή- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="375">σεις·
+                                οὐ σοὶ μόνῳ ἔγχος οὐδʼ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="376">ἰτέα
+                                κατάχαλκός <del>ἐστιν.</del>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="377">ἀλλʼ
+                                οὐ, πολέμων ἐραστάς, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="378">μή
+                                μοι δορὶ συνταράξεις </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="379">τὰν
+                                εὖ χαρίτων ἔχουσαν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="380"
+                                >πόλιν, ἀλλʼ ἀνάσχου. </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="381" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="episode">
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="381">ὦ παῖ, τί
+                            μοι σύννοιαν ὄμμασιν φέρων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="382">ἥκεις;
+                            νέον τι πολεμίων λέξεις πέρι; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="383">μέλλουσιν
+                            ἢ πάρεισιν ἢ τί πυνθάνῃ; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="384">οὐ γάρ τι
+                            μὴ ψεύσῃς γε κήρυκος λόγους· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="385">ὁ γὰρ
+                            στρατηγὸς εὐτυχὴς τὰ πρὸς θεῶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="386">εἶσιν,
+                            σάφʼ οἶδα, καὶ μάλʼ οὐ σμικρὸν φρονῶν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="387">ἐς τὰς
+                            Ἀθήνας. ἀλλὰ τῶν φρονημάτων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="388">ὁ Ζεὺς
+                            κολαστὴς τῶν ἄγαν ὑπερφρόνων. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="389">ἥκει
+                            στράτευμʼ Ἀργεῖον Εὐρυσθεύς τʼ ἄναξ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="390">ἐγώ νιν
+                            αὐτὸς εἶδον. ἄνδρα γὰρ χρεών, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="391">ὅστις
+                            στρατηγεῖν φησʼ ἐπίστασθαι καλῶς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="392">οὐκ
+                            ἀγγέλοισι τοὺς ἐναντίους ὁρᾶν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="393">πεδία μὲν
+                            οὖν γῆς ἐς τάδʼ οὐκ ἐφῆκέ πω </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="394">στρατόν,
+                            λεπαίαν δʼ ὀφρύην καθήμενος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="395">σκοπεῖ —
+                            δόκησιν δὴ τόδʼ ἂν λέγοιμί σοι — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="396">
+                            <sic>ποίᾳ προσάξει στρατόπεδον τὰ νῦν δορὸς</sic>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="397">
+                            <sic rend="merge">ἐν ἀσφαλεῖ τε τῆσδʼ ἱδρύσεται χθονός.</sic>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="398">καὶ τἀμὰ
+                            μέντοι πάντʼ ἄραρʼ ἤδη καλῶς· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="399">πόλις τʼ
+                            ἐν ὅπλοις, σφάγιά θʼ ἡτοιμασμένα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="400">ἕστηκεν
+                            οἷς χρὴ ταῦτα τέμνεσθαι θεῶν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="402">τροπαῖά
+                            τʼ ἐχθρῶν καὶ πόλει σωτήρια, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="401"
+                            >θυηπολεῖται δʼ ἄστυ μάντεων ὕπο. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="403">χρησμῶν
+                            δʼ ἀοιδοὺς πάντας εἰς ἓν ἁλίσας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="404">ἤλεγξα
+                            καὶ βέβηλα καὶ κεκρυμμένα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="405">λόγια
+                            παλαιά, τῇδε γῇ σωτήρια. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="406">καὶ τῶν
+                            μὲν ἄλλων διάφορʼ ἐστὶ θεσφάτοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="407">πόλλʼ· ἓν
+                            δὲ πᾶσι γνῶμα ταὐτὸν ἐμπρέπει· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="408">σφάξαι
+                            κελεύουσίν με παρθένον Κόρῃ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="409">Δήμητρος,
+                            ἥτις ἐστὶ πατρὸς εὐγενοῦς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="410"
+                            rend="indent">ἐγὼ δʼ ἔχω μέν, ὡς ὁρᾷς, προθυμίαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="411">τοσήνδʼ
+                            ἐς ὑμᾶς· παῖδα δʼ οὔτʼ ἐμὴν κτενῶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="412">οὔτʼ
+                            ἄλλον ἀστῶν τῶν ἐμῶν ἀναγκάσω </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="413">ἄκονθʼ·
+                            ἑκὼν δὲ τίς κακῶς οὕτω φρονεῖ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="414">ὅστις τὰ
+                            φίλτατʼ ἐκ χερῶν δώσει τέκνα; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="415">καὶ νῦν
+                            πικρὰς ἂν συστάσεις ἂν εἰσίδοις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="416">τῶν μὲν
+                            λεγόντων ὡς δίκαιον ἦν ξένοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="417">ἱκέταις
+                            ἀρήγειν, τῶν δὲ μωρίαν ἐμὴν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="418"
+                            >κατηγορούντων· εἰ δὲ δὴ δράσω τόδε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="419">οἰκεῖος
+                            ἤδη πόλεμος ἐξαρτύεται. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="420">ταῦτʼ οὖν
+                            ὅρα σὺ καὶ συνεξεύρισχʼ ὅπως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="421">αὐτοί τε
+                            σωθήσεσθε καὶ πέδον τόδε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="422">κἀγὼ
+                            πολίταις μὴ διαβληθήσομαι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="423">οὐ γὰρ
+                            τυραννίδʼ ὥστε βαρβάρων ἔχω· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="424">ἀλλʼ, ἢν
+                            δίκαια δρῶ, δίκαια πείσομαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="425">ἀλλʼ ἦ
+                            πρόθυμον οὖσαν οὐκ ἐᾷ θεὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="426">ξένοις
+                            ἀρήγειν τήνδε χρῄζουσιν πόλιν; </l>
+                    </sp>
+
+                    <milestone n="427" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="427">ὦ τέκνʼ,
+                            ἔοιγμεν ναυτίλοισιν, οἵτινες </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="428">χειμῶνος
+                            ἐκφυγόντες ἄγριον μένος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="429">ἐς χεῖρα
+                            γῇ συνῆψαν, εἶτα χερσόθεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="430">πνοιαῖσιν
+                            ἠλάθησαν ἐς πόντον πάλιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="431">οὕτω δὲ
+                            χἡμεῖς τῆσδʼ ἀπωθούμεσθα γῆς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="432">ἤδη πρὸς
+                            ἀκταῖς ὄντες ὡς σεσῳσμένοι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="433">οἴμοι· τί
+                            δῆτʼ ἔτερψας ὦ τάλαινά με </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="434">ἐλπὶς
+                            τότʼ, οὐ μέλλουσα διατελεῖν χάριν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="435">συγγνωστὰ
+                            γάρ τοι καὶ τὰ τοῦδʼ, εἰ μὴ θέλει </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="436">κτείνειν
+                            πολιτῶν παῖδας· αἰνέσαι δʼ ἔχω </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="437">καὶ
+                            τἀνθάδ’· εἰ θεοῖσι δὴ δοκεῖ τάδε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="438">πράσσειν
+                            ἔμʼ, οὔτοι σή γʼ ἀπόλλυται χάρις. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="439"
+                            rend="indent">ὦ παῖδες, ὑμῖν δʼ οὐκ ἔχω τί χρήσομαι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="440">ποῖ
+                            τρεψόμεσθα; τίς γὰρ ἄστεπτος θεῶν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="441">ποῖον δὲ
+                            γαίας ἕρκος οὐκ ἀφίγμεθα; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="442">ὀλούμεθʼ,
+                            ὦ τέκνʼ· ἐκδοθησόμεσθα δή. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="443">κἀμοῦ μὲν
+                            οὐδὲν εἴ με χρὴ θανεῖν μέλει, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="444">πλὴν εἴ
+                            τι τέρψω τοὺς ἐμοὺς ἐχθροὺς θανών· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="445">ὑμᾶς δὲ
+                            κλαίω καὶ κατοικτίρω, τέκνα, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="446">καὶ τὴν
+                            γεραιὰν μητέρʼ Ἀλκμήνην πατρός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="447">ὦ
+                            δυστάλαινα τοῦ μακροῦ βίου σέθεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="448">τλήμων δὲ
+                            κἀγὼ πολλὰ μοχθήσας μάτην. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="449">χρῆν χρῆν
+                            ἄρʼ ἡμᾶς ἀνδρὸς εἰς ἐχθροῦ χέρας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="450">πεσόντας
+                            αἰσχρῶς καὶ κακῶς λιπεῖν βίον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="451"
+                            rend="indent">ἀλλʼ οἶσθ’ ὅ μοι σύμπραξον; οὐχ ἅπασα γὰρ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="452">πέφευγεν
+                            ἐλπὶς τῶνδέ μοι σωτηρίας· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="453">ἔμʼ ἔκδος
+                            Ἀργείοισιν ἀντὶ τῶνδʼ, ἄναξ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="454">καὶ μήτε
+                            κινδύνευε, σωθήτω τέ μοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="455">τέκνʼ· οὐ
+                            φιλεῖν δεῖ τὴν ἐμὴν ψυχήν· ἴτω. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="456">μάλιστα
+                            δʼ Εὐρυσθεύς με βούλοιτʼ ἂν λαβὼν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="457">τὸν
+                            Ἡράκλειον σύμμαχον καθυβρίσαι· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="458">σκαιὸς
+                            γὰρ ἁνήρ. τοῖς σοφοῖς δʼ εὐκτὸν σοφῷ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="459">ἔχθραν
+                            συνάπτειν, μὴ ἀμαθεῖ φρονήματι· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="460">πολλῆς
+                            γὰρ αἰδοῦς καὶ δίκης τις ἂν τύχοι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="461">ὦ πρέσβυ,
+                            μή νυν τήνδʼ ἐπαιτιῶ πόλιν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="462">τάχʼ ἂν
+                            γὰρ ἡμῖν ψευδὲς ἀλλʼ ὅμως κακὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="463">γένοιτʼ
+                            ὄνειδος ὡς ξένους προυδώκαμεν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="464">γενναῖα
+                            μὲν τάδʼ εἶπας, ἀλλʼ ἀμήχανα. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="465">οὐ σοῦ
+                            χατίζων δεῦρʼ ἄναξ στρατηλατεῖ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="466">τί γὰρ
+                            γέροντος ἀνδρὸς Εὐρυσθεῖ πλέον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="467">θανόντος;
+                            ἀλλὰ τούσδε βούλεται κτανεῖν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="468">δεινὸν
+                            γὰρ ἐχθροῖς βλαστάνοντες εὐγενεῖς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="469">νεανίαι
+                            τε καὶ πατρὸς μεμνημένοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="470">λύμας· ἃ
+                            κεῖνον πάντα προσκοπεῖν χρεών.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="471">ἀλλʼ, εἴ
+                            τινʼ ἄλλην οἶσθα καιριωτέραν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="472">βουλήν,
+                            ἑτοίμαζʼ, ὡς ἔγωγʼ ἀμήχανος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="473">χρησμῶν
+                            ἀκούσας εἰμὶ καὶ φόβου πλέως. </l>
+                    </sp>
+
+                    <milestone n="474" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="474">ξένοι,
+                            θράσος μοι μηδὲν ἐξόδοις ἐμαῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="475">προσθῆτε·
+                            πρῶτον γὰρ τόδʼ ἐξαιτήσομαι· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="476">γυναικὶ
+                            γὰρ σιγή τε καὶ τὸ σωφρονεῖν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="477"
+                            >κάλλιστον, εἴσω θʼ ἥσυχον μένειν δόμων. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="478">τῶν σῶν
+                            δʼ ἀκούσασʼ, Ἰόλεως, στεναγμάτων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="479">ἐξῆλθον,
+                            οὐ ταχθεῖσα πρεσβεύειν γένους. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="480">ἀλλʼ,
+                            εἰμὶ γάρ πως πρόσφορος, μέλει δέ μοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="481">μάλιστ’
+                            ἀδελφῶν, τῶνδε κἀμαυτῆς πέρι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="482">θέλω
+                            πυθέσθαι, μὴ ’πὶ τοῖς πάλαι κακοῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="483"
+                            >προσκείμενόν τι πῆμα σὴν δάκνει φρένα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="484">ὦ παῖ,
+                            μάλιστα σʼ οὐ νεωστὶ δὴ τέκνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="485">τῶν
+                            Ἡρακλείων ἐνδίκως αἰνεῖν ἔχω. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="486">ἡμῖν δὲ
+                            δόξας εὖ προχωρῆσαι δρόμος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="487">πάλιν
+                            μεθέστηκʼ αὖθις ἐς τἀμήχανον· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="488">χρησμῶν
+                            γὰρ ᾠδούς φησι σημαίνειν ὅδε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="489">οὐ ταῦρον
+                            οὐδὲ μόσχον, ἀλλὰ παρθένον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="490">σφάξαι
+                            Κόρῃ Δήμητρος ἥτις εὐγενής, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="491">εἰ χρὴ
+                            μὲν ἡμᾶς, χρὴ δὲ τήνδʼ εἶναι πόλιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="492">ταῦτʼ οὖν
+                            ἀμηχανοῦμεν· οὔτε γὰρ τέκνα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="493">σφάξειν
+                            ὅδʼ αὑτοῦ φησιν οὔτʼ ἄλλου τινός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="494">κἀμοὶ
+                            λέγει μὲν οὐ σαφῶς, λέγει δέ πως, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="495">εἰ μή τι
+                            τούτων ἐξαμηχανήσομεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="496">ἡμᾶς μὲν
+                            ἄλλην γαῖαν εὑρίσκειν τινά, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="497">αὐτὸς δὲ
+                            σῶσαι τήνδε βούλεται χθόνα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="498">ἐν τῷδε
+                            κἀχόμεσθα σωθῆναι λόγῳ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="499">ἐν τῷδε,
+                            τἄλλα γʼ εὐτυχῶς πεπραγότες. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="500">μή νυν
+                            τρέσῃς ἔτʼ ἐχθρὸν Ἀργεῖον δόρυ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="501">ἐγὼ γὰρ
+                            αὐτὴ πρὶν κελευσθῆναι, γέρον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="502">θνῄσκειν
+                            ἑτοίμη καὶ παρίστασθαι σφαγῇ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="503">τί
+                            φήσομεν γάρ, εἰ πόλις μὲν ἀξιοῖ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="504">κίνδυνον
+                            ἡμῶν οὕνεκʼ αἴρεσθαι μέγαν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="505">αὐτοὶ δὲ
+                            προστιθέντες ἄλλοισιν πόνους, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="506">παρόν σφε
+                            σῷσαι, φευξόμεσθα μὴ θανεῖν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="507">οὐ δῆτʼ,
+                            ἐπεί τοι καὶ γέλωτος ἄξια, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="508">στένειν
+                            μὲν ἱκέτας δαιμόνων καθημένους, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="509">πατρὸς δʼ
+                            ἐκείνου φύντας οὗ πεφύκαμεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="510">κακοὺς
+                            ὁρᾶσθαι· ποῦ τάδʼ ἐν χρηστοῖς πρέπει; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="511">κάλλιον,
+                            οἶμαι, τῆσδʼ — ἃ μὴ τύχοι ποτέ — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="512">πόλεως
+                            ἁλούσης, χεῖρας εἰς ἐχθρῶν πεσεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="513"
+                                ><sic>κἄπειτα τινὰ</sic> πατρὸς οὖσαν εὐγενοῦς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="514">παθοῦσαν
+                            Ἅιδην μηδὲν ἧσσον εἰσιδεῖν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="515">ἀλλʼ
+                            ἐκπεσοῦσα τῆσδʼ ἀλητεύσω χθονός; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="516">κοὐκ
+                            αἰσχυνοῦμαι δῆτ’, ἐὰν δή τις λέγῃ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="517">Τί δεῦρʼ
+                            ἀφίκεσθʼ ἱκεσίοισι σὺν κλάδοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="518">αὐτοὶ
+                            φιλοψυχοῦντες; ἔξιτε χθονός· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="519">κακοὺς
+                            γὰρ ἡμεῖς οὐ προσωφελήσομεν. </l>
+                        <milestone n="520" unit="card" resp="perseus"/>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="520"
+                            rend="indent">ἀλλʼ οὐδὲ μέντοι, τῶνδε μὲν τεθνηκότων, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="521">αὐτὴ δὲ
+                            σωθεῖσʼ, ἐλπίδʼ εὖ πράξειν ἔχω· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="522">— πολλοὶ
+                            γὰρ ἤδη τῇδε προύδοσαν φίλους. — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="523">τίς γὰρ
+                            κόρην ἔρημον ἢ δάμαρτʼ ἔχειν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="524">ἢ
+                            παιδοποιεῖν ἐξ ἐμοῦ βουλήσεται; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="525">οὐκ οὖν
+                            θανεῖν ἄμεινον ἢ τούτων τυχεῖν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="526">ἀναξίαν;
+                            ἄλλῃ δὲ κἂν πρέποι τινὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="527">μᾶλλον
+                            τάδʼ, ἥτις μὴ ’πίσημος ὡς ἐγώ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="528"
+                            rend="indent">ἡγεῖσθʼ ὅπου δεῖ σῶμα κατθανεῖν τόδε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="529">καὶ
+                            στεμματοῦτε καὶ κατάρχεσθʼ, εἰ δοκεῖ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="530">νικᾶτε δʼ
+                            ἐχθρούς· ἥδε γὰρ ψυχὴ πάρα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="531">ἑκοῦσα
+                            κοὐκ ἄκουσα· κἀξαγγέλλομαι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="532">θνῄσκειν
+                            ἀδελφῶν τῶνδε κἀμαυτῆς ὕπερ.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="533">εὕρημα
+                            γάρ τοι μὴ φιλοψυχοῦσʼ ἐγὼ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="534">κάλλιστον
+                            ηὕρηκ’, εὐκλεῶς λιπεῖν βίον. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="535">φεῦ φεῦ,
+                            τί λέξω παρθένου μέγαν λόγον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="536">κλύων,
+                            ἀδελφῶν ἣ πάρος θέλει θανεῖν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="537">τούτων
+                            τίς ἂν λέξειε γενναίους λόγους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="538">μᾶλλον,
+                            τίς ἂν δράσειεν ἀνθρώπων ἔτι; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="539">ὦ τέκνον,
+                            οὐκ ἔστʼ ἄλλοθεν τὸ σὸν κάρα, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="540">ἀλλʼ ἐξ
+                            ἐκείνου σπέρμα τῆς θείας φρενὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="541">πέφυκας
+                            Ἡράκλειος· οὐδʼ αἰσχύνομαι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="542">τοῖς σοῖς
+                            λόγοισι, τῇ τύχῃ δʼ ἀλγύνομαι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="543">ἀλλʼ ᾗ
+                            γένοιτʼ ἂν ἐνδικωτέρως φράσω· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="544">πάσας
+                            ἀδελφὰς τῆσδε δεῦρο χρὴ καλεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="545">κᾆθʼ ἡ
+                            λαχοῦσα θνῃσκέτω γένους ὕπερ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="546">σὲ δʼ οὐ
+                            δίκαιον κατθανεῖν ἄνευ πάλου. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="547">οὐκ ἂν
+                            θάνοιμι τῇ τύχῃ λαχοῦσʼ ἐγώ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="548">χάρις γὰρ
+                            οὐ πρόσεστι· μὴ λέξῃς, γέρον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="549">ἀλλʼ, εἰ
+                            μὲν ἐνδέχεσθε καὶ βούλεσθέ μοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="550">χρῆσθαι
+                            προθύμως, τὴν ἐμὴν ψυχὴν ἐγὼ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="551">δίδωμʼ
+                            ἑκοῦσα τοῖσδʼ, ἀναγκασθεῖσα δʼ οὔ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="552">φεῦ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="553">ὅδʼ αὖ
+                            λόγος σοι τοῦ πρὶν εὐγενέστερος· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="554">κἀκεῖνος
+                            ἦν ἄριστος· ἀλλʼ ὑπερφέρεις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="555">τόλμῃ τε
+                            τόλμαν καὶ λόγῳ χρηστῷ λόγον.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="556">οὐ μὴν
+                            κελεύω γʼ οὐδʼ ἀπεννέπω, τέκνον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="557">θνῄσκειν
+                            σʼ· ἀδελφοὺς δʼ ὠφελεῖς θανοῦσα σούς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="558">σοφῶς
+                            κελεύεις· μὴ τρέσῃς μιάσματος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="559">τοὐμοῦ
+                            μετασχεῖν, ἀλλʼ ἐλευθέρως θάνω. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="560"
+                            rend="indent">ἕπου δέ, πρέσβυ· σῇ γὰρ ἐνθανεῖν χερὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="561">θέλω·
+                            πέπλοις δὲ σῶμʼ ἐμὸν κρύψον παρών· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="562">ἐπεὶ
+                            σφαγῆς γε πρὸς τὸ δεινὸν εἶμʼ ἐγώ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="563">εἴπερ
+                            πέφυκα πατρὸς οὗπερ εὔχομαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="564">οὐκ ἂν
+                            δυναίμην σῷ παρεστάναι μόρῳ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="565">σὺ δʼ
+                            ἀλλὰ τοῦδε χρῇζε, μή μʼ ἐν ἀρσένων, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="566">ἀλλʼ ἐν
+                            γυναικῶν, χερσὶν ἐκπνεῦσαι βίον. </l>
+                    </sp>
+
+                    <milestone n="567" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Δημοφῶν</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="567">ἔσται
+                            τάδʼ, ὦ τάλαινα παρθένων, ἐπεὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="568">κἀμοὶ
+                            τόδʼ αἰσχρόν, μή σε κοσμεῖσθαι καλῶς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="569">πολλῶν
+                            ἕκατι, τῆς τε σῆς εὐψυχίας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="570">καὶ τοῦ
+                            δικαίου· τλημονεστάτην δὲ σὲ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="571">πασῶν
+                            γυναικῶν εἶδον ὀφθαλμοῖς ἐγώ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="572">ἀλλʼ, εἴ
+                            τι βούλῃ, τούσδε τὸν γέροντά τε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="573">χώρει
+                            προσειποῦσʼ ὑστάτοις προσφθέγμασιν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Μακαρία</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="574">ὦ χαῖρε,
+                            πρέσβυ, χαῖρε καὶ δίδασκέ μοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="575">τοιούσδε
+                            τούσδε παῖδας, ἐς τὸ πᾶν σοφούς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="576">ὥσπερ σύ,
+                            μηδὲν μᾶλλον· ἀρκέσουσι γάρ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="577">πειρῶ δὲ
+                            σῶσαι μὴ θανεῖν, πρόθυμος ὤν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="578">σοὶ
+                            παῖδές ἐσμεν, σαῖν χεροῖν τεθράμμεθα. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="579">ὁρᾷς δὲ
+                            κἀμὲ τὴν ἐμὴν ὥραν γάμου </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="580">διδοῦσαν
+                            ἀντὶ τῶνδε κατθανουμένην. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="581">ὑμεῖς τʼ,
+                            ἀδελφῶν ἡ παροῦσʼ ὁμιλία, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="582"
+                            >εὐδαιμονοῖτε, καὶ γένοιθʼ ὑμῖν ὅσων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="583">ἡμὴ
+                            πάροιθε καρδία σφαγήσεται. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="584">καὶ τὸν
+                            γέροντα τήν τʼ ἔσω γραῖαν δόμων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="585">τιμᾶτε
+                            πατρὸς μητέρʼ Ἀλκμήνην ἐμοῦ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="586">ξένους τε
+                            τούσδε. κἂν ἀπαλλαγὴ πόνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="587">καὶ
+                            νόστος ὑμῖν εὑρεθῇ ποτʼ ἐκ θεῶν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="588">μέμνησθε
+                            τὴν σώτειραν ὡς θάψαι χρεών. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="589">κάλλιστά
+                            τοι δίκαιον· οὐ γὰρ ἐνδεὴς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="590">ὑμῖν
+                            παρέστην, ἀλλὰ προύθανον γένους.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="591">τάδʼ ἀντὶ
+                            παίδων ἐστί μοι κειμήλια </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="592">καὶ
+                            παρθενείας, εἴ τι δὴ κάτω χθονός· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="593">εἴη γε
+                            μέντοι μηδέν. εἰ γὰρ ἕξομεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="594">κἀκεῖ
+                            μερίμνας οἱ θανούμενοι βροτῶν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="595">οὐκ οἶδ’
+                            ὅποι τις τρέψεται· τὸ γὰρ θανεῖν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="596">κακῶν
+                            μέγιστον φάρμακον νομίζεται. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="597">ἀλλʼ, ὦ
+                            μέγιστον ἐκπρέπουσʼ εὐψυχίᾳ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="598">πασῶν
+                            γυναικῶν, ἴσθι, τιμιωτάτη </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="599">καὶ ζῶσʼ
+                            ὑφʼ ἡμῶν καὶ θανοῦσʼ ἔσῃ πολύ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="600">καὶ
+                            χαῖρε· δυσφημεῖν γὰρ ἅζομαι θεάν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="601">ᾗ σὸν
+                            κατῆρκται σῶμα, Δήμητρος κόρην. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="602"
+                            rend="indent">ὦ παῖδες, οἰχόμεσθα· λύεται μέλη </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="603">λύπῃ·
+                            λάβεσθε κεἰς ἕδραν μʼ ἐρείσατε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="604">αὐτοῦ
+                            πέπλοισι τοῖσδε κρύψαντες, τέκνα. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="605">ὡς οὔτε
+                            τούτοις ἥδόμαι πεπραγμένοις, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="606">χρησμοῦ
+                            τε μὴ κρανθέντος οὐ βιώσιμον· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="607">μείζων
+                            γὰρ ἄτη· συμφορὰ δὲ καὶ τάδε. </l>
+                    </sp>
+                </div>
+
+                <milestone n="608" unit="card" resp="perseus"/>
+
+
+                <div type="textpart" subtype="choral">
+                    <div type="textpart" subtype="strophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="608"
+                                >οὔτινά φημι θεῶν ἄτερ ὄλβιον, οὐ βαρύποτμον, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="609">ἄνδρα
+                                γενέσθαι· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="610">οὐδὲ
+                                τὸν αὐτὸν ἀεὶ βεβάναι δόμον </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="611"
+                                >εὐτυχίᾳ· παρὰ δʼ ἄλλαν ἄλλα </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="612">μοῖρα
+                                διώκει. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="613">τὸν
+                                μὲν ἀφʼ ὑψηλῶν βραχὺν ᾤκισε, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="614">τὸν
+                                δʼ ἀλέταν εὐδαίμονα τεύχει. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="615"
+                                >μόρσιμα δʼ οὔτι φυγεῖν θέμις, οὐ σοφί- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="616">ᾳ τις
+                                ἀπώσεται, ἀλλὰ μάταν ὁ πρό- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="617">θυμος
+                                ἀεὶ πόνον ἕξει. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="618" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="618">ἀλλὰ
+                                σὺ μὴ προπίτνων τὰ θεῶν φέρε, μηδʼ ὑπεράλγει </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="620"
+                                >φροντίδα λύπᾳ· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="621"
+                                >εὐδόκιμον γὰρ ἔχει θανάτου μέρος </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="622">ἁ
+                                μελέα πρό τʼ ἀδελφῶν καὶ γᾶς· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="623">οὐδʼ
+                                ἀκλεής νιν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="624">δόξα
+                                πρὸς ἀνθρώπων ὑποδέξεται· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="625">ἁ δʼ
+                                ἀρετὰ βαίνει διὰ μόχθων. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="626">ἄξια
+                                μὲν πατρός, ἄξια δʼ εὐγενί- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="627">ας
+                                τάδε γίγνεται· εἰ δὲ σέβεις θανά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="628">τους
+                                ἀγαθῶν, μετέχω σοι. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629">
+                                <gap reason="lost" rend=" . . . . . . . "/>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629a">
+                                <gap reason="lost" rend=" . . . . . . . "/>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629b">
+                                <gap reason="lost" rend=" . . . . . . . "/>
+                            </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="629c">
+                                <gap reason="lost" rend=" . . . . . . . "/>
+                            </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="630" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="episode">
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="630">ὦ τέκνα,
+                            χαίρετʼ· Ἰόλεως δὲ ποῦ γέρων; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="631">μήτηρ τε
+                            πατρὸς τῆσδʼ ἕδρας ἀποστατεῖ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="632">πάρεσμεν,
+                            οἵα δή γʼ ἐμοῦ παρουσία. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="633">τί χρῆμα
+                            κεῖσαι καὶ κατηφὲς ὄμμʼ ἔχεις; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="634">φροντίς
+                            τις ἦλθʼ οἰκεῖος, ᾗ συνειχόμην. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="635">ἔπαιρέ
+                            νυν σεαυτόν, ὄρθωσον κάρα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="636">γέροντές
+                            ἐσμεν κοὐδαμῶς ἐρρώμεθα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="637">ἥκω γε
+                            μέντοι χάρμα σοι φέρων μέγα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="638">τίς δʼ εἶ
+                            σύ; ποῦ σοι συντυχὼν ἀμνημονῶ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="639">Ὕλλου
+                            πενέστης· οὔ με γιγνώσκεις ὁρῶν; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="640">ὦ
+                            φίλταθʼ, ἥκεις ἆρα σωτὴρ νῷν βλάβης; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="641">μάλιστα·
+                            καὶ πρός γʼ εὐτυχεῖς τὰ νῦν τάδε. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="642">ὦ μῆτερ
+                            ἐσθλοῦ παιδός, Ἀλκμήνην λέγω, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="643">ἔξελθʼ,
+                            ἄκουσον τοῦδε φιλτάτους λόγους. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="644">πάλαι γὰρ
+                            ὠδίνουσα τῶν ἀφιγμένων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="645">ψυχὴν
+                            ἐτήκου νόστος εἰ γενήσεται. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="646">τί χρῆμʼ
+                            ἀϋτῆς πᾶν τόδʼ ἐπλήσθη στέγος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="647">Ἰόλαε;
+                            μῶν τίς σʼ αὖ βιάζεται παρὼν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="648">κῆρυξ ἀπʼ
+                            Ἄργους; ἀσθενὴς μὲν ἥ γʼ ἐμὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="649">ῥώμη,
+                            τοσόνδε δʼ εἰδέναι σʼ ἐχρῆν, ξένε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="650">οὐκ ἔστʼ
+                            ἄγειν σε τούσδʼ ἐμοῦ ζώσης ποτέ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="651">ἦ τἄρ’
+                            ἐκείνου μὴ νομιζοίμην ἐγὼ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="652">μήτηρ
+                            ἔτʼ· εἰ δὲ τῶνδε προσθίξῃ χερί, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="653">δυοῖν
+                            γερόντοιν οὐ καλῶς ἀγωνιῇ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="654">θάρσει,
+                            γεραιά, μὴ τρέσῃς· οὐκ Ἀργόθεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="655">κῆρυξ
+                            ἀφῖκται πολεμίους λόγους ἔχων.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="656">τί γὰρ
+                            βοὴν ἔστησας ἄγγελον φόβου; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="657">σέ,
+                            πρόσθε ναοῦ τοῦδʼ ὅπως βαίης πέλας. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="658">οὐκ ἴσμεν
+                            ἡμεῖς ταῦτα· τίς γάρ ἐσθʼ ὅδε; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="659">ἥκοντα
+                            παῖδα παιδὸς ἀγγέλλει σέθεν. </l>
+                    </sp>
+
+                    <milestone n="660" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="660">ὦ χαῖρε
+                            καὶ σὺ τοῖσδε τοῖς ἀγγέλμασιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="661">ἀτὰρ τί
+                            χώρᾳ τῇδε προσβαλὼν πόδα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="662">ποῦ νῦν
+                            ἄπεστι; τίς νιν εἶργε συμφορὰ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="663">σὺν σοὶ
+                            φανέντα δεῦρʼ ἐμὴν τέρψαι φρένα; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="664">στρατὸν
+                            καθίζει τάσσεταί θʼ ὃν ἦλθʼ ἔχων. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="665">τοῦδʼ
+                            οὐκέθʼ ἡμῖν τοῦ λόγου μέτεστι δή.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="666">μέτεστιν·
+                            ἡμῶν δʼ ἔργον ἱστορεῖν τάδε. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="667">τί δῆτα
+                            βούλῃ τῶν πεπραγμένων μαθεῖν; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="668">πόσον τι
+                            πλῆθος συμμάχων πάρεστʼ ἔχων; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="669">πολλούς·
+                            ἀριθμὸν δʼ ἄλλον οὐκ ἔχω φράσαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="670">ἴσασιν,
+                            οἶμαι, ταῦτʼ· Ἀθηναίων πρόμοι; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="671">ἴσασι·
+                            καὶ δὴ λαιὸν ἕστηκεν κέρας. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="672">ἤδη γὰρ
+                            ὡς ἐς ἔργον ὥπλισται στρατός; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="673">καὶ δὴ
+                            παρῆκται σφάγια τάξεων ἑκάς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="674">πόσον τι
+                            δʼ ἔστʼ ἄπωθεν Ἀργεῖον δόρυ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="675">ὥστʼ
+                            ἐξορᾶσθαι τὸν στρατηγὸν ἐμφανῶς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="676">τί
+                            δρῶντα; μῶν τάσσοντα πολεμίων στίχας; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="677">ᾐκάζομεν
+                            ταῦτʼ· οὐ γὰρ ἐξηκούομεν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="678">ἀλλʼ
+                            εἶμ’· ἐρήμους δεσπότας τοὐμὸν μέρος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="679">οὐκ ἂν
+                            θέλοιμι πολεμίοισι συμβαλεῖν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="680">κἄγωγε
+                            σὺν σοί· ταὐτὰ γὰρ φροντίζομεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="681">φίλοις
+                            παρόντες, ὡς ἔοιγμεν, ὠφελεῖν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="682">ἥκιστα
+                            πρὸς σοῦ μῶρον ἦν εἰπεῖν ἔπος. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="683">καὶ μὴ
+                            μετασχεῖν γʼ ἀλκίμου μάχης φίλοις. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="684">οὐκ ἔστʼ
+                            ἐν ὄψει τραῦμα μὴ δρώσης χερός. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="685">τί δʼ; οὐ
+                            σθένοιμι κἂν ἐγὼ δι’ ἀσπίδος; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="686">σθένοις
+                            ἄν, ἀλλὰ πρόσθεν αὐτὸς ἂν πέσοις. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="687">οὐδεὶς
+                            ἔμʼ ἐχθρῶν προσβλέπων ἀνέξεται. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="688">οὐκ
+                            ἔστιν, ὦ τᾶν, ἥ ποτʼ ἦν ῥώμη σέθεν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="689">ἀλλʼ οὖν
+                            μαχοῦνται γʼ ἀριθμὸν οὐκ ἐλάσσοσι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="690">σμικρὸν
+                            τὸ σὸν σήκωμα προστίθης φίλοις.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="691">μή τοί μʼ
+                            ἔρυκε δρᾶν παρεσκευασμένον. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="692">δρᾶν μὲν
+                            σύ γʼ οὐχ οἷός τε, βούλεσθαι δʼ ἴσως. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="693">ὡς μὴ
+                            μενοῦντα τἄλλα σοι λέγειν πάρα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="694">πῶς οὖν
+                            ὁπλίταις τευχέων ἄτερ φανῇ; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἰόλαος</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="695">ἔστʼ ἐν
+                            δόμοισιν ἔνδον αἰχμάλωθʼ ὅπλα, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="696">τοῖς δʼ
+                            οὖσι χρησόμεσθα· κἀποδώσομεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="697">ζῶντες,
+                            θανόντας δʼ οὐκ ἀπαιτήσει θεός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="698">ἀλλʼ
+                            εἴσιθʼ εἴσω κἀπὸ πασσάλων ἑλὼν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="699">ἔνεγχ’
+                            ὁπλίτην κόσμον ὡς τάχιστά μοι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="700">αἰσχρὸν
+                            γὰρ οἰκούρημα γίγνεται τόδε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="701">τοὺς μὲν
+                            μάχεσθαι, τοὺς δὲ δειλίᾳ μένειν. </l>
+                    </sp>
+
+                    <milestone n="702" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="anapests">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="702">λῆμα
+                                μὲν οὔπω στόρνυσι χρόνος </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="703">τὸ
+                                σόν, ἀλλʼ ἡβᾷ, σῶμα δὲ φροῦδον. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="704">τί
+                                πονεῖς ἄλλως ἃ σὲ μὲν βλάψει, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="705"
+                                >σμικρὰ δʼ ὀνήσει πόλιν ἡμετέραν; </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="706">χρὴ
+                                γνωσιμαχεῖν τὴν ἡλικίαν, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="707">τὰ δʼ
+                                ἀμήχανʼ ἐᾶν· οὐκ ἔστιν ὅπως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="708">ἥβην
+                                κτήσῃ πάλιν αὖθις. </l>
+                        </sp>
+
+                        <milestone n="709" unit="card" resp="perseus"/>
+
+                        <sp>
+                            <speaker>Ἀλκμήνη</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="709">τί
+                                χρῆμα μέλλεις σῶν φρενῶν οὐκ ἔνδον ὢν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="710"
+                                >λιπεῖν μʼ ἔρημον σὺν τέκνοις ἐμοῖς; <gap reason="ellipsis"
+                                    rend=" . . "/></l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="711"
+                                >ἀνδρῶν γὰρ ἀλκή· σοὶ δὲ χρῆν τούτων μέλειν. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἀλκμήνη</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="712">τί
+                                δʼ; ἢν θάνῃς σύ, πῶς ἐγὼ σωθήσομαι; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="713"
+                                >παιδὸς μελήσει παισὶ τοῖς λελειμμένοις. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἀλκμήνη</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="714">ἢν δʼ
+                                οὖν, ὃ μὴ γένοιτο, χρήσωνται τύχῃ; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="715">οἵδ’
+                                οὐ προδώσουσίν σε, μὴ τρέσῃς, ξένοι. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἀλκμήνη</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="716"
+                                >τοσόνδε γάρ τοι θάρσος, οὐδὲν ἄλλʼ ἔχω. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="717">καὶ
+                                Ζηνὶ τῶν σῶν, οἶδʼ ἐγώ, μέλει πόνων. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἀλκμήνη</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="718">φεῦ· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="718a">Ζεὺς
+                                ἐξ ἐμοῦ μὲν οὐκ ἀκούσεται κακῶς· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="719">εἰ δʼ
+                                ἐστὶν ὅσιος αὐτὸς οἶδεν εἰς ἐμέ. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="720">ὅπλων
+                                μὲν ἤδη τήνδʼ ὁρᾷς παντευχίαν, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="721"
+                                >φθάνοις δʼ ἂν οὐκ ἂν τοῖσδε συγκρύπτων δέμας· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="722">ὡς
+                                ἐγγὺς ἁγών, καὶ μάλιστʼ Ἄρης στυγεῖ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="723"
+                                >μέλλοντας· εἰ δὲ τευχέων φοβῇ βάρος, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="724">νῦν
+                                μὲν πορεύου γυμνός, ἐν δὲ τάξεσιν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="725">κόσμῳ
+                                πυκάζου τῷδʼ· ἐγὼ δʼ οἴσω τέως.</l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="726">καλῶς
+                                ἔλεξας· ἀλλʼ ἐμοὶ πρόχειρʼ ἔχων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="727">τεύχη
+                                κόμιζε, χειρὶ δʼ ἔνθες ὀξύην, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="728">λαιόν
+                                τʼ ἔπαιρε πῆχυν, εὐθύνων πόδα. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="729">ἦ
+                                παιδαγωγεῖν γὰρ τὸν ὁπλίτην χρεών; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="730"
+                                >ὄρνιθος οὕνεκʼ ἀσφαλῶς πορευτέον. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="731">εἴθʼ
+                                ἦσθα δυνατὸς δρᾶν ὅσον πρόθυμος εἶ. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="732"
+                                >ἔπειγε· λειφθεὶς δεινὰ πείσομαι μάχης. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="733">σύ
+                                τοι βραδύνεις, οὐκ ἐγὼ δοκῶ τι δρᾶν. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="734"
+                                >οὔκουν ὁρᾷς μου κῶλον ὡς ἐπείγεται; </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="735">ὁρῶ
+                                δοκοῦντα μᾶλλον ἢ σπεύδοντά σε. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="736">οὐ
+                                ταῦτα λέξεις, ἡνίκʼ ἂν λεύσσῃς μʼ ἐκεῖ. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="737">τί
+                                δρῶντα; βουλοίμην δʼ ἂν εὐτυχοῦντά γε. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="738">διʼ
+                                ἀσπίδος θείνοντα πολεμίων τινά. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Θεράπων</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="739">εἰ δή
+                                ποθʼ ἥξομέν γε· τοῦτο γὰρ φόβος. </l>
+                        </sp>
+
+                        <sp>
+                            <speaker>Ἰόλαος</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="740">φεῦ· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="740a"
+                                >εἴθʼ, ὦ βραχίων, οἷον ἡβήσαντά σε </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="741"
+                                >μεμνήμεθʼ ἡμεῖς, ἡνίκα ξὺν Ἡρακλεῖ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="742"
+                                >Σπάρτην ἐπόρθεις, σύμμαχος γένοιό μοι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="743"
+                                >τοιοῦτος· οἵαν ἂν τροπὴν Εὐρυσθέως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="744"
+                                >θείμην· ἐπεί τοι καὶ κακὸς μένειν δόρυ. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="745">ἔστιν
+                                δʼ ἐν ὄλβῳ καὶ τόδʼ οὐκ ὀρθῶς ἔχον, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="746"
+                                >εὐψυχίας δόκησις· οἰόμεσθα γὰρ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="747">τὸν
+                                εὐτυχοῦντα πάντʼ ἐπίστασθαι καλῶς. </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="748" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="choral">
+                    <div type="textpart" subtype="strophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="748">Γᾶ
+                                καὶ παννύχιος σελά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="749">να
+                                καὶ λαμπρόταται θεοῦ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="750"
+                                >φαεσίμβροτοι αὐγαί, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="751"
+                                >ἀγγελίαν μοι ἐνέγκαιτʼ· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="752"
+                                >ἰαχήσατε δʼ οὐρανῷ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="753">καὶ
+                                παρὰ θρόνον ἀρχέταν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="754"
+                                >γλαυκᾶς ἐν Ἀθάνας. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="755">μέλλω
+                                τᾶς πατριώτιδος </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="756">γᾶς,
+                                μέλλω καὶ ὑπὲρ δόμων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="757"
+                                >ἱκέτας ὑποδεχθεὶς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="758"
+                                >κίνδυνον πολιῷ τεμεῖν σιδάρῳ. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="759" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="759"
+                                >δεινὸν μὲν πόλιν ὡς Μυκή- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="760">νας
+                                εὐδαίμονα καὶ δορὸς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="761"
+                                >πολυαίνετον ἀλκᾷ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="762">μῆνιν
+                                ἐμᾷ χθονὶ κεύθειν· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="763">κακὸν
+                                δʼ, ὦ πόλις, εἰ ξένους </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="764"
+                                >ἱκτῆρας παραδώσομεν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="765"
+                                >κελεύμασιν Ἄργους. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="766">Ζεύς
+                                μοι σύμμαχος, οὐ φοβοῦ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="767">μαι,
+                                Ζεύς μοι χάριν ἐνδίκως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="768">ἔχει·
+                                οὔποτε θνατῶν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="769"
+                                >ἥσσους <add>δαίμονες</add> ἔκ γʼ ἐμοῦ φανοῦνται. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="770" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="strophe" n="2">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="770">ἀλλʼ,
+                                ὦ πότνια — σὸν γὰρ οὖ-</l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="771">δας
+                                    <del>γᾶς</del>, σὸν καὶ πόλις, ἇς σὺ μά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="772">τηρ
+                                δέσποινά τε καὶ φύλαξ — </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="773"
+                                >πόρευσον ἄλλᾳ τὸν οὐ δικαίως </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="774">τᾷδʼ
+                                ἐπάγοντα δορυσσοῦν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="775"
+                                >στρατὸν Ἀργόθεν· οὐ γὰρ ἐμᾷ γʼ ἀρετᾷ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="776"
+                                >δίκαιός εἰμʼ ἐκπεσεῖν μελάθρων. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="777" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="2">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="777">ἐπεί
+                                σοι πολύθυτος ἀεὶ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="778">τιμὰ
+                                κραίνεται, οὐδὲ λά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="779">θει
+                                μηνῶν φθινὰς ἁμέρα, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="780">νέων
+                                τʼ ἀοιδαὶ χορῶν τε μολπαί. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="781"
+                                >ἀνεμόεντι δʼ ἐπʼ ὄχθῳ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="782"
+                                >ὀλολύγματα παννυχίοις ὑπὸ παρ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="783">θένων
+                                ἰαχεῖ ποδῶν κρότοισιν. </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="784" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="episode">
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="784">δέσποινα,
+                            μύθους σοί τε συντομωτάτους </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="785">
+                            <sic>κλύειν ἐμοί τε τῷδε καλλίστους φέρω.</sic>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="786">νικῶμεν
+                            ἐχθροὺς καὶ τροπαῖʼ ἱδρύεται </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="787"
+                            >παντευχίαν ἔχοντα πολεμίων σέθεν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="788">ὦ
+                            φίλταθʼ, ἥδε σʼ ἡμέρα διήλασεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="789"
+                            >ἐλευθερῶσαι τοῖσδε τοῖς ἀγγέλμασιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="790">μιᾶς δʼ
+                            ἔμʼ οὔπω συμφορᾶς ἐλευθεροῖς· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="791">φόβος γὰρ
+                            εἴ μοι ζῶσιν οὓς ἐγὼ θέλω. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="792">ζῶσιν
+                            μέγιστόν γʼ εὐκλεεῖς κατὰ στρατόν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="793">ὁ μὲν
+                            γέρων οὐκ ἔστιν Ἰόλεως ὅδε; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="794">μάλιστα,
+                            πράξας δʼ ἐκ θεῶν κάλλιστα δή. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="795">τί δʼ
+                            ἔστι; μῶν τι κεδνὸν ἠγωνίζετο; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="796">νέος
+                            μεθέστηκʼ ἐκ γέροντος αὖθις αὖ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="797">θαυμάστʼ
+                            ἔλεξας· ἀλλά σʼ εὐτυχῆ φίλων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="798">μάχης
+                            ἀγῶνα πρῶτον ἀγγεῖλαι θέλω. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="799">εἷς μου
+                            λόγος σοι πάντα σημανεῖ τάδε. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="800">ἐπεὶ γὰρ
+                            ἀλλήλοισιν ὁπλίτην στρατὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="801">κατὰ
+                            στόμʼ ἐκτείνοντες ἀντετάξαμεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="802">ἐκβὰς
+                            τεθρίππων Ὕλλος ἁρμάτων πόδα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="803">ἔστη
+                            μέσοισιν ἐν μεταιχμίοις δορός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="804">κἄπειτ’
+                            ἔλεξεν· Ὦ στρατήγʼ ὃς Ἀργόθεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805">ἥκεις, τί
+                            τήνδε γαῖαν οὐκ εἰάσαμεν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805a">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="805b">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="806">καὶ τὰς
+                            Μυκήνας οὐδὲν ἐργάσῃ κακὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="807">ἀνδρὸς
+                            στερήσας· ἀλλʼ ἐμοὶ μόνος μόνῳ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="808">μάχην
+                            συνάψας, ἢ κτανὼν ἄγου λαβὼν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="809">τοὺς
+                            Ἡρακλείους παῖδας ἢ θανὼν ἐμοὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="810">τιμὰς
+                            πατρῴους καὶ δόμους ἔχειν ἄφες. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="811">στρατὸς
+                            δʼ ἐπῄνεσ’, ἔς τʼ ἀπαλλαγὰς πόνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="812">καλῶς
+                            λελέχθαι μῦθον ἔς τʼ εὐψυχίαν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="813">ὃ δʼ οὔτε
+                            τοὺς κλύοντας αἰδεσθεὶς λόγων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="814">οὔτʼ
+                            αὐτὸς αὑτοῦ δειλίαν στρατηγὸς ὢν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="815">ἐλθεῖν
+                            ἐτόλμησʼ ἐγγὺς ἀλκίμου δορός, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="816">ἀλλʼ ἦν
+                            κάκιστος· εἶτα τοιοῦτος γεγὼς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="817">τοὺς
+                            Ἡρακλείους ἦλθε δουλώσων γόνους. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="818">Ὕλλος μὲν
+                            οὖν ἀπῴχετ’ ἐς τάξιν πάλιν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="819">μάντεις
+                            δʼ, ἐπειδὴ μονομάχου διʼ ἀσπίδος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="820">διαλλαγὰς
+                            ἔγνωσαν οὐ τελουμένας, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="821">ἔσφαζον,
+                            οὐκ ἔμελλον, ἀλλʼ ἀφίεσαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="822">λαιμῶν
+                                <sic>βροτείων</sic> εὐθὺς οὔριον φόνον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="823">οἳ δʼ
+                            ἅρματʼ εἰσέβαινον, οἳ δʼ ὑπʼ ἀσπίδων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="824">πλευροῖς
+                            ἔκρυπτον πλεύρʼ· Ἀθηναίων δʼ ἄναξ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="825">στρατῷ
+                            παρήγγελλ’ οἷα χρὴ τὸν εὐγενῆ· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="826">Ὦ
+                            ξυμπολῖται, τῇ τε βοσκούσῃ χθονὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="827">καὶ τῇ
+                            τεκούσῃ νῦν τινʼ ἀρκέσαι χρεών. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="828">ὃ δʼ αὖ
+                            τό τʼ Ἄργος μὴ καταισχῦναι θέλειν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="829">καὶ τὰς
+                            Μυκήνας συμμάχους ἐλίσσετο. </l>
+                        <milestone n="830" unit="card" resp="perseus"/>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="830">ἐπεὶ δʼ
+                            ἐσήμηνʼ ὄρθιον Τυρσηνικῇ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="831">σάλπιγγι
+                            καὶ συνῆψαν ἀλλήλοις μάχην, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="832">πόσον
+                            τινʼ αὐχεῖς πάταγον ἀσπίδων βρέμειν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="833">πόσον
+                            τινὰ στεναγμὸν οἰμωγήν θʼ ὁμοῦ; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="834">τὰ πρῶτα
+                            μέν νυν πίτυλος Ἀργείου δορὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="835">ἐρρήξαθʼ
+                            ἡμᾶς· εἶτʼ ἐχώρησαν πάλιν. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="836">τὸ
+                            δεύτερον δὲ ποὺς ἐπαλλαχθεὶς ποδί, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="837">ἀνὴρ δʼ
+                            ἐπʼ ἀνδρὶ στάς, ἐκαρτέρει μάχη· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="838">πολλοὶ δʼ
+                            ἔπιπτον. ἦν δὲ τοῦ κελεύματος· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="839">Ὦ τὰς
+                            Ἀθήνας — Ὦ τὸν Ἀργείων γύην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="840"
+                            >σπείροντες — οὐκ ἀρήξετʼ αἰσχύνην πόλει; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="841">μόλις δὲ
+                            πάντα δρῶντες οὐκ ἄτερ πόνων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="842"
+                            >ἐτρεψάμεσθʼ Ἀργεῖον ἐς φυγὴν δόρυ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="843"
+                            rend="indent">κἀνταῦθʼ ὁ πρέσβυς Ὕλλον ἐξορμώμενον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="844">ἰδών,
+                            ὀρέξας ἱκέτευσε δεξιὰν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="845">Ἰόλαος
+                            ἐμβῆσαί νιν ἵππειον δίφρον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="846">λαβὼν δὲ
+                            χερσὶν ἡνίας Εὐρυσθέως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="847">πώλοις
+                            ἐπεῖχε. τἀπὸ τοῦδʼ ἤδη κλύων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="848">λέγοιμʼ
+                            ἂν ἄλλων, δεῦρο δʼ αὐτὸς εἰσιδών. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="849"
+                            >Παλληνίδος γὰρ σεμνὸν ἐκπερῶν πάγον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="850">δίας
+                            Ἀθάνας, ἅρμʼ ἰδὼν Εὐρυσθέως, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="851">ἠράσαθʼ
+                            Ἥβῃ Ζηνί θʼ, ἡμέραν μίαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="852">νέος
+                            γενέσθαι κἀποτείσασθαι δίκην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="853">ἐχθρούς.
+                            κλύειν δὴ θαύματος πάρεστί σοι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="854">δισσὼ γὰρ
+                            ἀστέρʼ ἱππικοῖς ἐπὶ ζυγοῖς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="855">σταθέντʼ
+                            ἔκρυψαν ἅρμα λυγαίῳ νέφει· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="856">σὸν δὴ
+                            λέγουσι παῖδά γʼ οἱ σοφώτεροι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="857">Ἥβην θʼ·
+                            ὃ δʼ ὄρφνης ἐκ δυσαιθρίου νέων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="858">βραχιόνων
+                            ἔδειξεν ἡβητὴν τύπον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="859">αἱρεῖ δʼ
+                            ὁ κλεινὸς Ἰόλεως Εὐρυσθέως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="860">τέτρωρον
+                            ἅρμα πρὸς πέτραις Σκιρωνίσιν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="861">δεσμοῖς
+                            τε δήσας χεῖρας ἀκροθίνιον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="862">κάλλιστον
+                            ἥκει τὸν στρατηλάτην ἄγων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="863">τὸν
+                            ὄλβιον πάροιθε. τῇ δὲ νῦν τύχῃ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="864">βροτοῖς
+                            ἅπασι λαμπρὰ κηρύσσει μαθεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="865">τὸν
+                            εὐτυχεῖν δοκοῦντα μὴ ζηλοῦν, πρὶν ἂν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="866">θανόντʼ
+                            ἴδῃ τις· ὡς ἐφήμεροι τύχαι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="867">ὦ Ζεῦ
+                            τροπαῖε, νῦν ἐμοὶ δεινοῦ φόβου </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="868">ἐλεύθερον
+                            πάρεστιν ἦμαρ εἰσιδεῖν. </l>
+                    </sp>
+
+                    <milestone n="869" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="869">ὦ Ζεῦ,
+                            χρόνῳ μὲν τἄμ’ ἐπεσκέψω κακά, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="870">χάριν δʼ
+                            ὅμως σοι τῶν πεπραγμένων ἔχω· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="871">καὶ παῖδα
+                            τὸν ἐμὸν πρόσθεν οὐ δοκοῦσʼ ἐγὼ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="872">θεοῖς
+                            ὁμιλεῖν νῦν ἐπίσταμαι σαφῶς. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="873"
+                            rend="indent">ὦ τέκνα, νῦν δὴ νῦν ἐλεύθεροι πόνων, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="874">ἐλεύθεροι
+                            δὲ τοῦ κακῶς ὀλουμένου </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="875">Εὐρυσθέως
+                            ἔσεσθε καὶ πόλιν πατρὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="876">ὄψεσθε,
+                            κλήρους δʼ ἐμβατεύσετε χθονὸς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="877">καὶ θεοῖς
+                            πατρῴοις θύσεθʼ, ὧν ἀπειργμένοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="878">ξένοι
+                            πλανήτην εἴχετʼ ἄθλιον βίον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="879"
+                            rend="indent">ἀτὰρ τί κεύθων Ἰόλεως σοφόν ποτε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="880">Εὐρυσθέως
+                            ἐφείσαθʼ ὥστε μὴ κτανεῖν; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="881">λέξον·
+                            παρʼ ἡμῖν μὲν γὰρ οὐ σοφὸν τόδε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="882">ἐχθροὺς
+                            λαβόντα μὴ ἀποτείσασθαι δίκην. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="883">τὸ σὸν
+                            προτιμῶν, ὥς νιν ὀφθαλμοῖς ἴδοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="884"
+                                ><sic>κρατοῦντα</sic> καὶ σῇ δεσποτούμενον χερί. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="885">οὐ μὴν
+                            ἑκόντα γʼ αὐτόν, ἀλλὰ πρὸς βίαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="886">ἔζευξʼ
+                            ἀνάγκῃ· καὶ γὰρ οὐκ ἐβούλετο </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="887">ζῶν ἐς
+                            σὸν ἐλθεῖν ὄμμα καὶ δοῦναι δίκην. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="888">ἀλλʼ, ὦ
+                            γεραιά, χαῖρε καὶ μέμνησό μοι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="889">ὃ πρῶτον
+                            εἶπας, ἡνίκʼ ἠρχόμην λόγου, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="890"
+                            >ἐλευθερώσειν μʼ· ἐν δὲ τοῖς τοιοῖσδε χρὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="891">ἀψευδὲς
+                            εἶναι τοῖσι γενναίοις στόμα. </l>
+                    </sp>
+                </div>
+
+                <milestone n="892" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="choral">
+                    <div type="textpart" subtype="strophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="892">Ἐμοὶ
+                                χορὸς μὲν ἡδύς, εἰ λίγεια λω- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="893">τοῦ
+                                χάρις <sic>ενι δαι</sic>· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="894">εἴη
+                                δʼ εὔχαρις Ἀφροδί- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="895">τα·
+                                τερπνὸν δέ τι καὶ φίλων ἆρʼ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="896"
+                                >εὐτυχίαν ἰδέσθαι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="897">τῶν
+                                πάρος οὐ δοκούντων. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="898">πολλὰ
+                                γὰρ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="899"
+                                >τίκτει Μοῖρα τελεσσιδώ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="900">τειρʼ
+                                Αἰών τε Χρόνου παῖς.</l>
+                        </sp>
+                    </div>
+
+                    <milestone n="901" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="1">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="901">ἔχεις
+                                ὁδόν τινʼ, ὦ πόλις, δίκαιον — οὐ </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="902">χρή
+                                ποτε τοῦδʼ ἀφέσθαι, — </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="903">τιμᾶν
+                                θεούς· ὁ <add>δὲ</add> μή σε φά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="904">σκων
+                                ἐγγὺς μανιῶν ἐλαύνει, </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="905"
+                                >δεικνυμένων ἐλέγχων </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="906"
+                                >τῶνδʼ· ἐπίσημα γάρ τοι </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="907">θεὸς
+                                παραγ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="908"
+                                >γέλλει, τῶν ἀδίκων παραι- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="909">ρῶν
+                                φρονήματος αἰεί. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="910" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="strophe" n="2">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="910">ἔστιν
+                                ἐν οὐρανῷ βεβα- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="911">κὼς
+                                τεὸς γόνος, ὦ γεραι- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="912">ά·
+                                φεύγει λόγον ὡς τὸν Ἅι- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="913">δα
+                                δόμον κατέβα, πυρὸς </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="914">δεινᾷ
+                                φλογὶ σῶμα δαισθείς· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="915">Ἥβας
+                                τʼ ἐρατὸν χροΐζει </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="916">λέχος
+                                χρυσέαν κατʼ αὐλάν. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="917">ὦ
+                                Ὑμέναιε, δισσοὺς παῖ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="918">δας
+                                Διὸς ἠξίωσας. </l>
+                        </sp>
+                    </div>
+
+                    <milestone n="919" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="antistrophe" n="2">
+                        <sp>
+                            <speaker>Χορός</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="919"
+                                >συμφέρεται τὰ πολλὰ πολ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="920">λοῖς·
+                                καὶ γὰρ πατρὶ τῶνδʼ Ἀθά- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="921">ναν
+                                λέγουσʼ ἐπίκουρον εἶ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="922">ναι,
+                                καὶ τούσδε θεᾶς πόλις </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="923">καὶ
+                                λαὸς ἔσωσε κείνας· </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="924">ἔσχεν
+                                δʼ ὕβριν ἀνδρὸς ᾧ θυ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="925">μὸς
+                                ἦν πρὸ δίκας βίαιος. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="926"
+                                >μήποτʼ ἐμοὶ φρόνημα ψυ- </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="927">χά τʼ
+                                ἀκόρεστος εἴη. </l>
+                        </sp>
+                    </div>
+                </div>
+
+                <milestone n="928" unit="card" resp="perseus"/>
+
+                <div type="textpart" subtype="episode">
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="928">δέσποινʼ,
+                            ὁρᾷς μέν, ἀλλʼ ὅμως εἰρήσεται, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="929">Εὐρυσθέα
+                            σοι τόνδʼ ἄγοντες ἥκομεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="930">ἄελπτον
+                            ὄψιν, τῷδέ τʼ οὐχ ἧσσον τύχην· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="931">οὐ γάρ
+                            ποτʼ ηὔχει χεῖρας ἵξεσθαι σέθεν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="932">ὅτʼ ἐκ
+                            Μυκηνῶν πολυπόνῳ σὺν ἀσπίδι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="933">ἔστειχε
+                            μείζω τῆς δίκης φρονῶν, πόλιν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="934">πέρσων
+                            Ἀθηνᾶς. ἀλλὰ τὴν ἐναντίαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="935">δαίμων
+                            ἔθηκε, καὶ μετέστησεν τύχην. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="936">Ὕλλος μὲν
+                            οὖν ὅ τʼ ἐσθλὸς Ἰόλεως βρέτας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="937">Διὸς
+                            τροπαίου καλλίνικον ἵστασαν· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="938">ἐμοὶ δὲ
+                            πρὸς σὲ τόνδʼ ἐπιστέλλουσʼ ἄγειν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="939">τέρψαι
+                            θέλοντες σὴν φρένʼ· ἐκ γὰρ εὐτυχοῦς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="940">ἥδιστον
+                            ἐχθρὸν ἄνδρα δυστυχοῦνθʼ ὁρᾶν.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="941">ὦ μῖσος,
+                            ἥκεις; εἷλέ σʼ ἡ Δίκη χρόνῳ; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="942">πρῶτον
+                            μὲν οὖν μοι δεῦρʼ ἐπίστρεψον κάρα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="943">καὶ τλῆθι
+                            τοὺς σοὺς προσβλέπειν ἐναντίον </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="944">ἐχθρούς·
+                            κρατῇ γὰρ νῦν γε κοὐ κρατεῖς ἔτι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="945">ἐκεῖνος
+                            εἶ σύ — βούλομαι γὰρ εἰδέναι — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="946">ὃς πολλὰ
+                            μὲν τὸν ὄνθʼ ὅπου ’στὶ νῦν ἐμὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="947">παῖδʼ
+                            ἠξίωσας, ὦ πανοῦργʼ, ἐφυβρίσαι; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="948">τί γὰρ σὺ
+                            κεῖνον οὐκ ἔτλης καθυβρίσαι; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="949">ὃς καὶ
+                            παρʼ Ἅιδην ζῶντά νιν κατήγαγες, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="950">ὕδρας
+                            λέοντάς τʼ ἐξαπολλύναι λέγων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="951">ἔπεμπες.
+                            ἄλλα δʼ οἷ’ ἐμηχανῶ κακὰ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="952">σιγῶ·
+                            μακρὸς γὰρ μῦθος ἂν γένοιτό μοι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="953">κοὐκ
+                            ἤρκεσέν σοι ταῦτα τολμῆσαι μόνον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="954">ἀλλʼ ἐξ
+                            ἁπάσης κἀμὲ καὶ τέκνʼ Ἑλλάδος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="955">ἤλαυνες
+                            ἱκέτας δαιμόνων καθημένους, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="956">τοὺς μὲν
+                            γέροντας, τοὺς δὲ νηπίους ἔτι. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="957">ἀλλʼ
+                            ηὗρες ἄνδρας καὶ πόλισμʼ ἐλεύθερον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="958">οἵ σʼ οὐκ
+                            ἔδεισαν. δεῖ σε κατθανεῖν κακῶς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="959">καὶ
+                            κερδανεῖς ἅπαντα· χρῆν γὰρ οὐχ ἅπαξ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="960">θνῄσκειν
+                            σὲ πολλὰ πήματʼ ἐξειργασμένον. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="961">οὐκ ἔστʼ
+                            ἀνυστὸν τόνδε σοι κατακτανεῖν. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Θεράπων</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="962">ἄλλως ἄρʼ
+                            αὐτὸν αἰχμάλωτον εἵλομεν; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="963">εἴργει δὲ
+                            δὴ τίς τόνδε μὴ θνῄσκειν νόμος; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="964">τοῖς
+                            τῆσδε χώρας προστάταισιν οὐ δοκεῖ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="965">τί δὴ
+                            τόδʼ; ἐχθροὺς τοισίδʼ οὐ καλὸν κτανεῖν;</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="966">οὐχ
+                            ὅντινʼ ἄν γε ζῶνθʼ ἕλωσιν ἐν μάχῃ. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="967">καὶ ταῦτα
+                            δόξανθʼ Ὕλλος ἐξηνέσχετο; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="968">χρῆν δʼ
+                            αὐτόν, οἶμαι, τῇδʼ ἀπιστῆσαι χθονί; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="969">χρῆν
+                            τόνδε μὴ ζῆν μηδʼ ὁρᾶν <sic>φάος ἔτι.</sic>
+                        </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="970">τότʼ
+                            ἠδικήθη πρῶτον οὐ θανὼν ὅδε. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="971">οὐκ οὖν
+                            ἔτʼ ἐστὶν ἐν καλῷ δοῦναι δίκην; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="972">οὐκ ἔστι
+                            τοῦτον ὅστις ἂν κατακτάνοι. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="973">ἔγωγε·
+                            καίτοι φημὶ κἄμʼ εἶναί τινα. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="974">πολλὴν
+                            ἄρʼ ἕξεις μέμψιν, εἰ δράσεις τόδε. </l>
+                    </sp>
+
+                    <milestone n="975" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="975">φιλῶ
+                            πόλιν τήνδʼ· οὐδὲν ἀντιλεκτέον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="976">τοῦτον
+                            δʼ, ἐπείπερ χεῖρας ἦλθεν εἰς ἐμάς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="977">οὐκ ἔστι
+                            θνητῶν ὅστις ἐξαιρήσεται. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="978">πρὸς
+                            ταῦτα τὴν θρασεῖαν ὅστις ἂν θέλῃ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="979">καὶ τὴν
+                            φρονοῦσαν μεῖζον ἢ γυναῖκα χρὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="980">λέξει· τὸ
+                            δʼ ἔργον τοῦτʼ ἐμοὶ πεπράξεται. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="981">δεινόν τι
+                            καὶ συγγνωστόν, ὦ γύναι, σʼ ἔχει </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="982">νεῖκος
+                            πρὸς ἄνδρα τόνδε, γιγνώσκω καλῶς. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἐυρυσθεύς</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="983">γύναι,
+                            σάφʼ ἴσθι μή με θωπεύσοντά σε, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="984">μηδʼ ἄλλο
+                            μηδὲν τῆς ἐμῆς ψυχῆς πέρι </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="985">λέξονθʼ
+                            ὅθεν χρὴ δειλίαν ὀφλεῖν τινα. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="986">ἐγὼ δὲ
+                            νεῖκος οὐχ ἑκὼν τόδʼ ἠράμην· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="987">ᾔδη γε
+                            σοὶ μὲν αὐτανέψιος γεγώς, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="988">τῷ σῷ δὲ
+                            παιδὶ συγγενὴς Ἡρακλέει. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="989">ἀλλʼ εἴτʼ
+                            ἔχρῃζον εἴτε μή — θεὸς γὰρ ἦν — </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="990">Ἥρα με
+                            κάμνειν τήνδʼ ἔθηκε τὴν νόσον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="991">ἐπεὶ δʼ
+                            ἐκείνῳ δυσμένειαν ἠράμην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="992">κἄγνων
+                            ἀγῶνα τόνδʼ ἀγωνιούμενος, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="993">πολλῶν
+                            σοφιστὴς πημάτων ἐγιγνόμην </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="994">καὶ πόλλʼ
+                            ἔτικτον νυκτὶ συνθακῶν ἀεί, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="995">ὅπως
+                            διώσας καὶ κατακτείνας ἐμοὺς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="996">ἐχθροὺς
+                            τὸ λοιπὸν μὴ συνοικοίην φόβῳ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="997">εἰδὼς μὲν
+                            οὐκ ἀριθμὸν ἀλλʼ ἐτητύμως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="998">ἄνδρʼ
+                            ὄντα τὸν σὸν παῖδα· καὶ γὰρ ἐχθρὸς ὢν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="999">ἀκούσεται
+                                <add>’μοί</add> γʼ ἐσθλὰ χρηστὸς ὢν ἀνήρ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1000">κείνου
+                            δʼ ἀπαλλαχθέντος οὐκ ἐχρῆν μʼ ἄρα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1001"
+                            >μισούμενον πρὸς τῶνδε καὶ ξυνειδότα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1002">ἔχθραν
+                            πατρῴαν, πάντα κινῆσαι πέτρον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1003"
+                            >κτείνοντα κἀκβάλλοντα καὶ τεχνώμενον; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1004">τοιαῦτα
+                            δρῶντι τἄμʼ ἐγίγνετʼ ἀσφαλῆ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1005">οὔκουν
+                            σύ γʼ ἀναλαβοῦσα τὰς ἐμὰς τύχας </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1006">ἐχθροῦ
+                            λέοντος δυσγενῆ βλαστήματα </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1007">ἤλαυνες
+                            ἂν κακοῖσιν, ἀλλὰ σωφρόνως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1008">εἴασας
+                            οἰκεῖν Ἄργος; οὔτινʼ ἂν πίθοις. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1009">νῦν οὖν
+                            ἐπειδή μʼ οὐ διώλεσαν τότε </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1010">πρόθυμον
+                            ὄντα, τοῖσιν Ἑλλήνων νόμοις </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1011">οὐχ
+                            ἁγνός εἰμι τῷ κτανόντι κατθανών· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1012">πόλις τʼ
+                            ἀφῆκε σωφρονοῦσα, τὸν θεὸν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1013">μεῖζον
+                            τίουσα τῆς ἐμῆς ἔχθρας πολύ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1014"
+                            >προσεῖπας, ἀντήκουσας· ἐντεῦθεν δὲ χρὴ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1015">τὸν
+                            προστρόπαιον τόν τε γενναῖον καλεῖν.</l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1016">οὕτω γε
+                            μέντοι τἄμ’ ἔχεις· θανεῖν μὲν οὐ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017">χρῄζω,
+                            λιπὼν δʼ ἂν οὐδὲν ἀχθοίμην βίον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017a">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017b">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1017c">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                    </sp>
+
+                    <milestone n="1018" unit="card" resp="perseus"/>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1018"
+                            >παραινέσαι σοι σμικρόν, Ἀλκμήνη, θέλω, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1019">τὸν
+                            ἄνδρʼ ἀφεῖναι τόνδʼ, ἐπεὶ δοκεῖ πόλει. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1020">τί δʼ,
+                            ἢν θάνῃ τε καὶ πόλει πιθώμεθα; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Χορός</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1021">τὰ λῷστ’
+                            ἂν εἴη· πῶς τάδʼ οὖν γενήσεται; </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1022">ἐγὼ
+                            διδάξω ῥᾳδίως· κτανοῦσα γὰρ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1023">τόνδʼ
+                            εἶτα νεκρὸν τοῖς μετελθοῦσιν φίλων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1024">δώσω· τὸ
+                            γὰρ σῶμʼ οὐκ ἀπιστήσω χθονί, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1025">οὗτος δὲ
+                            δώσει τὴν δίκην θανὼν ἐμοί. </l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἐυρυσθεύς</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1026">κτεῖνʼ,
+                            οὐ παραιτοῦμαί σε· τήνδε δὲ πτόλιν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1027">ἐπεί μʼ
+                            ἀφῆκε καὶ κατῃδέσθη κτανεῖν, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1028">χρησμῷ
+                            παλαιῷ Λοξίου δωρήσομαι, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1029">ὃς
+                            ὠφελήσει μείζονʼ ἢ δοκεῖν χρόνῳ. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1030">θανόντα
+                            γάρ με θάψεθʼ οὗ τὸ μόρσιμον, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1031">δίας
+                            πάροιθε παρθένου Παλληνίδος· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1032">καὶ σοὶ
+                            μὲν εὔνους καὶ πόλει σωτήριος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1033">μέτοικος
+                            αἰεὶ κείσομαι κατὰ χθονός, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1034">τοῖς
+                            τῶνδε δʼ ἐκγόνοισι πολεμιώτατος, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1035">ὅταν
+                            μόλωσι δεῦρο σὺν πολλῇ χερὶ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1036">χάριν
+                            προδόντες τήνδε. τοιούτων ξένων </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1037"
+                            >προύστητε. πῶς οὖν ταῦτʼ ἐγὼ πεπυσμένος </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1038">δεῦρʼ
+                            ἦλθον, ἀλλʼ οὐ χρησμὸν ἠρόμην θεοῦ; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1039">Ἥραν
+                            νομίζων θεσφάτων κρείσσω πολὺ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1040">κοὐκ ἂν
+                            προδοῦναί μʼ. ἀλλὰ μήτε μοι χοὰς </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1041">μήθʼ
+                            αἷμʼ ἐάσῃς εἰς ἐμὸν στάξαι τόπον. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1042">κακὸν
+                            γὰρ αὐτοῖς νόστον ἀντὶ τῶνδʼ ἐγὼ </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1043">δώσω·
+                            διπλοῦν δὲ κέρδος ἕξετʼ ἐξ ἐμοῦ, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1044">ὑμᾶς τʼ
+                            ὀνήσω τούσδε τε βλάψω θανών.</l>
+                    </sp>
+
+                    <sp>
+                        <speaker>Ἀλκμήνη</speaker>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1045">τί δῆτα
+                            μέλλετʼ, εἰ πόλει σωτηρίαν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1046"
+                            >κατεργάσασθαι τοῖσί τʼ ἐξ ἡμῶν χρεών, </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1047">κτείνειν
+                            τὸν ἄνδρα τόνδʼ, ἀκούοντες τάδε; </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1048">δείκνυσι
+                            γὰρ κέλευθον ἀσφαλεστάτην· </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1049">ἐχθρὸς
+                            μὲν ἁνήρ, ὠφελεῖ δὲ κατθανών. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1050">κομίζετʼ
+                            αὐτόν, δμῶες· εἶτα χρὴ κυσὶν </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1051">δοῦναι
+                            κτανόντας· μὴ γὰρ ἐλπίσῃς ὅπως </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052">αὖθις
+                            πατρῴας ζῶν ἔμʼ ἐκβαλεῖς χθονός. </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052a">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052b">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052c">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052d">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                        <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1052e">
+                            <gap reason="lost" rend=" . . . . . . "/>
+                        </l>
+                    </sp>
+
+                    <milestone n="1053" unit="card" resp="perseus"/>
+
+                    <div type="textpart" subtype="anapests">
+                        <sp>
+                            <speaker>Ἡμιχόριον</speaker>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1053"
+                                >ταὐτὰ δοκεῖ μοι. στείχετʼ, ὀπαδοί. </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1054">τὰ
+                                γὰρ ἐξ ἡμῶν </l>
+                            <l xml:base="urn:cts:greekLit:tlg0006.tlg004.perseus-grc2" n="1055"
+                                >καθαρῶς ἔσται βασιλεῦσιν. </l>
+                        </sp>
+                    </div>
+                </div>
+            </div>
+        </body>
+    </text>
 </TEI>


### PR DESCRIPTION
Add and encode the argumentum and encode the list of the dramatis personae, as discussed in issue https://github.com/PerseusDL/canonical-greekLit/issues/1735.