### PR TITLE
(tlg0001.tlg001) revert to original πλυμμυρίς at 4.1241

### DIFF
--- a/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
+++ b/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
@@ -5958,7 +5958,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1238">τάρφεα· κωφὴ δέ σφιν ἐπιβλύει ὕδατος ἄχνη·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1239">ἠερίη δʼ ἄμαθος παρακέκλιται· οὐδέ τι κεῖσε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1240">ἑρπετόν, οὐδὲ ποτητὸν ἀείρεται. ἔνθʼ ἄρα τούσγε</l>
-				                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1241"><choice><sic>πλυμμυρίς</sic><corr>πλημμυρίς</corr></choice>—καὶ γάρ τʼ ἀναχάζεται ἠπείροιο</l>
+				                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1241">πλυμμυρίς—καὶ γάρ τʼ ἀναχάζεται ἠπείροιο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1242">ἦ θαμὰ δὴ τόδε χεῦμα, καὶ ἂψ ἐπερεύγεται ἀκτὰς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1243">λάβρον ἐποιχόμενον—μυχάτῃ ἐνέωσε τάχιστα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1244">ἠιόνι, τρόπιος δὲ μάλʼ ὕδασι παῦρον ἔλειπτο.</l>


### PR DESCRIPTION
The original print edition (Geroge W. Mooney 1912) has πλυμμυρίς:
https://archive.org/details/argonauticaedite00apoluoft/page/371/mode/1up
It's also πλυμμυρίς in Teubner 1828:
https://archive.org/details/apolloniirhodiia00apol/page/n284/mode/1up

In the Perseus version, πλυμμυρίς was amended to πλημμυρίς (υ changed to η) in #1241.

However the Oxford Classical Texts OCT (Fraenkel 1961, repr. 1970) has πλημυρίς (remove the second μ):
https://github.com/sasansom/sedes/issues/57#issuecomment-3128104892

Cc @sasansom