### PR TITLE
(tlg0533.tlg017, tlg0533.tlg019) fix incorrectly encoded parentheses

### DIFF
--- a/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
+++ b/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
@@ -147,7 +147,7 @@
 <pb n="64"/>
 <l n="46" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">αὖθι δὲ Κύκλωπας μετεκίαθε· τοὺς μὲν ἔτετμε</l>
 <l n="47" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">νήσῳ ἐνὶ Λιπάρῃ (Λιπάρη νέον, ἀλλὰ τότʼ ἔσκεν</l>
-<l n="48" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">οὔνομά οἱ Μελιγουνίσ) ἐπʼ ἄκμοσιν Ἡφαίστοιο</l>
+<l n="48" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">οὔνομά οἱ Μελιγουνίς) ἐπʼ ἄκμοσιν Ἡφαίστοιο</l>
 <l n="49" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">ἑσταότας περὶ μύδρον· ἐπείγετο γὰρ μέγα ἔργον·</l>
 <l n="50" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">ἱππείην τετύκοντο Ποσειδάωνι ποτίστρην. </l>
 <l n="51" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">αἱ νύμφαι δʼ ἔδδεισαν, ὅπως ἴδον αἰνὰ πέλωρα</l>

--- a/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
+++ b/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
@@ -146,8 +146,8 @@
 <l n="45" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">οὕνεκα θυγατέρας Λητωίδι πέμπον <note xml:lang="eng"><foreign xml:lang="grc">πέμπον</foreign> schol. Nicand. Th. 349; <foreign xml:lang="grc">πέμπεν</foreign> or <foreign xml:lang="grc">πέμπειν</foreign>.</note> ἀμορβούς.</l> 
 <pb n="64"/>
 <l n="46" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">αὖθι δὲ Κύκλωπας μετεκίαθε· τοὺς μὲν ἔτετμε</l>
-<l n="47" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">νήσῳ ἐνὶ Λιπάρῃ Λ̔ιπάρη νέον, ἀλλὰ τότʼ ἔσκεν</l>
-<l n="48" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">οὔνομά οἱ Μελιγουνίσʼ ἐπʼ ἄκμοσιν Ἡφαίστοιο</l>
+<l n="47" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">νήσῳ ἐνὶ Λιπάρῃ (Λιπάρη νέον, ἀλλὰ τότʼ ἔσκεν</l>
+<l n="48" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">οὔνομά οἱ Μελιγουνίσ) ἐπʼ ἄκμοσιν Ἡφαίστοιο</l>
 <l n="49" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">ἑσταότας περὶ μύδρον· ἐπείγετο γὰρ μέγα ἔργον·</l>
 <l n="50" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">ἱππείην τετύκοντο Ποσειδάωνι ποτίστρην. </l>
 <l n="51" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">αἱ νύμφαι δʼ ἔδδεισαν, ὅπως ἴδον αἰνὰ πέλωρα</l>

--- a/data/tlg0533/tlg019/tlg0533.tlg019.perseus-grc3.xml
+++ b/data/tlg0533/tlg019/tlg0533.tlg019.perseus-grc3.xml
@@ -115,7 +115,7 @@
 <l n="13" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3">ὦ ἴτʼ Ἀχαιιάδες, καὶ μὴ μύρα μηδʼ ἀλαβάστρως</l>
 <l n="14" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3" rend="align(indent)">συρίγγων ἀίω φθόγγον ὑπαξονίων <note xml:lang="eng"><foreign xml:lang="grc">ὑπαξόνιον</foreign> e; <foreign xml:lang="grc">ὑπ’ ἀξονίων</foreign> Schneider.</note>,</l>
 <l n="15" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3">μὴ μύρα λωτροχόοι τᾷ Παλλάδι μηδʼ ἀλαβάστρως </l>
-<l n="16" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3" rend="align(indent)">̔οὐ γὰρ Ἀθαναία χρίματα μεικτὰ φιλεἶ</l>
+<l n="16" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3" rend="align(indent)">(οὐ γὰρ Ἀθαναία χρίματα μεικτὰ φιλεῖ)</l>
 <l n="17" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3">οἴσετε μηδὲ κάτοπτρον· ἀεὶ καλὸν ὄμμα τὸ τήνας</l>
 <l n="18" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3" rend="align(indent)">οὐδʼ ὅκα τὰν Ἴδᾳ <note xml:lang="eng"><foreign xml:lang="grc">Ἴδαν</foreign> MSS.; corr. Bentley.</note> Φρὺξ ἐδίκαζεν ἔριν,</l>
 <l n="19" xml:base="urn:cts:greekLit:tlg0533.tlg019.perseus-grc3">οὔτʼ ἐς ὀρείχαλκον μεγάλα θεὸς οὔτε <note xml:lang="eng"><foreign xml:lang="grc">οὐδ’ . . . οὐδὲ</foreign> MSS.; corr. Meineke.</note> Σιμοῦντος</l>


### PR DESCRIPTION
In both cases, the opening parenthesis had become a rough breathing diacritic. In one case, the closing parenthesis had become an apostrophe, and in the other a smooth breathing diacritic.

Book scans:
https://archive.org/details/callimachuslycop00calluoft/page/64/mode/1up
https://archive.org/details/callimachuslycop00calluoft/page/112/mode/1up

Rendering in the Scaife viewer:
https://web.archive.org/web/20250901154911/https://scaife.perseus.org/reader/urn:cts:greekLit:tlg0533.tlg017.perseus-grc3:31-60/
https://web.archive.org/web/20250901161226/https://scaife.perseus.org/reader/urn:cts:greekLit:tlg0533.tlg019.perseus-grc3:1-30/

These corrections are for the grc3 edition. The corresponding places in the grc4 edition look correct:
https://github.com/PerseusDL/canonical-greekLit/blob/00a21f2465862c804eacedc7f7602efc68022582/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc4.xml#L150-L151
https://github.com/PerseusDL/canonical-greekLit/blob/00a21f2465862c804eacedc7f7602efc68022582/data/tlg0533/tlg019/tlg0533.tlg019.perseus-grc4.xml#L117