### PR TITLE
Update tlg0005.tlg001.perseus-grc2.xml

### DIFF
--- a/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc2.xml
+++ b/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc2.xml
@@ -55,7 +55,7 @@
       </editorialDecl>
       <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
   <refsDecl n="CTS">
-    <cRefPattern n="line" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:l[@n='$2'])">
+    <cRefPattern n="line" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']//tei:l[@n='$2'])">
       <p>This pointer pattern extracts poem and line.</p>
     </cRefPattern>
     


### PR DESCRIPTION
fixed refsDecl to capture lines within lg tags, which are another layer that was previously unaccounted for