### PR TITLE
(tlg0001.tlg001) use `<q>` for quotations instead of literal `‘` / `’`

### DIFF
--- a/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
+++ b/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
@@ -377,11 +377,11 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="240">ἀστέρες ὣς νεφέεσσι μετέπρεπον· ὧδε δʼ ἕκαστος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="241">ἔννεπεν εἰσορόων σὺν τεύχεσιν ἀίσσοντας·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="242">‘Ζεῦ ἄνα, τίς Πελίαο νόος; πόθι τόσσον ὅμιλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="243">ἡρώων γαίης Παναχαιίδος ἔκτοθι βάλλει;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="244">αὐτῆμάρ κε δόμους ὀλοῷ πυρὶ δῃώσειαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="245">Αἰήτεω, ὅτε μή σφιν ἑκὼν δέρος ἐγγυαλίξῃ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="246">ἀλλʼ οὐ φυκτὰ κέλευθα, πόνος δʼ ἄπρηκτος ἰοῦσιν.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="242"><q rend="double">Ζεῦ ἄνα, τίς Πελίαο νόος; πόθι τόσσον ὅμιλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="243"><q rend="double; merge">ἡρώων γαίης Παναχαιίδος ἔκτοθι βάλλει;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="244"><q rend="double; merge">αὐτῆμάρ κε δόμους ὀλοῷ πυρὶ δῃώσειαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="245"><q rend="double; merge">Αἰήτεω, ὅτε μή σφιν ἑκὼν δέρος ἐγγυαλίξῃ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="246"><q rend="double; merge">ἀλλʼ οὐ φυκτὰ κέλευθα, πόνος δʼ ἄπρηκτος ἰοῦσιν.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="247">ὧς φάσαν ἔνθα καὶ ἔνθα κατὰ πτόλιν· αἱ δὲ
 						γυναῖκες</l>
@@ -389,15 +389,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="249">εὐχόμεναι νόστοιο τέλος θυμηδὲς ὀπάσσαι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="250">ἄλλη δʼ εἰς ἑτέρην ὀλοφύρετο δακρυχέουσα·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="251">‘δειλὴ Ἀλκιμέδη, καὶ σοὶ κακὸν ὀφέ περ ἔμπης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="252">ἤλυθεν, οὐδʼ ἐτέλεσσας ἐπʼ ἀγλαΐῃ βιότοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="253">Αἴσων αὖ μέγα δή τι δυσάμμορος. ἦ τέ οἱ ἦεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="254">βέλτερον, εἰ τὸ πάροιθεν ἐνὶ κτερέεσσιν ἐλυσθεὶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="255">νειόθι γαίης κεῖτο, κακῶν ἔτι νῆις ἀέθλων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="256">ὡς ὄφελεν καὶ Φρίξον, ὅτʼ ὤλετο παρθένος Ἕλλη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="257">κῦμα μέλαν κριῷ ἅμʼ ἐπικλύσαι· ἀλλὰ καὶ αὐδὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="258">ἀνδρομέην προέηκε κακὸν τέρας, ὥς κεν ἀνίας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="259">Ἀλκιμέδῃ μετόπισθε καὶ ἄλγεα μυρία θείη.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="251"><q rend="double">δειλὴ Ἀλκιμέδη, καὶ σοὶ κακὸν ὀφέ περ ἔμπης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="252"><q rend="double; merge">ἤλυθεν, οὐδʼ ἐτέλεσσας ἐπʼ ἀγλαΐῃ βιότοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="253"><q rend="double; merge">Αἴσων αὖ μέγα δή τι δυσάμμορος. ἦ τέ οἱ ἦεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="254"><q rend="double; merge">βέλτερον, εἰ τὸ πάροιθεν ἐνὶ κτερέεσσιν ἐλυσθεὶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="255"><q rend="double; merge">νειόθι γαίης κεῖτο, κακῶν ἔτι νῆις ἀέθλων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="256"><q rend="double; merge">ὡς ὄφελεν καὶ Φρίξον, ὅτʼ ὤλετο παρθένος Ἕλλη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="257"><q rend="double; merge">κῦμα μέλαν κριῷ ἅμʼ ἐπικλύσαι· ἀλλὰ καὶ αὐδὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="258"><q rend="double; merge">ἀνδρομέην προέηκε κακὸν τέρας, ὥς κεν ἀνίας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="259"><q rend="double; merge">Ἀλκιμέδῃ μετόπισθε καὶ ἄλγεα μυρία θείη.</q></l>
 					          <milestone n="260" unit="card"/>
 					          <milestone unit="para"/>
 				        	   <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="260">αἱ μὲν ἄρʼ ὧς ἀγόρευον ἐπὶ προμολῇσι
@@ -420,37 +420,37 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="276">ὧς ἀδινὸν κλαίεσκεν ἑὸν παῖδʼ ἀγκὰς ἔχουσα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="277">Ἀλκιμέδη, καὶ τοῖον ἔπος φάτο κηδοσύνῃσιν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="278">‘αἴθʼ ὄφελον κεῖνʼ ἦμαρ, ὅτʼ ἐξειπόντος ἄκουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="279">δειλὴ ἐγὼ Πελίαο κακὴν βασιλῆος ἐφετμήν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="280">αὐτίκʼ ἀπὸ ψυχὴν μεθέμεν, κηδέων τε λαθέσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="281">ὄφρʼ αὐτός με τεῇσι φίλαις ταρχύσαο χερσίν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="282">τέκνον ἐμόν· τὸ γὰρ οἶον ἔην ἔτι λοιπὸν ἐέλδωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="283">ἐκ σέθεν, ἄλλα δὲ πάντα πάλαι θρεπτήρια πέσσω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="284">νῦν γε μὲν ἡ τὸ πάροιθεν Ἀχαιιάδεσσιν ἀγητὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="285">δμωὶς ὅπως κενεοῖσι λελείψομαι ἐν μεγάροισιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="286">σεῖο πόθῳ μινύθουσα δυσάμμορος, ᾧ ἔπι πολλὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="287">ἀγλαΐην καὶ κῦδος ἔχον πάρος, ᾧ ἔπι μούνῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="288">μίτρην πρῶτον ἔλυσα καὶ ὕστατον. ἔξοχα γάρ μοι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="289">Εἰλείθυια θεὰ πολέος ἐμέγηρε τόκοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="290">ᾤ μοι ἐμῆς ἄτης· τὸ μὲν οὐδʼ ὅσον, οὐδʼ ἐν ὀνείρῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="291">ὠισάμην, εἰ Φρίξος ἐμοὶ κακὸν ἔσσετʼ ἀλύξας.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="278"><q rend="double">αἴθʼ ὄφελον κεῖνʼ ἦμαρ, ὅτʼ ἐξειπόντος ἄκουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="279"><q rend="double; merge">δειλὴ ἐγὼ Πελίαο κακὴν βασιλῆος ἐφετμήν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="280"><q rend="double; merge">αὐτίκʼ ἀπὸ ψυχὴν μεθέμεν, κηδέων τε λαθέσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="281"><q rend="double; merge">ὄφρʼ αὐτός με τεῇσι φίλαις ταρχύσαο χερσίν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="282"><q rend="double; merge">τέκνον ἐμόν· τὸ γὰρ οἶον ἔην ἔτι λοιπὸν ἐέλδωρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="283"><q rend="double; merge">ἐκ σέθεν, ἄλλα δὲ πάντα πάλαι θρεπτήρια πέσσω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="284"><q rend="double; merge">νῦν γε μὲν ἡ τὸ πάροιθεν Ἀχαιιάδεσσιν ἀγητὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="285"><q rend="double; merge">δμωὶς ὅπως κενεοῖσι λελείψομαι ἐν μεγάροισιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="286"><q rend="double; merge">σεῖο πόθῳ μινύθουσα δυσάμμορος, ᾧ ἔπι πολλὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="287"><q rend="double; merge">ἀγλαΐην καὶ κῦδος ἔχον πάρος, ᾧ ἔπι μούνῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="288"><q rend="double; merge">μίτρην πρῶτον ἔλυσα καὶ ὕστατον. ἔξοχα γάρ μοι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="289"><q rend="double; merge">Εἰλείθυια θεὰ πολέος ἐμέγηρε τόκοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="290"><q rend="double; merge">ᾤ μοι ἐμῆς ἄτης· τὸ μὲν οὐδʼ ὅσον, οὐδʼ ἐν ὀνείρῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="291"><q rend="double; merge">ὠισάμην, εἰ Φρίξος ἐμοὶ κακὸν ἔσσετʼ ἀλύξας.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="292">ὧς ἥγε στενάχουσα κινύρετο· ταὶ δὲ γυναῖκες</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="293">ἀμφίπολοι γοάασκον ἐπισταδόν· αὐτὰρ ὁ τήνγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="294">μειλιχίοις ἐπέεσσι παρηγορέων προσέειπεν·</l>
 					          <milestone unit="para"/>
-				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="295">‘μή μοι λευγαλέας ἐνιβάλλεο, μῆτερ,
-						ἀνίας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="296">ὧδε λίην, ἐπεὶ οὐ μὲν ἐρητύσεις κακότητος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="297">δάκρυσιν, ἀλλʼ ἔτι κεν καὶ ἐπʼ ἄλγεσιν ἄλγος ἄροιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="298">πήματα γάρ τʼ ἀίδηλα θεοὶ θνητοῖσι ϝέμουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="299">τῶν μοῖραν κατὰ θυμὸν ἀνιάζουσά περ ἔμπης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="300">τλῆθι φέρειν· θάρσει δὲ συνημοσύνῃσιν Ἀθήνης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="301">ἠδὲ θεοπροπίοισιν, ἐπεὶ μάλα δεξιὰ Φοῖβος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="302">ἔχρη, ἀτὰρ μετέπειτά γʼ ἀριστήων ἐπαρωγῇ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="303">ἀλλὰ σὺ μὲν νῦν αὖθι μετʼ ἀμφιπόλοισιν ἕκηλος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="304">μίμνε δόμοις, μηδʼ ὄρνις ἀεικελίη πέλε νηί·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="305">κεῖσε δʼ ὁμαρτήσουσιν ἔται δμῶές τε κιόντι.’</l>
+				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="295"><q rend="double">μή μοι λευγαλέας ἐνιβάλλεο, μῆτερ,
+						ἀνίας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="296"><q rend="double; merge">ὧδε λίην, ἐπεὶ οὐ μὲν ἐρητύσεις κακότητος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="297"><q rend="double; merge">δάκρυσιν, ἀλλʼ ἔτι κεν καὶ ἐπʼ ἄλγεσιν ἄλγος ἄροιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="298"><q rend="double; merge">πήματα γάρ τʼ ἀίδηλα θεοὶ θνητοῖσι ϝέμουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="299"><q rend="double; merge">τῶν μοῖραν κατὰ θυμὸν ἀνιάζουσά περ ἔμπης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="300"><q rend="double; merge">τλῆθι φέρειν· θάρσει δὲ συνημοσύνῃσιν Ἀθήνης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="301"><q rend="double; merge">ἠδὲ θεοπροπίοισιν, ἐπεὶ μάλα δεξιὰ Φοῖβος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="302"><q rend="double; merge">ἔχρη, ἀτὰρ μετέπειτά γʼ ἀριστήων ἐπαρωγῇ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="303"><q rend="double; merge">ἀλλὰ σὺ μὲν νῦν αὖθι μετʼ ἀμφιπόλοισιν ἕκηλος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="304"><q rend="double; merge">μίμνε δόμοις, μηδʼ ὄρνις ἀεικελίη πέλε νηί·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="305"><q rend="double; merge">κεῖσε δʼ ὁμαρτήσουσιν ἔται δμῶές τε κιόντι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="306">ἦ, καὶ ὁ μὲν προτέρωσε δόμων ἐξῶρτο νέεσθαι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="307">οἷος δʼ ἐκ νηοῖο θυώδεος εἶσιν Ἀπόλλων</l>
@@ -481,42 +481,42 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="330">κεκλιμένῳ μάλα πάντες ἐπισχερὼ ἑδριόωντο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="331">τοῖσιν δʼ Αἴσονος υἱὸς ἐυφρονέων μετέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="332">‘ἄλλα μὲν ὅσσα τε νηὶ ἐφοπλίσσασθαι ἔοικεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="333">—πάντα γὰρ εὖ κατὰ κόσμον—ἐπαρτέα κεῖται ἰοῦσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="334">τῶ οὐκ ἂν δηναιὸν ἐχοίμεθα τοῖο ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="335">ναυτιλίης, ὅτε μοῦνον ἐπιπνεύσουσιν ἀῆται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="336">ἀλλά, φίλοι,—ξυνὸς γὰρ ἐς Ἑλλάδα νόστος ὀπίσσω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="337">ξυναὶ δʼ ἄμμι πέλονται ἐς Αἰήταο κέλευθοι—</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="338">τούνεκα νῦν τὸν ἄριστον ἀφειδήσαντες ἕλεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="339">ὄρχαμον ἡμείων, ᾧ κεν τὰ ἕκαστα μέλοιτο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="340">νείκεα συνθεσίας τε μετὰ ξείνοισι βαλέσθαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="332"><q rend="double">ἄλλα μὲν ὅσσα τε νηὶ ἐφοπλίσσασθαι ἔοικεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="333"><q rend="double; merge">—πάντα γὰρ εὖ κατὰ κόσμον—ἐπαρτέα κεῖται ἰοῦσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="334"><q rend="double; merge">τῶ οὐκ ἂν δηναιὸν ἐχοίμεθα τοῖο ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="335"><q rend="double; merge">ναυτιλίης, ὅτε μοῦνον ἐπιπνεύσουσιν ἀῆται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="336"><q rend="double; merge">ἀλλά, φίλοι,—ξυνὸς γὰρ ἐς Ἑλλάδα νόστος ὀπίσσω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="337"><q rend="double; merge">ξυναὶ δʼ ἄμμι πέλονται ἐς Αἰήταο κέλευθοι—</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="338"><q rend="double; merge">τούνεκα νῦν τὸν ἄριστον ἀφειδήσαντες ἕλεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="339"><q rend="double; merge">ὄρχαμον ἡμείων, ᾧ κεν τὰ ἕκαστα μέλοιτο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="340"><q rend="double; merge">νείκεα συνθεσίας τε μετὰ ξείνοισι βαλέσθαι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="341">ὧς φάτο· πάπτηναν δὲ νέοι θρασὺν Ἡρακλῆα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="342">ἥμενον ἐν μέσσοισι· μιῇ δέ ἑ πάντες ἀυτῇ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="343">σημαίνειν ἐπέτελλον· ὁ δʼ αὐτόθεν, ἔνθα περ ἧστο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="344">δεξιτερὴν ἀνὰ χεῖρα τανύσσατο φώνησέν τε·</l>
 					          <milestone unit="para"/>
-				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="345">‘μήτις ἐμοὶ τόδε κῦδος ὀπαζέτω. οὐ γὰρ
-						ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="346">πείσομαι· ὥστε καὶ ἄλλον ἀναστήσεσθαι ἐρύξω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="347">αὐτός, ὅτις ξυνάγειρε, καὶ ἀρχεύοι ὁμάδοιο.’</l>
+				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="345"><q rend="double">μήτις ἐμοὶ τόδε κῦδος ὀπαζέτω. οὐ γὰρ
+						ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="346"><q rend="double; merge">πείσομαι· ὥστε καὶ ἄλλον ἀναστήσεσθαι ἐρύξω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="347"><q rend="double; merge">αὐτός, ὅτις ξυνάγειρε, καὶ ἀρχεύοι ὁμάδοιο.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="348">ἦ ῥα μέγα φρονέων, ἐπὶ δʼ ᾔνεον, ὡς ἐκέλευεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="349">Ἡρακλέης· ἀνὰ δʼ αὐτὸς ἀρήιος ὤρνυτʼ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="350">γηθόσυνος, καὶ τοῖα λιλαιομένοις ἀγόρευεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="351">‘εἰ μὲν δή μοι κῦδος ἐπιτρωπᾶτε μέλεσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="352">μηκέτʼ ἔπειθʼ, ὡς καὶ πρίν, ἐρητύοιτο κέλευθα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="353">νῦν γε μὲν ἤδη Φοῖβον ἀρεσσάμενοι θυέεσσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="354">δαῖτʼ ἐντυνώμεσθα παρασχεδόν. ὄφρα δʼ ἴωσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="355">δμῶες ἐμοὶ σταθμῶν σημάντορες, οἷσι μέμηλεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="356">δεῦρο βόας ἀγέληθεν ἐὺ κρίναντας ἐλάσσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="357">τόφρα κε νῆʼ ἐρύσαιμεν ἔσω ἁλός, ὅπλα δὲ πάντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="358">ἐνθέμενοι πεπάλαχθε κατὰ κληῖδας ἐρετμά.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="359">τείως δʼ αὖ καὶ βωμὸν ἐπάκτιον Ἐμβασίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="360">θείομεν Ἀπόλλωνος, ὅ μοι χρείων ὑπέδεκτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="361">σημανέειν δείξειν τε πόρους ἁλός, εἴ κε θυηλαῖς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="362">οὗ ἕθεν ἐξάρχωμαι ἀεθλεύων βασιλῆι.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="351"><q rend="double">εἰ μὲν δή μοι κῦδος ἐπιτρωπᾶτε μέλεσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="352"><q rend="double; merge">μηκέτʼ ἔπειθʼ, ὡς καὶ πρίν, ἐρητύοιτο κέλευθα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="353"><q rend="double; merge">νῦν γε μὲν ἤδη Φοῖβον ἀρεσσάμενοι θυέεσσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="354"><q rend="double; merge">δαῖτʼ ἐντυνώμεσθα παρασχεδόν. ὄφρα δʼ ἴωσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="355"><q rend="double; merge">δμῶες ἐμοὶ σταθμῶν σημάντορες, οἷσι μέμηλεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="356"><q rend="double; merge">δεῦρο βόας ἀγέληθεν ἐὺ κρίναντας ἐλάσσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="357"><q rend="double; merge">τόφρα κε νῆʼ ἐρύσαιμεν ἔσω ἁλός, ὅπλα δὲ πάντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="358"><q rend="double; merge">ἐνθέμενοι πεπάλαχθε κατὰ κληῖδας ἐρετμά.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="359"><q rend="double; merge">τείως δʼ αὖ καὶ βωμὸν ἐπάκτιον Ἐμβασίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="360"><q rend="double; merge">θείομεν Ἀπόλλωνος, ὅ μοι χρείων ὑπέδεκτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="361"><q rend="double; merge">σημανέειν δείξειν τε πόρους ἁλός, εἴ κε θυηλαῖς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="362"><q rend="double; merge">οὗ ἕθεν ἐξάρχωμαι ἀεθλεύων βασιλῆι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="363">η ῥα, καὶ εἰς ἔργον πρῶτος τράπεθ̓· οἱ δʼ
 						ἐπανέσταν</l>
@@ -571,21 +571,21 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="409">χέρνιβά τʼ οὐλοχύτας τε παρέσχεθον. αὐτὰρ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="410">εὔχετο κεκλόμενος πατρώιον Ἀπόλλωνα·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="411">‘κλῦθι ἄναξ, Παγασάς τε πόλιν τʼ Αἰσωνίδα
-						ναίων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="412">ἡμετέροιο τοκῆος ἐπώνυμον, ὅς μοι ὑπέστης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="413">Πυθοῖ χρειομένῳ ἄνυσιν καὶ πείραθʼ ὁδοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="414">σημανέειν, αὐτὸς γὰρ ἐπαίτιος ἔπλευ ἀέθλων·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="415">αὐτὸς νῦν ἄγε νῆα σὺν ἀρτεμέεσσιν ἑταίροις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="416">κεῖσέ τε καὶ παλίνορσον ἐς Ἑλλάδα. σοὶ δʼ ἂν ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="417">τόσσων, ὅσσοι κεν νοστήσομεν, ἀγλαὰ ταύρων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="418">ἱρὰ πάλιν βωμῷ ἐπιθήσομεν· ἄλλα δὲ Πυθοῖ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="419">ἄλλα δʼ ἐς Ὀρτυγίην ἀπερείσια δῶρα κομίσσω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="420">νῦν δʼ ἴθι, καὶ τήνδʼ ἧμιν, Ἑκηβόλε, δέξο θυηλήν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="421">ἥν τοι τῆσδʼ ἐπίβαθρα χάριν προτεθείμεθα νηὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="422">πρωτίστην· λύσαιμι δʼ, ἄναξ, ἐπʼ ἀπήμονι μοίρῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="423">πείσματα σὴν διὰ μῆτιν· ἐπιπνεύσειε δʼ ἀήτης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="424">μείλιχος, ᾧ κʼ ἐπὶ πόντον ἐλευσόμεθʼ εὐδιόωντες.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="411"><q rend="double">κλῦθι ἄναξ, Παγασάς τε πόλιν τʼ Αἰσωνίδα
+						ναίων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="412"><q rend="double; merge">ἡμετέροιο τοκῆος ἐπώνυμον, ὅς μοι ὑπέστης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="413"><q rend="double; merge">Πυθοῖ χρειομένῳ ἄνυσιν καὶ πείραθʼ ὁδοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="414"><q rend="double; merge">σημανέειν, αὐτὸς γὰρ ἐπαίτιος ἔπλευ ἀέθλων·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="415"><q rend="double; merge">αὐτὸς νῦν ἄγε νῆα σὺν ἀρτεμέεσσιν ἑταίροις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="416"><q rend="double; merge">κεῖσέ τε καὶ παλίνορσον ἐς Ἑλλάδα. σοὶ δʼ ἂν ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="417"><q rend="double; merge">τόσσων, ὅσσοι κεν νοστήσομεν, ἀγλαὰ ταύρων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="418"><q rend="double; merge">ἱρὰ πάλιν βωμῷ ἐπιθήσομεν· ἄλλα δὲ Πυθοῖ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="419"><q rend="double; merge">ἄλλα δʼ ἐς Ὀρτυγίην ἀπερείσια δῶρα κομίσσω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="420"><q rend="double; merge">νῦν δʼ ἴθι, καὶ τήνδʼ ἧμιν, Ἑκηβόλε, δέξο θυηλήν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="421"><q rend="double; merge">ἥν τοι τῆσδʼ ἐπίβαθρα χάριν προτεθείμεθα νηὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="422"><q rend="double; merge">πρωτίστην· λύσαιμι δʼ, ἄναξ, ἐπʼ ἀπήμονι μοίρῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="423"><q rend="double; merge">πείσματα σὴν διὰ μῆτιν· ἐπιπνεύσειε δʼ ἀήτης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="424"><q rend="double; merge">μείλιχος, ᾧ κʼ ἐπὶ πόντον ἐλευσόμεθʼ εὐδιόωντες.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="425">ἦ, καὶ ἅμʼ εὐχωλῇ προχύτας βάλε. τὼ δʼ ἐπὶ
 						βουσὶν</l>
@@ -603,15 +603,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="437">πάντοσε λαμπόμενον θυέων ἄπο τοῖό τε λιγνὺν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="438">πορφυρέαις ἑλίκεσσιν ἐναίσιμον ἀίσσουσαν·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="439">αἶψα δʼ ἀπηλεγέως νόον ἔκφατο Λητοΐδαο·</l>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="440">‘ὑμῖν μὲν δὴ μοῖρα θεῶν χρειώ τε
-						περῆσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="441">ἐνθάδε κῶας ἄγοντας· ἀπειρέσιοι δʼ ἐνὶ μέσσῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="442">κεῖσέ τε δεῦρό τʼ ἔασιν ἀνερχομένοισιν ἄεθλοι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="443">αὐτὰρ ἐμοὶ θανέειν στυγερῇ ὑπὸ δαίμονος αἴσῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="444">τηλόθι που πέπρωται ἐπʼ Ἀσίδος ἠπείροιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="445">ὧδε κακοῖς δεδαὼς ἔτι καὶ πάρος οἰωνοῖσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="446">πότμον ἐμὸν πάτρης ἐξήιον, ὄφρʼ ἐπιβαίην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="447">νηός, ἐυκλείη δὲ δόμοις ἐπιβάντι λίπηται.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="440"><q rend="double">ὑμῖν μὲν δὴ μοῖρα θεῶν χρειώ τε
+						περῆσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="441"><q rend="double; merge">ἐνθάδε κῶας ἄγοντας· ἀπειρέσιοι δʼ ἐνὶ μέσσῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="442"><q rend="double; merge">κεῖσέ τε δεῦρό τʼ ἔασιν ἀνερχομένοισιν ἄεθλοι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="443"><q rend="double; merge">αὐτὰρ ἐμοὶ θανέειν στυγερῇ ὑπὸ δαίμονος αἴσῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="444"><q rend="double; merge">τηλόθι που πέπρωται ἐπʼ Ἀσίδος ἠπείροιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="445"><q rend="double; merge">ὧδε κακοῖς δεδαὼς ἔτι καὶ πάρος οἰωνοῖσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="446"><q rend="double; merge">πότμον ἐμὸν πάτρης ἐξήιον, ὄφρʼ ἐπιβαίην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="447"><q rend="double; merge">νηός, ἐυκλείη δὲ δόμοις ἐπιβάντι λίπηται.</q></l>
 					          <milestone n="448" unit="card"/>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="448">ὧς ἄρʼ ἔφη· κοῦροι δὲ θεοπροπίης ἀίοντες</l>
@@ -630,41 +630,41 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="461">πορφύρεσκεν ἕκαστα κατηφιόωντι ἐοικώς.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="462">τὸν δʼ ἄρʼ ὑποφρασθεὶς μεγάλῃ ὀπὶ νείκεσεν Ἴδας·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="463">‘Αἰσονίδη, τίνα τήνδε μετὰ φρεσὶ μῆτιν
-						ἑλίσσεις;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="464">αὔδα ἐνὶ μέσσοισι τεὸν νόον. ἦέ σε δαμνᾷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="465">τάρβος ἐπιπλόμενον, τό τʼ ἀνάλκιδας ἄνδρας ἀτύζει;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="466">ἴστω νῦν δόρυ θοῦρον, ὅτῳ περιώσιον ἄλλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="467">κῦδος ἐνὶ πτολέμοισιν ἀείρομαι, οὐδέ μʼ ὀφέλλει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="468">Ζεὺς τόσον, ὁσσάτιόν περ ἐμὸν δόρυ, μή νύ τι πῆμα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="469">λοίγιον ἔσσεσθαι, μηδʼ ἀκράαντον ἄεθλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="470">Ἴδεω ἑσπομένοιο, καὶ εἰ θεὸς ἀντιόῳτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="471">τοῖόν μʼ Ἀρήνηθεν ἀοσσητῆρα κομίζεις.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="463"><q rend="double">Αἰσονίδη, τίνα τήνδε μετὰ φρεσὶ μῆτιν
+						ἑλίσσεις;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="464"><q rend="double; merge">αὔδα ἐνὶ μέσσοισι τεὸν νόον. ἦέ σε δαμνᾷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="465"><q rend="double; merge">τάρβος ἐπιπλόμενον, τό τʼ ἀνάλκιδας ἄνδρας ἀτύζει;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="466"><q rend="double; merge">ἴστω νῦν δόρυ θοῦρον, ὅτῳ περιώσιον ἄλλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="467"><q rend="double; merge">κῦδος ἐνὶ πτολέμοισιν ἀείρομαι, οὐδέ μʼ ὀφέλλει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="468"><q rend="double; merge">Ζεὺς τόσον, ὁσσάτιόν περ ἐμὸν δόρυ, μή νύ τι πῆμα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="469"><q rend="double; merge">λοίγιον ἔσσεσθαι, μηδʼ ἀκράαντον ἄεθλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="470"><q rend="double; merge">Ἴδεω ἑσπομένοιο, καὶ εἰ θεὸς ἀντιόῳτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="471"><q rend="double; merge">τοῖόν μʼ Ἀρήνηθεν ἀοσσητῆρα κομίζεις.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="472">ἦ, καὶ ἐπισχόμενος πλεῖον δέπας ἀμφοτέρῃσιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="473">πῖνε χαλίκρητον λαρὸν μέθυ· δεύετο δʼ οἴνῳ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="474">χείλεα, κυάνεαί τε γενειάδες· οἱ δʼ ὁμάδησαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="475">πάντες ὁμῶς, Ἴδμων δὲ καὶ ἀμφαδίην ἀγόρευσεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="476">‘δαιμόνιε, φρονέεις ὀλοφώια καὶ πάρος αὐτῷ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="477">ἦέ τοι εἰς ἄτην ζωρὸν μέθυ θαρσαλέον κῆρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="478">οἰδάνει ἐν στήθεσσι, θεοὺς δʼ ἀνέηκεν ἀτίζειν;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="479">ἄλλοι μῦθοι ἔασι παρήγοροι, οἷσί περ ἀνὴρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="480">θαρσύνοι ἕταρον· σὺ δʼ ἀτάσθαλα πάμπαν ἔειπας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="481">τοῖα φάτις καὶ τοὺς πρὶν ἐπιφλύειν μακάρεσσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="482">υἷας Ἀλωιάδας, οἷς οὐδʼ ὅσον ἰσοφαρίζεις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="483">ἠνορέην· ἔμπης δὲ θοοῖς ἐδάμησαν ὀιστοῖς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="484">ἄμφω Λητοΐδαο, καὶ ἴφθιμοί περ ἐόντες.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="476"><q rend="double">δαιμόνιε, φρονέεις ὀλοφώια καὶ πάρος αὐτῷ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="477"><q rend="double; merge">ἦέ τοι εἰς ἄτην ζωρὸν μέθυ θαρσαλέον κῆρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="478"><q rend="double; merge">οἰδάνει ἐν στήθεσσι, θεοὺς δʼ ἀνέηκεν ἀτίζειν;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="479"><q rend="double; merge">ἄλλοι μῦθοι ἔασι παρήγοροι, οἷσί περ ἀνὴρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="480"><q rend="double; merge">θαρσύνοι ἕταρον· σὺ δʼ ἀτάσθαλα πάμπαν ἔειπας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="481"><q rend="double; merge">τοῖα φάτις καὶ τοὺς πρὶν ἐπιφλύειν μακάρεσσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="482"><q rend="double; merge">υἷας Ἀλωιάδας, οἷς οὐδʼ ὅσον ἰσοφαρίζεις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="483"><q rend="double; merge">ἠνορέην· ἔμπης δὲ θοοῖς ἐδάμησαν ὀιστοῖς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="484"><q rend="double; merge">ἄμφω Λητοΐδαο, καὶ ἴφθιμοί περ ἐόντες.</q></l>
 					          <milestone unit="para"/>
 				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="485">ὧς ἔφατʼ· ἐκ δʼ ἐγέλασσεν ἄδην Ἀφαρήιος
 						Ἴδας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="486">καί μιν ἐπιλλίζων ἠμείβετο κερτομίοισιν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="487">‘ἄγρει νυν τόδε σῇσι θεοπροπίῃσιν ἐνίσπες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="488">εἰ καὶ ἐμοὶ τοιόνδε θεοὶ τελέουσιν ὄλεθρον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="489">οἷον Ἀλωιάδῃσι πατὴρ τεὸς ἐγγυάλιξεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="490">φράζεο δʼ ὅππως χεῖρας ἐμὰς σόος ἐξαλέοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="491">χρειὼ θεσπίζων μεταμώνιον εἴ κεν ἁλῴης.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="487"><q rend="double">ἄγρει νυν τόδε σῇσι θεοπροπίῃσιν ἐνίσπες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="488"><q rend="double; merge">εἰ καὶ ἐμοὶ τοιόνδε θεοὶ τελέουσιν ὄλεθρον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="489"><q rend="double; merge">οἷον Ἀλωιάδῃσι πατὴρ τεὸς ἐγγυάλιξεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="490"><q rend="double; merge">φράζεο δʼ ὅππως χεῖρας ἐμὰς σόος ἐξαλέοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="491"><q rend="double; merge">χρειὼ θεσπίζων μεταμώνιον εἴ κεν ἁλῴης.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="492">Χώετʼ ἐνιπτάζων· προτέρω δέ κε νεῖκος ἐτύχθη,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="493">εἰ μὴ δηριόωντας ὁμοκλήσαντες ἑταῖροι</l>
@@ -848,16 +848,16 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="655">καί ῥʼ ὅτε δὴ μάλα πᾶσαι ὁμιλαδὸν ἠγερέθοντο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="656">αὐτίκʼ ἄρʼ ἥγʼ ἐνὶ τῇσιν ἐποτρύνουσʼ ἀγόρευεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="657">‘Ὦφιλαι, εἰ δʼ ἄγε δὴ μενοεικέα δῶρα πόρωμεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="658">ἀνδράσιν, οἷά τʼ ἔοικεν ἄγειν ἐπὶ νηὸς ἔχοντας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="659">ἤια, καὶ μέθυ λαρόν, ἵνʼ ἔμπεδον ἔκτοθι πύργων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="660">μίμνοιεν, μηδʼ ἄμμε κατὰ χρειὼ μεθέποντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="661">ἀτρεκέως γνώωσι, κακὴ δʼ ἐπὶ πολλὸν ἵκηται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="662">βάξις· ἐπεὶ μέγα ἔργον ἐρέξαμεν, οὐδέ τι πάμπαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="663">θυμηδὲς καὶ τοῖσι τόγʼ ἔσσεται, εἴ κε δαεῖεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="664">ἡμετέρη μὲν νῦν τοίη παρενήνοθε μῆτις·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="665">ὑμέων δʼ εἴ τις ἄρειον ἔπος μητίσεται ἄλλη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="666">ἐγρέσθω· τοῦ γάρ τε καὶ εἵνεκα δεῦρʼ ἐκάλεσσα.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="657"><q rend="double">Ὦφιλαι, εἰ δʼ ἄγε δὴ μενοεικέα δῶρα πόρωμεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="658"><q rend="double; merge">ἀνδράσιν, οἷά τʼ ἔοικεν ἄγειν ἐπὶ νηὸς ἔχοντας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="659"><q rend="double; merge">ἤια, καὶ μέθυ λαρόν, ἵνʼ ἔμπεδον ἔκτοθι πύργων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="660"><q rend="double; merge">μίμνοιεν, μηδʼ ἄμμε κατὰ χρειὼ μεθέποντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="661"><q rend="double; merge">ἀτρεκέως γνώωσι, κακὴ δʼ ἐπὶ πολλὸν ἵκηται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="662"><q rend="double; merge">βάξις· ἐπεὶ μέγα ἔργον ἐρέξαμεν, οὐδέ τι πάμπαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="663"><q rend="double; merge">θυμηδὲς καὶ τοῖσι τόγʼ ἔσσεται, εἴ κε δαεῖεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="664"><q rend="double; merge">ἡμετέρη μὲν νῦν τοίη παρενήνοθε μῆτις·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="665"><q rend="double; merge">ὑμέων δʼ εἴ τις ἄρειον ἔπος μητίσεται ἄλλη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="666"><q rend="double; merge">ἐγρέσθω· τοῦ γάρ τε καὶ εἵνεκα δεῦρʼ ἐκάλεσσα.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="667">ὧς ἄρʼ ἔφη, καὶ θῶκον ἐφίζανε πατρὸς ἑοῖο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="668">λάινον· αὐτὰρ ἔπειτα φίλη τροφὸς ὦρτο Πολυξώ,</l>
@@ -868,29 +868,29 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="673">στῆ δʼ ἄρʼ ἐνὶ μέσσῃ ἀγορῇ, ἀνὰ δʼ ἔσχεθε δειρὴν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="674">ἦκα μόλις κυφοῖο μεταφρένου, ὧδέ τʼ ἔειπεν·</l>
 					          <milestone unit="para"/>
-				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="675">‘δῶρα μέν, ὡς αὐτῇ περ ἐφανδάνει
-						Ὑψιπυλείῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="676">πέμπωμεν ξείνοισιν, ἐπεὶ καὶ ἄρειον ὀπάσσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="677">ὔμμι γε μὴν τίς μῆτις ἐπαύρεσθαι βιότοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="678">αἴ κεν ἐπιβρίσῃ Θρήιξ στρατός, ἠέ τις ἄλλος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="679">δυσμενέων, ἅ τε πολλὰ μετʼ ἀνθρώποισι πέλονται;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="680">ὡς καὶ νῦν ὅδʼ ὅμιλος ἀνωίστως ἐφικάνει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="681">εἰ δὲ τὸ μὲν μακάρων τις ἀποτρέποι, ἄλλα δʼ ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="682">μυρία δηιοτῆτος ὑπέρτερα πήματα μίμνει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="683">εὖτʼ ἂν δὴ γεραραὶ μὲν ἀποφθινύθωσι γυναῖκες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="684">κουρότεραι δʼ ἄγονοι στυγερὸν ποτὶ γῆρας ἵκησθε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="685">πῶς τῆμος βώσεσθε δυσάμμοροι; ἦε βαθείαις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="686">αὐτόματοι βόες ὔμμιν ἐνιζευχθέντες ἀρούραις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="687">γειοτόμον νειοῖο διειρύσσουσιν ἄροτρον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="688">καὶ πρόκα τελλομένου ἔτεος στάχυν ἀμήσονται;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="689">ἦ μὲν ἐγών, εἰ καί με τὰ νῦν ἔτι πεφρίκασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="690">κῆρες, ἐπερχόμενόν που ὀίομαι εἰς ἔτος ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="691">γαῖαν ἐφέσσεσθαι, κτερέων ἀπὸ μοῖραν ἑλοῦσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="692">αὔτως, ἣ θέμις ἐστί, πάρος κακότητα πελάσσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="693">ὁπλοτέρῃσι δὲ πάγχυ τάδε φράζεσθαι ἄνωγα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="694">νῦν γὰρ δὴ παρὰ ποσσὶν ἐπήβολός ἐστʼ ἀλεωρή,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="695">εἴ κεν ἐπιτρέψητε δόμους καὶ ληίδα πᾶσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="696">ὑμετέρην ξείνοισι καὶ ἀγλαὸν ἄστυ μέλεσθαι.’</l>
+				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="675"><q rend="double">δῶρα μέν, ὡς αὐτῇ περ ἐφανδάνει
+						Ὑψιπυλείῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="676"><q rend="double; merge">πέμπωμεν ξείνοισιν, ἐπεὶ καὶ ἄρειον ὀπάσσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="677"><q rend="double; merge">ὔμμι γε μὴν τίς μῆτις ἐπαύρεσθαι βιότοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="678"><q rend="double; merge">αἴ κεν ἐπιβρίσῃ Θρήιξ στρατός, ἠέ τις ἄλλος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="679"><q rend="double; merge">δυσμενέων, ἅ τε πολλὰ μετʼ ἀνθρώποισι πέλονται;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="680"><q rend="double; merge">ὡς καὶ νῦν ὅδʼ ὅμιλος ἀνωίστως ἐφικάνει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="681"><q rend="double; merge">εἰ δὲ τὸ μὲν μακάρων τις ἀποτρέποι, ἄλλα δʼ ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="682"><q rend="double; merge">μυρία δηιοτῆτος ὑπέρτερα πήματα μίμνει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="683"><q rend="double; merge">εὖτʼ ἂν δὴ γεραραὶ μὲν ἀποφθινύθωσι γυναῖκες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="684"><q rend="double; merge">κουρότεραι δʼ ἄγονοι στυγερὸν ποτὶ γῆρας ἵκησθε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="685"><q rend="double; merge">πῶς τῆμος βώσεσθε δυσάμμοροι; ἦε βαθείαις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="686"><q rend="double; merge">αὐτόματοι βόες ὔμμιν ἐνιζευχθέντες ἀρούραις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="687"><q rend="double; merge">γειοτόμον νειοῖο διειρύσσουσιν ἄροτρον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="688"><q rend="double; merge">καὶ πρόκα τελλομένου ἔτεος στάχυν ἀμήσονται;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="689"><q rend="double; merge">ἦ μὲν ἐγών, εἰ καί με τὰ νῦν ἔτι πεφρίκασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="690"><q rend="double; merge">κῆρες, ἐπερχόμενόν που ὀίομαι εἰς ἔτος ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="691"><q rend="double; merge">γαῖαν ἐφέσσεσθαι, κτερέων ἀπὸ μοῖραν ἑλοῦσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="692"><q rend="double; merge">αὔτως, ἣ θέμις ἐστί, πάρος κακότητα πελάσσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="693"><q rend="double; merge">ὁπλοτέρῃσι δὲ πάγχυ τάδε φράζεσθαι ἄνωγα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="694"><q rend="double; merge">νῦν γὰρ δὴ παρὰ ποσσὶν ἐπήβολός ἐστʼ ἀλεωρή,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="695"><q rend="double; merge">εἴ κεν ἐπιτρέψητε δόμους καὶ ληίδα πᾶσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="696"><q rend="double; merge">ὑμετέρην ξείνοισι καὶ ἀγλαὸν ἄστυ μέλεσθαι.</q></l>
 					          <milestone n="697" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="697">ὧς ἔφατʼ· ἐν δʼ ἀγορὴ πλῆτο θρόου. εὔαδε γάρ
@@ -898,16 +898,16 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="698">μῦθος. ἀτὰρ μετὰ τήνγε παρασχεδὸν αὖτις ἀνῶρτο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="699">Ὑψιπύλη, καὶ τοῖον ὑποβλήδην ἔπος ηὔδα·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="700">‘εἰ μὲν δὴ πάσῃσιν ἐφανδάνει ἥδε
-						μενοινή,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="701">ἤδη κεν μετὰ νῆα καὶ ἄγγελον ὀτρύναιμι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="700"><q rend="double">εἰ μὲν δὴ πάσῃσιν ἐφανδάνει ἥδε
+						μενοινή,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="701"><q rend="double; merge">ἤδη κεν μετὰ νῆα καὶ ἄγγελον ὀτρύναιμι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="702">ἦ ῥα, καὶ Ἰφινόην μετεφώνεεν ἆσσον ἐοῦσαν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="703">‘ὄρσο μοι, Ἰφινόη, τοῦδʼ ἀνέρος ἀντιόωσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="704">ἡμέτερόνδε μολεῖν, ὅστις στόλου ἡγεμονεύει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="705">ὄφρα τί οἱ δήμοιο ἔπος θυμῆρες ἐνίσπω·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="706">καὶ δʼ αὐτοὺς γαίης τε καὶ ἄστεος, αἴ κʼ ἐθέλωσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="707">κέκλεο θαρσαλέως ἐπιβαινέμεν εὐμενέοντας.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="703"><q rend="double">ὄρσο μοι, Ἰφινόη, τοῦδʼ ἀνέρος ἀντιόωσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="704"><q rend="double; merge">ἡμέτερόνδε μολεῖν, ὅστις στόλου ἡγεμονεύει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="705"><q rend="double; merge">ὄφρα τί οἱ δήμοιο ἔπος θυμῆρες ἐνίσπω·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="706"><q rend="double; merge">καὶ δʼ αὐτοὺς γαίης τε καὶ ἄστεος, αἴ κʼ ἐθέλωσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="707"><q rend="double; merge">κέκλεο θαρσαλέως ἐπιβαινέμεν εὐμενέοντας.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="708">ἦ, καὶ ἔλυσʼ ἀγορήν, μετὰ δʼ εἰς ἑὸν ὦρτο
 						νέεσθαι.</l>
@@ -915,11 +915,11 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="710">χρεῖος ὅ τι φρονέουσα μετήλυθεν. ὦκα δὲ τούσγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="711">πασσυδίῃ μύθοισι προσέννεπεν ἐξερέοντας·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="712">‘κούρη τοί μʼ ἐφέηκε Θοαντιὰς ἐνθάδʼ ἰοῦσαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="713">Ὑψιπύλη, καλέειν νηὸς πρόμον, ὅστις ὄρωρεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="714">ὄφρα τί οἱ δήμοιο ἔπος θυμῆρες ἐνίσπῃ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="715">καὶ δʼ αὐτοὺς γαίης τε καὶ ἄστεος, αἴ κʼ ἐθέλητε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="716">κέκλεται αὐτίκα νῦν ἐπιβαινέμεν εὐμενέοντας.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="712"><q rend="double">κούρη τοί μʼ ἐφέηκε Θοαντιὰς ἐνθάδʼ ἰοῦσαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="713"><q rend="double; merge">Ὑψιπύλη, καλέειν νηὸς πρόμον, ὅστις ὄρωρεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="714"><q rend="double; merge">ὄφρα τί οἱ δήμοιο ἔπος θυμῆρες ἐνίσπῃ·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="715"><q rend="double; merge">καὶ δʼ αὐτοὺς γαίης τε καὶ ἄστεος, αἴ κʼ ἐθέλητε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="716"><q rend="double; merge">κέκλεται αὐτίκα νῦν ἐπιβαινέμεν εὐμενέοντας.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="717">ὧς ἄρʼ ἔφη· πάντεσσι δʼ ἐναίσιμος ἥνδανε
 						μῦθος.</l>
@@ -1010,58 +1010,58 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="791">παρθενικὰς ἐρύθηνε παρηίδας· ἔμπα δὲ τόνγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="792">αἰδομένη μύθοισι προσέννεπεν αἱμυλίοισιν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="793">‘ξεῖνε, τίη μίμνοντες ἐπὶ χρόνον ἔκτοθι πύργων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="794">ἧσθʼ αὔτως; ἐπεὶ οὐ μὲν ὑπʼ ἀνδράσι ναίεται ἄστυ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="795">ἀλλὰ Θρηικίης ἐπινάστιοι ἠπείροιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="796">πυροφόρους ἀρόωσι γύας. κακότητα δὲ πᾶσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="797">ἐξερέω νημερτές, ἵνʼ εὖ γνοίητε καὶ αὐτοί.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="798">εὖτε Θόας ἀστοῖσι πατὴρ ἐμὸς ἐμβασίλευεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="799">τηνίκα Θρηικίην, οἵ τʼ ἀντία ναιετάουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="800">δήμου ἀπορνύμενοι λαοὶ πέρθεσκον ἐπαύλους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="801">ἐκ νηῶν, αὐτῇσι δʼ ἀπείρονα ληίδα κούραις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="802">δεῦρʼ ἄγον· οὐλομένης δὲ θεᾶς πορσύνετο μῆτις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="803">Κύπριδος, ἥ τέ σφιν θυμοφθόρον ἔμβαλεν ἄτην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="804">δὴ γὰρ κουριδίας μὲν ἀπέστυγον, ἐκ δὲ μελάθρων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="805">ᾗ ματίῃ εἴξαντες, ἀπεσσεύοντο γυναῖκας·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="806">αὐτὰρ ληιάδεσσι δορικτήταις παρίαυον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="807">σχέτλιοι. ἦ μὲν δηρὸν ἐτέτλαμεν, εἴ κέ ποτʼ αὖτις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="808">ὀψὲ μεταστρέψωσι νόον· τὸ δὲ διπλόον αἰεὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="809">πῆμα κακὸν προύβαινεν. ἀτιμάζοντο δὲ τέκνα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="810">γνήσιʼ ἐνὶ μεγάροις, σκοτίη δʼ ἀνέτελλε γενέθλη.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="811">αὔτως δʼ ἀδμῆτές τε κόραι, χῆραί τʼ ἐπὶ τῇσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="812">μητέρες ἂμ πτολίεθρον ἀτημελέες ἀλάληντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="813">οὐδὲ πατὴρ ὀλίγον περ ἑῆς ἀλέγιζε θυγατρός,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="814">εἰ καὶ ἐν ὀφθαλμοῖσι δαϊζομένην ὁρόῳτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="815">μητρυιῆς ὑπὸ χερσὶν ἀτασθάλου· οὐδʼ ἀπὸ μητρὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="816">λώβην, ὡς τὸ πάροιθεν, ἀεικέα παῖδες ἄμυνον·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="817">οὐδὲ κασιγνήτοισι κασιγνήτη μελε θυμῷ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="818">ἀλλʼ οἶαι κοῦραι ληίτιδες ἔν τε δόμοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="819">ἔν τε χοροῖς ἀγορῇ τε καὶ εἰλαπίνῃσι μέλοντο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="820">εἰσόκε τις θεὸς ἄμμιν ὑπέρβιον ἔμβαλε θάρσος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="821">ἂψ ἀναερχομένους Θρῃκῶν ἄπο μηκέτι πύργοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="822">δέχθαι, ἵνʼ ἢ φρονέοιεν ἅπερ θέμις, ἠέ πῃ ἄλλῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="823">αὐταῖς ληιάδεσσιν ἀφορμηθέντες ἵκοιντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="824">οἱ δʼ ἄρα θεσσάμενοι παίδων γένος, ὅσσον ἔλειπτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="825">ἄρσεν ἀνὰ πτολίεθρον, ἔβαν πάλιν, ἔνθʼ ἔτι νῦν περ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="826">Θρηικίης ἄροσιν χιονώδεα ναιετάουσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="827">τῶ ὑμεῖς στρωφᾶσθʼ ἐπιδήμιοι· εἰ δέ κεν αὖθι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="828">ναιετάειν ἐθέλοις, καί τοι ἅδοι, ἦ τʼ ἂν ἔπειτα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="829">πατρὸς ἐμεῖο Θόαντος ἔχοις γέρας· οὐδέ τί σʼ οἴω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="830">γαῖαν ὀνόσσεσθαι· περὶ γὰρ βαθυλήιος ἄλλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="831">νήσων, Αἰγαίῃ ὅσαι εἰν ἁλὶ ναιετάουσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="832">ἀλλʼ ἄγε νῦν ἐπὶ νῆα κιὼν ἑτάροισιν ἐνίσπες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="833">μύθους ἡμετέρους, μηδʼ ἔκτοθι μίμνε πόληος.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="793"><q rend="double">ξεῖνε, τίη μίμνοντες ἐπὶ χρόνον ἔκτοθι πύργων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="794"><q rend="double; merge">ἧσθʼ αὔτως; ἐπεὶ οὐ μὲν ὑπʼ ἀνδράσι ναίεται ἄστυ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="795"><q rend="double; merge">ἀλλὰ Θρηικίης ἐπινάστιοι ἠπείροιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="796"><q rend="double; merge">πυροφόρους ἀρόωσι γύας. κακότητα δὲ πᾶσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="797"><q rend="double; merge">ἐξερέω νημερτές, ἵνʼ εὖ γνοίητε καὶ αὐτοί.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="798"><q rend="double; merge">εὖτε Θόας ἀστοῖσι πατὴρ ἐμὸς ἐμβασίλευεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="799"><q rend="double; merge">τηνίκα Θρηικίην, οἵ τʼ ἀντία ναιετάουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="800"><q rend="double; merge">δήμου ἀπορνύμενοι λαοὶ πέρθεσκον ἐπαύλους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="801"><q rend="double; merge">ἐκ νηῶν, αὐτῇσι δʼ ἀπείρονα ληίδα κούραις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="802"><q rend="double; merge">δεῦρʼ ἄγον· οὐλομένης δὲ θεᾶς πορσύνετο μῆτις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="803"><q rend="double; merge">Κύπριδος, ἥ τέ σφιν θυμοφθόρον ἔμβαλεν ἄτην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="804"><q rend="double; merge">δὴ γὰρ κουριδίας μὲν ἀπέστυγον, ἐκ δὲ μελάθρων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="805"><q rend="double; merge">ᾗ ματίῃ εἴξαντες, ἀπεσσεύοντο γυναῖκας·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="806"><q rend="double; merge">αὐτὰρ ληιάδεσσι δορικτήταις παρίαυον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="807"><q rend="double; merge">σχέτλιοι. ἦ μὲν δηρὸν ἐτέτλαμεν, εἴ κέ ποτʼ αὖτις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="808"><q rend="double; merge">ὀψὲ μεταστρέψωσι νόον· τὸ δὲ διπλόον αἰεὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="809"><q rend="double; merge">πῆμα κακὸν προύβαινεν. ἀτιμάζοντο δὲ τέκνα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="810"><q rend="double; merge">γνήσιʼ ἐνὶ μεγάροις, σκοτίη δʼ ἀνέτελλε γενέθλη.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="811"><q rend="double; merge">αὔτως δʼ ἀδμῆτές τε κόραι, χῆραί τʼ ἐπὶ τῇσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="812"><q rend="double; merge">μητέρες ἂμ πτολίεθρον ἀτημελέες ἀλάληντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="813"><q rend="double; merge">οὐδὲ πατὴρ ὀλίγον περ ἑῆς ἀλέγιζε θυγατρός,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="814"><q rend="double; merge">εἰ καὶ ἐν ὀφθαλμοῖσι δαϊζομένην ὁρόῳτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="815"><q rend="double; merge">μητρυιῆς ὑπὸ χερσὶν ἀτασθάλου· οὐδʼ ἀπὸ μητρὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="816"><q rend="double; merge">λώβην, ὡς τὸ πάροιθεν, ἀεικέα παῖδες ἄμυνον·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="817"><q rend="double; merge">οὐδὲ κασιγνήτοισι κασιγνήτη μελε θυμῷ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="818"><q rend="double; merge">ἀλλʼ οἶαι κοῦραι ληίτιδες ἔν τε δόμοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="819"><q rend="double; merge">ἔν τε χοροῖς ἀγορῇ τε καὶ εἰλαπίνῃσι μέλοντο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="820"><q rend="double; merge">εἰσόκε τις θεὸς ἄμμιν ὑπέρβιον ἔμβαλε θάρσος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="821"><q rend="double; merge">ἂψ ἀναερχομένους Θρῃκῶν ἄπο μηκέτι πύργοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="822"><q rend="double; merge">δέχθαι, ἵνʼ ἢ φρονέοιεν ἅπερ θέμις, ἠέ πῃ ἄλλῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="823"><q rend="double; merge">αὐταῖς ληιάδεσσιν ἀφορμηθέντες ἵκοιντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="824"><q rend="double; merge">οἱ δʼ ἄρα θεσσάμενοι παίδων γένος, ὅσσον ἔλειπτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="825"><q rend="double; merge">ἄρσεν ἀνὰ πτολίεθρον, ἔβαν πάλιν, ἔνθʼ ἔτι νῦν περ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="826"><q rend="double; merge">Θρηικίης ἄροσιν χιονώδεα ναιετάουσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="827"><q rend="double; merge">τῶ ὑμεῖς στρωφᾶσθʼ ἐπιδήμιοι· εἰ δέ κεν αὖθι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="828"><q rend="double; merge">ναιετάειν ἐθέλοις, καί τοι ἅδοι, ἦ τʼ ἂν ἔπειτα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="829"><q rend="double; merge">πατρὸς ἐμεῖο Θόαντος ἔχοις γέρας· οὐδέ τί σʼ οἴω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="830"><q rend="double; merge">γαῖαν ὀνόσσεσθαι· περὶ γὰρ βαθυλήιος ἄλλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="831"><q rend="double; merge">νήσων, Αἰγαίῃ ὅσαι εἰν ἁλὶ ναιετάουσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="832"><q rend="double; merge">ἀλλʼ ἄγε νῦν ἐπὶ νῆα κιὼν ἑτάροισιν ἐνίσπες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="833"><q rend="double; merge">μύθους ἡμετέρους, μηδʼ ἔκτοθι μίμνε πόληος.</q></l>
 					          <milestone n="834" unit="card"/>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="834">Ἴσκεν, ἀμαλδύνουσα φόνου τέλος, οἷον ἐτύχθη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="835">ἀνδράσιν· αὐτὰρ ὁ τήνγε παραβλήδην προσέειπεν</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="836">‘Ὑψιπύλη, μάλα κεν θυμηδέος ἀντιάσαιμεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="837">χρησμοσύνης, ἣν ἄμμι σέθεν χατέουσιν ὀπάζεις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="838">εἶμι δʼ ὑπότροπος αὖτις ἀνὰ πτόλιν, εὖτʼ ἂν ἕκαστα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="839">ἐξείπω κατὰ κόσμον. ἀνακτορίη δὲ μελέσθω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="840">σοίγʼ αὐτῇ καὶ νῆσος· ἔγωγε μὲν οὐκ ἀθερίζων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="841">χάζομαι, ἀλλά με λυγροὶ ἐπισπέρχουσιν ἄεθλοι.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="836"><q rend="double">Ὑψιπύλη, μάλα κεν θυμηδέος ἀντιάσαιμεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="837"><q rend="double; merge">χρησμοσύνης, ἣν ἄμμι σέθεν χατέουσιν ὀπάζεις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="838"><q rend="double; merge">εἶμι δʼ ὑπότροπος αὖτις ἀνὰ πτόλιν, εὖτʼ ἂν ἕκαστα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="839"><q rend="double; merge">ἐξείπω κατὰ κόσμον. ἀνακτορίη δὲ μελέσθω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="840"><q rend="double; merge">σοίγʼ αὐτῇ καὶ νῆσος· ἔγωγε μὲν οὐκ ἀθερίζων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="841"><q rend="double; merge">χάζομαι, ἀλλά με λυγροὶ ἐπισπέρχουσιν ἄεθλοι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="842">ἦ, καὶ δεξιτερῆς χειρὸς θίγεν· αἶψα δʼ ὀπίσσω</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="843">βῆ ῥʼ ἴμεν, ἀμφὶ δὲ τόνγε νεήνιδες ἄλλοθεν ἄλλαι</l>
@@ -1087,17 +1087,17 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="862">ναυτιλίης· δηρὸν δʼ ἂν ἐλίνυον αὖθι μένοντες,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="863">εἰ μὴ ἀολλίσσας ἑτάρους ἀπάνευθε γυναικῶν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="864">Ἡρακλέης τοίοισιν ἐνιπτάζων μετέειπεν·</l>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="865">‘δαιμόνιοι, πάτρης ἐμφύλιον αἷμʼ
-						ἀποέργει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="866">ἡμέας; ἦε γάμων ἐπιδευέες ἐνθάδʼ ἔβημεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="867">κεῖθεν, ὀνοσσάμενοι πολιήτιδας; αὖθι δʼ ἕαδεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="868">ναίοντας λιπαρὴν ἄροσιν Λήμνοιο ταμέσθαι;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="869">οὐ μὰν εὐκλειεῖς γε σὺν ὀθνείῃσι γυναιξὶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="870">ἐσσόμεθʼ ὧδʼ ἐπὶ δηρὸν ἐελμένοι· οὐδέ τι κῶας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="871">αὐτόματον δώσει τις ἑλὼν θεὸς εὐξαμένοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="872">ἴομεν αὖτις ἕκαστοι ἐπὶ σφέα· τὸν δʼ ἐνὶ λέκτροις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="873">Ὑψιπύλης εἰᾶτε πανήμερον, εἰσόκε Λῆμνον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="874">παισὶν ἐσανδρώσῃ, μεγάλη τέ ἑ βάξις ἵκηται.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="865"><q rend="double">δαιμόνιοι, πάτρης ἐμφύλιον αἷμʼ
+						ἀποέργει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="866"><q rend="double; merge">ἡμέας; ἦε γάμων ἐπιδευέες ἐνθάδʼ ἔβημεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="867"><q rend="double; merge">κεῖθεν, ὀνοσσάμενοι πολιήτιδας; αὖθι δʼ ἕαδεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="868"><q rend="double; merge">ναίοντας λιπαρὴν ἄροσιν Λήμνοιο ταμέσθαι;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="869"><q rend="double; merge">οὐ μὰν εὐκλειεῖς γε σὺν ὀθνείῃσι γυναιξὶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="870"><q rend="double; merge">ἐσσόμεθʼ ὧδʼ ἐπὶ δηρὸν ἐελμένοι· οὐδέ τι κῶας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="871"><q rend="double; merge">αὐτόματον δώσει τις ἑλὼν θεὸς εὐξαμένοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="872"><q rend="double; merge">ἴομεν αὖτις ἕκαστοι ἐπὶ σφέα· τὸν δʼ ἐνὶ λέκτροις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="873"><q rend="double; merge">Ὑψιπύλης εἰᾶτε πανήμερον, εἰσόκε Λῆμνον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="874"><q rend="double; merge">παισὶν ἐσανδρώσῃ, μεγάλη τέ ἑ βάξις ἵκηται.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="875">ὧς νείκεσσεν ὅμιλον· ἐναντία δʼ οὔ νύ τις
 						ἔτλη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="876">ὄμματʼ ἀνασχεθέειν, οὐδὲ προτιμυθήσασθαι·</l>
@@ -1114,31 +1114,31 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="887">Αἰσονίδεω, τὰ δέ οἱ ῥέε δάκρυα χήτει ἰόντος·</l>
 					          <milestone n="888" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="888">‘Νίσσεο, καὶ σὲ θεοὶ σὺν ἀπηρέσιν αὖτις
-						ἑταίροις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="889">χρύσειον βασιλῆι δέρος κομίσειαν ἄγοντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="890">αὔτως, ὡς ἐθέλεις καί τοι φίλον. ἥδε δὲ νῆσος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="891">σκῆπτρά τε πατρὸς ἐμεῖο παρέσσεται, ἢν καὶ ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="892">δή ποτε νοστήσας ἐθέλῃς ἄψορρον ἱκέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="893">ῥηιδίως δʼ ἂν ἑοῖ καὶ ἀπείρονα λαὸν ἀγείραις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="894">ἄλλων ἐκ πολίων· ἀλλʼ οὐ σύγε τήνδε μενοινὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="895">σχήσεις, οὔτʼ αὐτὴ προτιόσσομαι ὧδε τελεῖσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="896">μνώεο μὴν ἀπεών περ ὁμῶς καὶ νόστιμος ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="897">Ὑψιπύλης· λίπε δʼ ἧμιν ἔπος, τό κεν ἐξανύσαιμι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="898">πρόφρων, ἢν ἄρα δή με θεοὶ δώωσι τεκέσθαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="888"><q rend="double">Νίσσεο, καὶ σὲ θεοὶ σὺν ἀπηρέσιν αὖτις
+						ἑταίροις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="889"><q rend="double; merge">χρύσειον βασιλῆι δέρος κομίσειαν ἄγοντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="890"><q rend="double; merge">αὔτως, ὡς ἐθέλεις καί τοι φίλον. ἥδε δὲ νῆσος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="891"><q rend="double; merge">σκῆπτρά τε πατρὸς ἐμεῖο παρέσσεται, ἢν καὶ ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="892"><q rend="double; merge">δή ποτε νοστήσας ἐθέλῃς ἄψορρον ἱκέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="893"><q rend="double; merge">ῥηιδίως δʼ ἂν ἑοῖ καὶ ἀπείρονα λαὸν ἀγείραις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="894"><q rend="double; merge">ἄλλων ἐκ πολίων· ἀλλʼ οὐ σύγε τήνδε μενοινὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="895"><q rend="double; merge">σχήσεις, οὔτʼ αὐτὴ προτιόσσομαι ὧδε τελεῖσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="896"><q rend="double; merge">μνώεο μὴν ἀπεών περ ὁμῶς καὶ νόστιμος ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="897"><q rend="double; merge">Ὑψιπύλης· λίπε δʼ ἧμιν ἔπος, τό κεν ἐξανύσαιμι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="898"><q rend="double; merge">πρόφρων, ἢν ἄρα δή με θεοὶ δώωσι τεκέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="899">τὴν δʼ αὖτʼ Αἴσονος υἱὸς ἀγαιόμενος
 						προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="900">‘Ὑψιπύλη, τὰ μὲν οὕτω ἐναίσιμα πάντα γένοιτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="901">ἐκ μακάρων· τύνη δʼ ἐμέθεν πέρι θυμὸν ἀρείω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="902">ἴσχανʼ, ἐπεὶ πάτρην μοι ἅλις Πελίαο ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="903">ναιετάειν· μοῦνόν με θεοὶ λύσειαν ἀέθλων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="904">εἰ δʼ οὔ μοι πέπρωται ἐς Ἑλλάδα γαῖαν ἱκέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="905">τηλοῦ ἀναπλώοντι, σὺ δʼ ἄρσενα παῖδα τέκηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="906">πέμπε μιν ἡβήσαντα Πελασγίδος ἔνδον Ἰωλκοῦ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="907">πατρί τʼ ἐμῷ καὶ μητρὶ δύης ἄκος, ἢν ἄρα τούσγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="908">τέτμῃ ἔτι ζώοντας, ἵνʼ ἄνδιχα τοῖο ἄνακτος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="909">σφοῖσιν πορσύνωνται ἐφέστιοι ἐν μεγάροισιν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="900"><q rend="double">Ὑψιπύλη, τὰ μὲν οὕτω ἐναίσιμα πάντα γένοιτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="901"><q rend="double; merge">ἐκ μακάρων· τύνη δʼ ἐμέθεν πέρι θυμὸν ἀρείω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="902"><q rend="double; merge">ἴσχανʼ, ἐπεὶ πάτρην μοι ἅλις Πελίαο ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="903"><q rend="double; merge">ναιετάειν· μοῦνόν με θεοὶ λύσειαν ἀέθλων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="904"><q rend="double; merge">εἰ δʼ οὔ μοι πέπρωται ἐς Ἑλλάδα γαῖαν ἱκέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="905"><q rend="double; merge">τηλοῦ ἀναπλώοντι, σὺ δʼ ἄρσενα παῖδα τέκηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="906"><q rend="double; merge">πέμπε μιν ἡβήσαντα Πελασγίδος ἔνδον Ἰωλκοῦ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="907"><q rend="double; merge">πατρί τʼ ἐμῷ καὶ μητρὶ δύης ἄκος, ἢν ἄρα τούσγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="908"><q rend="double; merge">τέτμῃ ἔτι ζώοντας, ἵνʼ ἄνδιχα τοῖο ἄνακτος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="909"><q rend="double; merge">σφοῖσιν πορσύνωνται ἐφέστιοι ἐν μεγάροισιν.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="910">ἦ, καὶ ἔβαινʼ ἐπὶ νῆα παροίτατος· ὧς δὲ
 						καὶ ἄλλοι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="911">βαῖνον ἀριστῆες· λάζοντο δὲ χερσὶν ἐρετμὰ</l>
@@ -1333,17 +1333,17 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1090">τὸν δʼ ὅγε κεκλιμένον μαλακοῖς ἐνὶ κώεσιν οἰῶν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1091">κινήσας ἀνέγειρε παρασχεδόν, ὧδέ τʼ ἔειπεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1092">‘Αἰσονίδη, χρειώ σε τόδʼ ἱερὸν εἰσανιόντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1093">Δινδύμου ὀκριόεντος ἐύθρονον ἱλάξασθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1094">μητέρα συμπάντων μακάρων· λήξουσι δʼ ἄελλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1095">ζαχρηεῖς· τοίην γὰρ ἐγὼ νέον ὄσσαν ἄκουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1096">ἀλκυόνος ἁλίης, ἥ τε κνώσσοντος ὕπερθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1097">σεῖο πέριξ τὰ ἕκαστα πιφαυσκομένη πεπότηται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1098">ἐκ γὰρ τῆς ἄνεμοί τε θάλασσά τε νειόθι τε χθὼν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1099">πᾶσα πεπείρανται νιφόεν θʼ ἕδος Οὐλύμποιο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1100">καί οἱ, ὅτʼ ἐξ ὀρέων μέγαν οὐρανὸν εἰσαναβαίνῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1101">Ζεὺς αὐτὸς Κρονίδης ὑποχάζεται. ὧς δὲ καὶ ὧλλοι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1102">ἀθάνατοι μάκαρες δεινὴν θεὸν ἀμφιέπουσιν.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1092"><q rend="double">Αἰσονίδη, χρειώ σε τόδʼ ἱερὸν εἰσανιόντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1093"><q rend="double; merge">Δινδύμου ὀκριόεντος ἐύθρονον ἱλάξασθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1094"><q rend="double; merge">μητέρα συμπάντων μακάρων· λήξουσι δʼ ἄελλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1095"><q rend="double; merge">ζαχρηεῖς· τοίην γὰρ ἐγὼ νέον ὄσσαν ἄκουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1096"><q rend="double; merge">ἀλκυόνος ἁλίης, ἥ τε κνώσσοντος ὕπερθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1097"><q rend="double; merge">σεῖο πέριξ τὰ ἕκαστα πιφαυσκομένη πεπότηται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1098"><q rend="double; merge">ἐκ γὰρ τῆς ἄνεμοί τε θάλασσά τε νειόθι τε χθὼν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1099"><q rend="double; merge">πᾶσα πεπείρανται νιφόεν θʼ ἕδος Οὐλύμποιο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1100"><q rend="double; merge">καί οἱ, ὅτʼ ἐξ ὀρέων μέγαν οὐρανὸν εἰσαναβαίνῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1101"><q rend="double; merge">Ζεὺς αὐτὸς Κρονίδης ὑποχάζεται. ὧς δὲ καὶ ὧλλοι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1102"><q rend="double; merge">ἀθάνατοι μάκαρες δεινὴν θεὸν ἀμφιέπουσιν.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1103">ὧς φάτο· τῷ δʼ ἀσπαστὸν ἔπος γένετʼ εἰσαΐοντι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1104">ὤρνυτο δʼ ἐξ εὐνῆς κεχαρημένος· ὦρσε δʼ ἑταίρους</l>
@@ -1510,10 +1510,10 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1256">ἔκφατο λευγαλέην, βεβαρημένος ἄσθματι θυμόν·</l>
 					          <milestone n="1257" unit="card"/>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1257">‘δαιμόνιε, στυγερόν τοι ἄχος πάμπρωτος ἐνίψω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1258">οὐ γὰρ Ὕλας κρήνηνδε κιὼν σόος αὖτις ἱκάνει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1259">ἀλλά ἑ ληιστῆρες ἐνιχρίμψαντες ἄγουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1260">ἢ θῆρες σίνονται· ἐγὼ δʼ ἰάχοντος ἄκουσα.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1257"><q rend="double">δαιμόνιε, στυγερόν τοι ἄχος πάμπρωτος ἐνίψω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1258"><q rend="double; merge">οὐ γὰρ Ὕλας κρήνηνδε κιὼν σόος αὖτις ἱκάνει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1259"><q rend="double; merge">ἀλλά ἑ ληιστῆρες ἐνιχρίμψαντες ἄγουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1260"><q rend="double; merge">ἢ θῆρες σίνονται· ἐγὼ δʼ ἰάχοντος ἄκουσα.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1261">ὧς φάτο· τῷ δʼ ἀίοντι κατὰ κροτάφων ἅλις ἱδρὼς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1262">κήκιεν, ἐν δὲ κελαινὸν ὑπὸ σπλάγχνοις ζέεν αἷμα.</l>
@@ -1546,13 +1546,13 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1288">Αἰσονίδης· ἀλλʼ ἧστο βαρείῃ νειόθεν ἄτῃ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1289">θυμὸν ἔδων· Τελαμῶνα δʼ ἕλεν χόλος, ὧδέ τʼ ἔειπεν·</l>
 					          <milestone unit="para"/>
-				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1290">‘ἧσʼ αὔτως εὔκηλος, ἐπεί νύ τοι ἄρμενον
-						ἦεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1291">Ἡρακλῆα λιπεῖν· σέο δʼ ἔκτοθι μῆτις ὄρωρεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1292">ὄφρα τὸ κείνου κῦδος ἀνʼ Ἑλλάδα μή σε καλύψῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1293">αἴ κε θεοὶ δώωσιν ὑπότροπον οἴκαδε νόστον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1294">ἀλλὰ τί μύθων ἦδος; ἐπεὶ καὶ νόσφιν ἑταίρων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1295">εἶμι τεῶν, οἳ τόνγε δόλον συνετεκτήναντο.’</l>
+				        	<l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1290"><q rend="double">ἧσʼ αὔτως εὔκηλος, ἐπεί νύ τοι ἄρμενον
+						ἦεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1291"><q rend="double; merge">Ἡρακλῆα λιπεῖν· σέο δʼ ἔκτοθι μῆτις ὄρωρεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1292"><q rend="double; merge">ὄφρα τὸ κείνου κῦδος ἀνʼ Ἑλλάδα μή σε καλύψῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1293"><q rend="double; merge">αἴ κε θεοὶ δώωσιν ὑπότροπον οἴκαδε νόστον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1294"><q rend="double; merge">ἀλλὰ τί μύθων ἦδος; ἐπεὶ καὶ νόσφιν ἑταίρων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1295"><q rend="double; merge">εἶμι τεῶν, οἳ τόνγε δόλον συνετεκτήναντο.</q></l>
 					          <milestone unit="para"/>
                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1296">ἦ, καὶ ἐς Ἁγνιάδην Τῖφυν θόρε· τὼ δέ οἱ ὄσσε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1297">ὄστλιγγες μαλεροῖο πυρὸς ὣς ἰνδάλλοντο.</l>
@@ -1575,18 +1575,18 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1314">νηίου ὁλκαίοιο, καὶ ἴαχεν ἐσσυμένοισιν· </l>
                               <milestone n="1315" unit="card"/>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1315">‘τίπτε παρὲκ μεγάλοιο Διὸς μενεαίνετε
-						βουλὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1316">Αἰήτεω πτολίεθρον ἄγειν θρασὺν Ἡρακλῆα;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1317">Ἄργεΐ οἱ μοῖρʼ ἐστὶν ἀτασθάλῳ Εὐρυσθῆι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1318">ἐκπλῆσαι μογέοντα δυώδεκα πάντας ἀέθλους,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1319">ναίειν δʼ ἀθανάτοισι συνέστιον, εἴ κʼ ἔτι παύρους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1320">ἐξανύσῃ· τῶ μή τι ποθὴ κείνοιο πελέσθω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1321">αὔτως δʼ αὖ Πολύφημον ἐπὶ προχοῇσι Κίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1322">πέπρωται Μυσοῖσι περικλεὲς ἄστυ καμόντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1323">μοῖραν ἀναπλήσειν Χαλύβων ἐν ἀπείρονι γαίῃ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1324">αὐτὰρ Ὕλαν φιλότητι θεὰ ποιήσατο νύμφη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1325">ὃν πόσιν, οἷό περ οὕνεκʼ ἀποπλαγχθέντες ἔλειφθεν.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1315"><q rend="double">τίπτε παρὲκ μεγάλοιο Διὸς μενεαίνετε
+						βουλὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1316"><q rend="double; merge">Αἰήτεω πτολίεθρον ἄγειν θρασὺν Ἡρακλῆα;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1317"><q rend="double; merge">Ἄργεΐ οἱ μοῖρʼ ἐστὶν ἀτασθάλῳ Εὐρυσθῆι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1318"><q rend="double; merge">ἐκπλῆσαι μογέοντα δυώδεκα πάντας ἀέθλους,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1319"><q rend="double; merge">ναίειν δʼ ἀθανάτοισι συνέστιον, εἴ κʼ ἔτι παύρους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1320"><q rend="double; merge">ἐξανύσῃ· τῶ μή τι ποθὴ κείνοιο πελέσθω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1321"><q rend="double; merge">αὔτως δʼ αὖ Πολύφημον ἐπὶ προχοῇσι Κίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1322"><q rend="double; merge">πέπρωται Μυσοῖσι περικλεὲς ἄστυ καμόντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1323"><q rend="double; merge">μοῖραν ἀναπλήσειν Χαλύβων ἐν ἀπείρονι γαίῃ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1324"><q rend="double; merge">αὐτὰρ Ὕλαν φιλότητι θεὰ ποιήσατο νύμφη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1325"><q rend="double; merge">ὃν πόσιν, οἷό περ οὕνεκʼ ἀποπλαγχθέντες ἔλειφθεν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1326">ἦ, καὶ κῦμʼ ἀλίαστον ἐφέσσατο νειόθι δύψας·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1327">ἀμφὶ δέ οἱ δίνῃσι κυκώμενον ἄφρεεν ὕδωρ</l>
@@ -1595,20 +1595,20 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1330">Αἰακίδης Τελαμὼν ἐς Ἰήσονα, χεῖρα δὲ χειρὶ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1331">ἄκρην ἀμφιβαλὼν προσπτύξατο, φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1332">‘Αἰσονίδη, μή μοί τι χολώσεαι, ἀφραδίῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1333">εἴ τί περ ἀασάμην· πέρι γάρ μʼ ἄχος εἷλεν ἐνισπεῖν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1334">μῦθον ὑπερφίαλόν τε καὶ ἄσχετον, ἀλλʼ ἀνέμοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1335">δώομεν ἀμπλακίην, ὡς καὶ πάρος εὐμενέοντες.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1332"><q rend="double">Αἰσονίδη, μή μοί τι χολώσεαι, ἀφραδίῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1333"><q rend="double; merge">εἴ τί περ ἀασάμην· πέρι γάρ μʼ ἄχος εἷλεν ἐνισπεῖν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1334"><q rend="double; merge">μῦθον ὑπερφίαλόν τε καὶ ἄσχετον, ἀλλʼ ἀνέμοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1335"><q rend="double; merge">δώομεν ἀμπλακίην, ὡς καὶ πάρος εὐμενέοντες.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1336">τὸν δʼ αὖτʼ Αἴσονος υἱὸς ἐπιφραδέως
 						προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1337">‘ὦ πέπον, ἦ μάλα δή με κακῷ ἐκυδάσσαο μύθῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1338">φὰς ἐνὶ τοῖσιν ἅπασιν ἐνηέος ἀνδρὸς ἀλείτην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1339">ἔμμεναι. ἀλλʼ οὐ θήν τοι ἀδευκέα μῆνιν ἀέξω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1340">πρίν περ ἀνιηθείς· ἐπεὶ οὐ περὶ πώεσι μήλων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1341">οὐδὲ περὶ κτεάτεσσι χαλεψάμενος μενέηνας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1342">ἀλλʼ ἑτάρου περὶ φωτός. ἔολπα δέ τοι σὲ καὶ ἄλλῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1343">ἀμφʼ ἐμεῦ, εἰ τοιόνδε πέλοι ποτέ, δηρίσασθαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1337"><q rend="double">ὦ πέπον, ἦ μάλα δή με κακῷ ἐκυδάσσαο μύθῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1338"><q rend="double; merge">φὰς ἐνὶ τοῖσιν ἅπασιν ἐνηέος ἀνδρὸς ἀλείτην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1339"><q rend="double; merge">ἔμμεναι. ἀλλʼ οὐ θήν τοι ἀδευκέα μῆνιν ἀέξω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1340"><q rend="double; merge">πρίν περ ἀνιηθείς· ἐπεὶ οὐ περὶ πώεσι μήλων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1341"><q rend="double; merge">οὐδὲ περὶ κτεάτεσσι χαλεψάμενος μενέηνας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1342"><q rend="double; merge">ἀλλʼ ἑτάρου περὶ φωτός. ἔολπα δέ τοι σὲ καὶ ἄλλῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1343"><q rend="double; merge">ἀμφʼ ἐμεῦ, εἰ τοιόνδε πέλοι ποτέ, δηρίσασθαι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1344">ἦ ῥα, καὶ ἀρθμηθέντες, ὅπῃ πάρος, ἑδριόωντο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1345">τὼ δὲ Διὸς βουλῇσιν, ὁ μὲν Μυσοῖσι βαλέσθαι</l>
@@ -1644,22 +1644,22 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="9">ναυτιλίης, οἵ τʼ εἶεν, ὑπερβασίῃσιν ἄτισσεν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="10">τοῖον δʼ ἐν πάντεσσι παρασχεδὸν ἔκφατο μῦθον·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="11">‘Κέκλυθʼ, ἁλίπλαγκτοι, τάπερ ἴδμεναι ὔμμιν
-						ἔοικεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="12">οὔτινα θέσμιόν ἐστιν ἀφορμηθέντα νέεσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="13">ἀνδρῶν ὀθνείων, ὅς κεν Βέβρυξι πελάσσῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="14">πρὶν χείρεσσιν ἐμῇσιν ἑὰς ἀνὰ χεῖρας ἀεῖραι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="15">τῶ καί μοι τὸν ἄριστον ἀποκριδὸν οἶον ὁμίλου</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="16">πυγμαχίῃ στήσασθε καταυτόθι δηρινθῆναι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="17">εἰ δʼ ἂν ἀπηλεγέοντες ἐμὰς πατέοιτε θέμιστας,</l>
-				                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="18">ἦ κέν τις στυγερῶς κρατερὴ ἐπιέψετʼ ἀνάγκη.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="11"><q rend="double">Κέκλυθʼ, ἁλίπλαγκτοι, τάπερ ἴδμεναι ὔμμιν
+						ἔοικεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="12"><q rend="double; merge">οὔτινα θέσμιόν ἐστιν ἀφορμηθέντα νέεσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="13"><q rend="double; merge">ἀνδρῶν ὀθνείων, ὅς κεν Βέβρυξι πελάσσῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="14"><q rend="double; merge">πρὶν χείρεσσιν ἐμῇσιν ἑὰς ἀνὰ χεῖρας ἀεῖραι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="15"><q rend="double; merge">τῶ καί μοι τὸν ἄριστον ἀποκριδὸν οἶον ὁμίλου</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="16"><q rend="double; merge">πυγμαχίῃ στήσασθε καταυτόθι δηρινθῆναι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="17"><q rend="double; merge">εἰ δʼ ἂν ἀπηλεγέοντες ἐμὰς πατέοιτε θέμιστας,</q></l>
+				                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="18"><q rend="double; merge">ἦ κέν τις στυγερῶς κρατερὴ ἐπιέψετʼ ἀνάγκη.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="19">ἦ ῥα μέγα φρονέων· τοὺς δʼ ἄγριος εἰσαΐοντας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="20">εἷλε χόλος· περὶ δʼ αὖ Πολυδεύκεα τύψεν ὁμοκλη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="21">αἶψα δʼ ἑῶν ἑτάρων πρόμος ἵστατο, φώνησέν τε·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="22">‘ἴσχεο νῦν, μηδʼ ἄμμι κακήν, ὅτις εὔχεαι εἶναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="23">φαῖνε βίην· θεσμοῖς γὰρ ὑπείξομεν, ὡς ἀγορεύεις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="24">αὐτὸς ἑκὼν ἤδη τοι ὑπίσχομαι ἀντιάασθαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="22"><q rend="double">ἴσχεο νῦν, μηδʼ ἄμμι κακήν, ὅτις εὔχεαι εἶναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="23"><q rend="double; merge">φαῖνε βίην· θεσμοῖς γὰρ ὑπείξομεν, ὡς ἀγορεύεις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="24"><q rend="double; merge">αὐτὸς ἑκὼν ἤδη τοι ὑπίσχομαι ἀντιάασθαι.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="25">ὧς φάτʼ ἀπηλεγέως· ὁ δʼ ἐσέδρακεν ὄμμαθʼ
 						ἑλίξας,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="26">ὥστε λέων ὑπʼ ἄκοντι τετυμμένος, ὅν τʼ ἐν ὄρεσσιν</l>
@@ -1692,12 +1692,12 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="53">ὠμούς, ἀζαλέους, περὶ δʼ οἵγʼ ἔσαν ἐσκληῶτες.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="54">αὐτὰρ ὁ τόνγʼ ἐπέεσσιν ὑπερφιάλοισι μετηύδα·</l>
 					          <milestone n="55" unit="card"/>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="55">‘τῶνδέ τοι ὅν κʼ ἐθέλῃσθα, πάλου ἄτερ
-						ἐγγυαλίξω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="56">αὐτὸς ἑκών, ἵνα μή μοι ἀτέμβηαι μετόπισθεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="57">ἀλλὰ βάλευ περὶ χειρί· δαεὶς δέ κεν ἄλλῳ ἐνίσποις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="58">ὅσσον ἐγὼ ῥινούς τε βοῶν περίειμι ταμέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="59">ἀζαλέας, ἀνδρῶν τε παρηίδας αἵματι φύρσαι.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="55"><q rend="double">τῶνδέ τοι ὅν κʼ ἐθέλῃσθα, πάλου ἄτερ
+						ἐγγυαλίξω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="56"><q rend="double; merge">αὐτὸς ἑκών, ἵνα μή μοι ἀτέμβηαι μετόπισθεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="57"><q rend="double; merge">ἀλλὰ βάλευ περὶ χειρί· δαεὶς δέ κεν ἄλλῳ ἐνίσποις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="58"><q rend="double; merge">ὅσσον ἐγὼ ῥινούς τε βοῶν περίειμι ταμέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="59"><q rend="double; merge">ἀζαλέας, ἀνδρῶν τε παρηίδας αἵματι φύρσαι.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="60">ὧς ἔφατʼ· αὐτὰρ ὅγʼ οὔτι παραβλήδην
 						ἐρίδηνεν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="61">ἦκα δὲ μειδήσας, οἵ οἱ παρὰ ποσσὶν ἔκειντο,</l>
@@ -1788,16 +1788,16 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="144">ἥρωες, καὶ δή τις ἔπος μετὰ τοῖσιν ἔειπεν·</l>
 					          <milestone n="145" unit="card"/>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="145">‘Φράζεσθʼ ὅττι κεν ᾗσιν ἀναλκείῃσιν
-						ἔρεξαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="146">εἴ πως Ἡρακλῆα θεὸς καὶ δεῦρʼ ἐκόμισσεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="147">ἤτοι μὲν γὰρ ἐγὼ κείνου παρεόντος ἔολπα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="148">οὐδʼ ἂν πυγμαχίῃ κρινθήμεναι· ἀλλʼ ὅτε θεσμοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="149">ἤλυθεν ἐξερέων, αὐτοῖς ἄφαρ οἷς ἀγόρευεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="150">θεσμοῖσιν ῥοπάλῳ μιν ἀγηνορίης λελαθέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="151">ναὶ μὲν ἀκήδεστον γαίῃ ἔνι τόνγε λιπόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="152">πόντον ἐπέπλωμεν· μάλα δʼ ἡμέων αὐτὸς ἕκαστος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="153">εἴσεται οὐλομένην ἄτην, ἀπάνευθεν ἐόντος.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="145"><q rend="double">Φράζεσθʼ ὅττι κεν ᾗσιν ἀναλκείῃσιν
+						ἔρεξαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="146"><q rend="double; merge">εἴ πως Ἡρακλῆα θεὸς καὶ δεῦρʼ ἐκόμισσεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="147"><q rend="double; merge">ἤτοι μὲν γὰρ ἐγὼ κείνου παρεόντος ἔολπα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="148"><q rend="double; merge">οὐδʼ ἂν πυγμαχίῃ κρινθήμεναι· ἀλλʼ ὅτε θεσμοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="149"><q rend="double; merge">ἤλυθεν ἐξερέων, αὐτοῖς ἄφαρ οἷς ἀγόρευεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="150"><q rend="double; merge">θεσμοῖσιν ῥοπάλῳ μιν ἀγηνορίης λελαθέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="151"><q rend="double; merge">ναὶ μὲν ἀκήδεστον γαίῃ ἔνι τόνγε λιπόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="152"><q rend="double; merge">πόντον ἐπέπλωμεν· μάλα δʼ ἡμέων αὐτὸς ἕκαστος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="153"><q rend="double; merge">εἴσεται οὐλομένην ἄτην, ἀπάνευθεν ἐόντος.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="154">ὧς ἄρʼ ἔφη· τὰ δὲ πάντα Διὸς βουλῇς ἐτέτυκτο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="155">καὶ τότε μὲν μένον αὖθι διὰ κνέφας, ἕλκεά τʼ ἀνδρῶν</l>
@@ -1858,64 +1858,64 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="208">στήθεος ἀμπνεύσας μετεφώνεε μαντοσύνῃσιν· </l>
                               <milestone n="209" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="209">‘κλῦτε, Πανελλήνων προφερέστατοι, εἰ ἐτεὸν δὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="210">οἵδʼ ὑμεῖς, οὓς δή κρυερῇ βασιλῆος ἐφετμῇ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="211">Ἁργῴης ἐπὶ νηὸς ἄγει μετὰ κῶας Ἰήσων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="212">ὑμεῖς ἀτρεκέως. ἔτι μοι νόος οἶδεν ἕκαστα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="213">ᾗσι θεοπροπίῃσι. χάριν νύ τοι, ὦ ἄνα Λητοῦς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="214">υἱέ, καὶ ἀργαλέοισιν ἀνάπτομαι ἐν καμάτοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="215">Ἱκεσίου πρὸς Ζηνός, ὅτις ῥίγιστος ἀλιτροῖς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="216">ἀνδράσι, Φοίβου τʼ ἀμφὶ καὶ αὐτῆς εἵνεκεν Ἥρης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="217">λίσσομαι, ᾗ περίαλλα θεῶν μέμβλεσθε κιόντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="218">χραίσμετέ μοι, ῥύσασθε δυσάμμορον ἀνέρα λύμης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="219">μηδέ μʼ ἀκηδείῃσιν ἀφορμήθητε λιπόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="220">αὔτως. οὐ γὰρ μοῦνον ἐπʼ ὀφθαλμοῖσιν Ἐρινὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="221">λὰξ ἐπέβη, καὶ γῆρας ἀμήρυτον ἐς τέλος ἕλκω·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="222">πρὸς δʼ ἔτι πικρότατον κρέμαται κακὸν ἄλλο κακοῖσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="223">ἅρπυιαι στόματός μοι ἀφαρπάζουσιν ἐδωδὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="224">ἔκποθεν ἀφράστοιο καταΐσσουσαι ὄλεθροι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="225">ἴσχω δʼ οὔτινα μῆτιν ἐπίρροθον. ἀλλά κε ῥεῖα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="226">αὐτὸς ἑὸν λελάθοιμι νόον δόρποιο μεμηλώς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="227">ἢ κείνας· ὧδʼ αἶψα διηέριαι ποτέονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="228">τυτθὸν δʼ ἢν ἄρα δήποτʼ ἐδητύος ἄμμι λίπωσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="229">πνεῖ τόδε μυδαλέον τε καὶ οὐ τλητὸν μένος ὀδμῆς·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="230">οὔ κέ τις οὐδὲ μίνυνθα βροτῶν ἄνσχοιτο πελάσσας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="231">οὐδʼ εἴ οἱ ἀδάμαντος ἐληλάμενον κέαρ εἴη.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="232">ἀλλά με πικρὴ δῆτα καὶ ἄατος ἴσχει ἀνάγκη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="233">μίμνειν καὶ μίμνοντα κακῇ ἐνὶ γαστέρι θέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="234">τὰς μὲν θέσφατόν ἐστιν ἐρητῦσαι Βορέαο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="235">υἱέας. οὐδʼ ὀθνεῖοι ἀλαλκήσουσιν ἐόντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="236">εἰ δὴ ἐγὼν ὁ πρίν ποτʼ ἐπικλυτὸς ἀνδράσι Φινεὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="237">ὄλβῳ μαντοσύνῃ τε, πατὴρ δέ με γείνατʼ Ἀγήνωρ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="238">τῶν δὲ κασιγνήτην, ὅτʼ ἐνὶ Θρῄκεσσιν ἄνασσον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="239">Κλειοπάτρην ἕδνοισιν ἐμὸν δόμον ἦγον ἄκοιτιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="209"><q rend="double">κλῦτε, Πανελλήνων προφερέστατοι, εἰ ἐτεὸν δὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="210"><q rend="double; merge">οἵδʼ ὑμεῖς, οὓς δή κρυερῇ βασιλῆος ἐφετμῇ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="211"><q rend="double; merge">Ἁργῴης ἐπὶ νηὸς ἄγει μετὰ κῶας Ἰήσων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="212"><q rend="double; merge">ὑμεῖς ἀτρεκέως. ἔτι μοι νόος οἶδεν ἕκαστα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="213"><q rend="double; merge">ᾗσι θεοπροπίῃσι. χάριν νύ τοι, ὦ ἄνα Λητοῦς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="214"><q rend="double; merge">υἱέ, καὶ ἀργαλέοισιν ἀνάπτομαι ἐν καμάτοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="215"><q rend="double; merge">Ἱκεσίου πρὸς Ζηνός, ὅτις ῥίγιστος ἀλιτροῖς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="216"><q rend="double; merge">ἀνδράσι, Φοίβου τʼ ἀμφὶ καὶ αὐτῆς εἵνεκεν Ἥρης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="217"><q rend="double; merge">λίσσομαι, ᾗ περίαλλα θεῶν μέμβλεσθε κιόντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="218"><q rend="double; merge">χραίσμετέ μοι, ῥύσασθε δυσάμμορον ἀνέρα λύμης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="219"><q rend="double; merge">μηδέ μʼ ἀκηδείῃσιν ἀφορμήθητε λιπόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="220"><q rend="double; merge">αὔτως. οὐ γὰρ μοῦνον ἐπʼ ὀφθαλμοῖσιν Ἐρινὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="221"><q rend="double; merge">λὰξ ἐπέβη, καὶ γῆρας ἀμήρυτον ἐς τέλος ἕλκω·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="222"><q rend="double; merge">πρὸς δʼ ἔτι πικρότατον κρέμαται κακὸν ἄλλο κακοῖσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="223"><q rend="double; merge">ἅρπυιαι στόματός μοι ἀφαρπάζουσιν ἐδωδὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="224"><q rend="double; merge">ἔκποθεν ἀφράστοιο καταΐσσουσαι ὄλεθροι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="225"><q rend="double; merge">ἴσχω δʼ οὔτινα μῆτιν ἐπίρροθον. ἀλλά κε ῥεῖα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="226"><q rend="double; merge">αὐτὸς ἑὸν λελάθοιμι νόον δόρποιο μεμηλώς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="227"><q rend="double; merge">ἢ κείνας· ὧδʼ αἶψα διηέριαι ποτέονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="228"><q rend="double; merge">τυτθὸν δʼ ἢν ἄρα δήποτʼ ἐδητύος ἄμμι λίπωσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="229"><q rend="double; merge">πνεῖ τόδε μυδαλέον τε καὶ οὐ τλητὸν μένος ὀδμῆς·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="230"><q rend="double; merge">οὔ κέ τις οὐδὲ μίνυνθα βροτῶν ἄνσχοιτο πελάσσας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="231"><q rend="double; merge">οὐδʼ εἴ οἱ ἀδάμαντος ἐληλάμενον κέαρ εἴη.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="232"><q rend="double; merge">ἀλλά με πικρὴ δῆτα καὶ ἄατος ἴσχει ἀνάγκη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="233"><q rend="double; merge">μίμνειν καὶ μίμνοντα κακῇ ἐνὶ γαστέρι θέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="234"><q rend="double; merge">τὰς μὲν θέσφατόν ἐστιν ἐρητῦσαι Βορέαο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="235"><q rend="double; merge">υἱέας. οὐδʼ ὀθνεῖοι ἀλαλκήσουσιν ἐόντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="236"><q rend="double; merge">εἰ δὴ ἐγὼν ὁ πρίν ποτʼ ἐπικλυτὸς ἀνδράσι Φινεὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="237"><q rend="double; merge">ὄλβῳ μαντοσύνῃ τε, πατὴρ δέ με γείνατʼ Ἀγήνωρ·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="238"><q rend="double; merge">τῶν δὲ κασιγνήτην, ὅτʼ ἐνὶ Θρῄκεσσιν ἄνασσον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="239"><q rend="double; merge">Κλειοπάτρην ἕδνοισιν ἐμὸν δόμον ἦγον ἄκοιτιν.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="240">Ἴσκεν Ἀγηνορίδης· ἀδινὸν δʼ ἕλε κῆδος
 						ἕκαστον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="241">ἡρώων, πέρι δʼ αὖτε δύω υἷας Βορέαο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="242">δάκρυ δʼ ὀμορξαμένω σχεδὸν ἤλυθον, ὧδέ τʼ ἔειπεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="243">Ζήτης, ἀσχαλόωντος ἑλὼν χερὶ χεῖρα γέροντος·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="244">‘Ἆ δείλʼ, οὔτινά φημι σέθεν σμυγερώτερον
-						ἄλλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="245">ἔμμεναι ἀνθρώπων. τί νύ τοι τόσα κήδεʼ ἀνῆπται;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="246">ἦ ῥα θεοὺς ὀλοῇσι παρήλιτες ἀφραδίῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="247">μαντοσύνας δεδαώς; τῶ τοι μέγα μηνιόωσιν;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="248">ἄμμι γε μὴν νόος ἔνδον ἀτύζεται ἱεμένοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="249">χραισμεῖν, εἰ δὴ πρόχνυ γέρας τόδε πάρθετο δαίμων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="250">νῶιν. ἀρίζηλοι γὰρ ἐπιχθονίοισιν ἐνιπαὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="251">ἀθανάτων. οὐδʼ ἂν πρὶν ἐρητύσαιμεν ἰούσας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="252">Ἁρπυίας, μάλα περ λελιημένοι, ἔστʼ ἂν ὀμόσσῃς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="253">μὴ μὲν τοῖό γʼ ἕκητι θεοῖς ἀπὸ θυμοῦ ἔσεσθαι.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="244"><q rend="double">Ἆ δείλʼ, οὔτινά φημι σέθεν σμυγερώτερον
+						ἄλλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="245"><q rend="double; merge">ἔμμεναι ἀνθρώπων. τί νύ τοι τόσα κήδεʼ ἀνῆπται;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="246"><q rend="double; merge">ἦ ῥα θεοὺς ὀλοῇσι παρήλιτες ἀφραδίῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="247"><q rend="double; merge">μαντοσύνας δεδαώς; τῶ τοι μέγα μηνιόωσιν;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="248"><q rend="double; merge">ἄμμι γε μὴν νόος ἔνδον ἀτύζεται ἱεμένοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="249"><q rend="double; merge">χραισμεῖν, εἰ δὴ πρόχνυ γέρας τόδε πάρθετο δαίμων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="250"><q rend="double; merge">νῶιν. ἀρίζηλοι γὰρ ἐπιχθονίοισιν ἐνιπαὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="251"><q rend="double; merge">ἀθανάτων. οὐδʼ ἂν πρὶν ἐρητύσαιμεν ἰούσας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="252"><q rend="double; merge">Ἁρπυίας, μάλα περ λελιημένοι, ἔστʼ ἂν ὀμόσσῃς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="253"><q rend="double; merge">μὴ μὲν τοῖό γʼ ἕκητι θεοῖς ἀπὸ θυμοῦ ἔσεσθαι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="254">ὧς φάτο· τοῦ δʼ ἰθὺς κενεὰς ὁ γεραιὸς ἀνέσχεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="255">γλήνας ἀμπετάσας, καὶ ἀμείψατο τοῖσδʼ ἐπέεσσιν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="256">‘σίγα· μή μοι ταῦτα νόῳ ἔνι βάλλεο, τέκνον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="257">ἴστω Λητοῦς υἱός, ὅ με πρόφρων ἐδίδαξεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="258">μαντοσύνας· ἴστω δὲ δυσώνυμος, ἥ μʼ ἔλαχεν, κὴρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="259">καὶ τόδʼ ἐπʼ ὀφθαλμῶν ἀλαὸν νέφος, οἵ θʼ ὑπένερθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="260">δαίμονες, οἳ μηδʼ ὧδε θανόντι περ εὐμενέοιεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="261">ὡς οὔ τις θεόθεν χόλος ἔσσεται εἵνεκʼ ἀρωγῆς.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="256"><q rend="double">σίγα· μή μοι ταῦτα νόῳ ἔνι βάλλεο, τέκνον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="257"><q rend="double; merge">ἴστω Λητοῦς υἱός, ὅ με πρόφρων ἐδίδαξεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="258"><q rend="double; merge">μαντοσύνας· ἴστω δὲ δυσώνυμος, ἥ μʼ ἔλαχεν, κὴρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="259"><q rend="double; merge">καὶ τόδʼ ἐπʼ ὀφθαλμῶν ἀλαὸν νέφος, οἵ θʼ ὑπένερθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="260"><q rend="double; merge">δαίμονες, οἳ μηδʼ ὧδε θανόντι περ εὐμενέοιεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="261"><q rend="double; merge">ὡς οὔ τις θεόθεν χόλος ἔσσεται εἵνεκʼ ἀρωγῆς.</q></l>
 					          <milestone n="262" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="262">τὼ μὲν ἔπειθʼ ὅρκοισιν ἀλαλκέμεναι μενέαινον.</l>
@@ -1945,9 +1945,9 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="286">εἰ μὴ ἄρʼ ὠκέα Ἶρις ἴδεν, κατὰ δʼ αἰθέρος ἆλτο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="287">οὐρανόθεν, καὶ τοῖα παραιφαμένη κατέρυκεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="288">‘οὐ θέμις, ὦ υἱεῖς Βορέω, ξιφέεσσιν ἐλάσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="289">Ἁρπυίας, μεγάλοιο Διὸς κύνας· ὅρκια δʼ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="290">δώσω ἐγών, ὡς οὔ οἱ ἔτι χρίμψουσιν ἰοῦσαι.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="288"><q rend="double">οὐ θέμις, ὦ υἱεῖς Βορέω, ξιφέεσσιν ἐλάσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="289"><q rend="double; merge">Ἁρπυίας, μεγάλοιο Διὸς κύνας· ὅρκια δʼ αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="290"><q rend="double; merge">δώσω ἐγών, ὡς οὔ οἱ ἔτι χρίμψουσιν ἰοῦσαι.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="291">ὧς φαμένη λοιβὴν Στυγὸς ὤμοσεν, ἥ τε θεοῖσιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="292">ῥιγίστη πάντεσσιν ὀπιδνοτάτη τε τέτυκται,</l>
@@ -1971,112 +1971,112 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="309">αὐτὸς δʼ ἐν μέσσοισι παρʼ ἐσχάρῃ ἧστο γεραιὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="310">πείρατα ναυτιλίης ἐνέπων ἄνυσίν τε κελεύθου·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="311">‘κλῦτέ νυν. οὐ μὲν πάντα πέλει θέμις ὔμμι
-						δαῆναι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="312">ἀτρεκές· ὅσσα δʼ ὄρωρε θεοῖς φίλον, οὐκ ἐπικεύσω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="313">ἀασάμην καὶ πρόσθε Διὸς νόον ἀφραδίῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="314">χρείων ἑξείης τε καὶ ἐς τέλος. ὧδε γὰρ αὐτὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="315">βούλεται ἀνθρώποις ἐπιδευέα θέσφατα φαίνειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="316">μαντοσύνης, ἵνα καί τι θεῶν χατέωσι νόοιο.</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="311"><q rend="double">κλῦτέ νυν. οὐ μὲν πάντα πέλει θέμις ὔμμι
+						δαῆναι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="312"><q rend="double; merge">ἀτρεκές· ὅσσα δʼ ὄρωρε θεοῖς φίλον, οὐκ ἐπικεύσω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="313"><q rend="double; merge">ἀασάμην καὶ πρόσθε Διὸς νόον ἀφραδίῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="314"><q rend="double; merge">χρείων ἑξείης τε καὶ ἐς τέλος. ὧδε γὰρ αὐτὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="315"><q rend="double; merge">βούλεται ἀνθρώποις ἐπιδευέα θέσφατα φαίνειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="316"><q rend="double; merge">μαντοσύνης, ἵνα καί τι θεῶν χατέωσι νόοιο.</q></l>
 					          <milestone n="317" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="317">πέτρας μὲν πάμπρωτον, ἀφορμηθέντες ἐμεῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="318">Κυανέας ὄψεσθε δύω ἁλὸς ἐν ξυνοχῇσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="319">τάων οὔτινά φημι διαμπερὲς ἐξαλέασθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="320">οὐ γάρ τε ῥίζῃσιν ἐρήρεινται νεάτῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="321">ἀλλὰ θαμὰ ξυνίασιν ἐναντίαι ἀλλήλῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="322">εἰς ἕν, ὕπερθε δὲ πολλὸν ἁλὸς κορθύεται ὕδωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="323">βρασσόμενον· στρηνὲς δὲ περὶ στυφελῇ βρέμει ἀκτῇ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="324">τῶ νῦν ἡμετέρῃσι παραιφασίῃσι πίθεσθε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="325">εἰ ἐτεὸν πυκινῷ τε νόῳ μακάρων τʼ ἀλέγοντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="326">πείρετε· μηδʼ αὔτως αὐτάγρετον οἶτον ὄλησθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="327">ἀφραδέως, ἢ θύνετʼ ἐπισπόμενοι νεότητι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="328">οἰωνῷ δή πρόσθε πελειάδι πειρήσασθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="329">νηὸς ἄπο προμεθέντες ἐφιέμεν. ἢν δὲ διʼ αὐτῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="330">πετράων πόντονδε σόη πτερύγεσσι δίηται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="331">μηκέτι δὴν μηδʼ αὐτοὶ ἐρητύεσθε κελεύθου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="332">ἀλλʼ εὖ καρτύναντες ἑαῖς ἐνὶ χερσὶν ἐρετμὰ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="333">τέμνεθʼ ἁλὸς στεινωπόν· ἐπεὶ φάος οὔ νύ τι τόσσον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="334">ἔσσετʼ ἐν εὐχωλῇσιν, ὅσον τʼ ἐνὶ κάρτεϊ χειρῶν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="335">τῶ καὶ τἆλλα μεθέντες ὀνήιστον πονέεσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="336">θαρσαλέως· πρὶν δʼ οὔτι θεοὺς λίσσεσθαι ἐρύκω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="337">εἰ δέ κεν ἀντικρὺ πταμένη μεσσηγὺς ὄληται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="338">ἄψορροι στέλλεσθαι ἐπεὶ πολὺ βέλτερον εἶξαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="339">ἀθανάτοις. οὐ γάρ κε κακὸν μόρον ἐξαλέαισθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="340">πετράων, οὐδʼ εἴ κε σιδηρείη πέλοι Λ̓ργώ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="341">ὦ μέλεοι, μὴ τλῆτε παρὲξ ἐμὰ θέσφατα βῆναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="342">εἰ καί με τρὶς τόσσον ὀίεσθʼ Οὐρανίδῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="343">ὅσσον ἀνάρσιός εἰμι, καὶ εἰ πλεῖον στυγέεσθαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="344">μὴ τλῆτʼ οἰωνοῖο πάρεξ ἔτι νηὶ περῆσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="345">καὶ τὰ μὲν ὥς κε πέλῃ, τὼς ἔσσεται. ἢν δὲ φύγητε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="346">σύνδρομα πετράων ἀσκηθέες ἔνδοθι Πόντου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="347">αὐτίκα Βιθυνῶν ἐπὶ δεξιὰ γαῖαν ἔχοντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="348">πλώετε ῥηγμῖνας πεφυλαγμένοι, εἰσόκεν αὖτε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="349">Ῥήβαν ὠκυρόην ποταμὸν ἄκρην τε Μέλαιναν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="350">γνάμψαντες νήσου Θυνηίδος ὅρμον ἵκησθε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="351">κεῖθεν δʼ οὐ μάλα πουλὺ διὲξ ἁλὸς ἀντιπέραιαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="352">γῆν Μαριανδυνῶν ἐπικέλσετε νοστήσαντες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="353">ἔνθα μὲν εἰς Ἀίδαο καταιβάτις ἐστὶ κέλευθος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="354">ἄκρη τε προβλὴς Ἀχερουσιὰς ὑψόθι τείνει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="355">δινήεις τʼ Ἀχέρων αὐτὴν διὰ νειόθι τέμνων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="356">ἄκρην ἐκ μεγάλης προχοὰς ἵησι φάραγγος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="357">ἀγχίμολον δʼ ἐπὶ τῇ πολέας παρανεῖσθε κολωνοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="358">Παφλαγόνων, τοῖσίν τʼ Ἐνετήιος ἐμβασίλευσεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="359">πρῶτα Πέλοψ, τοῦ καί περ ἀφʼ αἵματος εὐχετόωνται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="360">ἔστι δέ τις ἄκρη Ἑλίκης κατεναντίον Ἄρκτου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="361">πάντοθεν ἠλίβατος, καί μιν καλέουσι Κάραμβιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="362">τῆς καὶ ὑπὲρ βορέαο περισχίζονται ἄελλαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="363">ὧδε μάλʼ ἂμ πέλαγος τετραμμένη αἰθέρι κύρει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="364">τήνδε περιγνάμψαντι πολὺς παρακέκλιται· ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="365">αἰγιαλός· πολέος δʼ ἐπὶ πείρασιν Αἰγιαλοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="366">ἀκτῇ ἐπὶ προβλῆτι ῥοαὶ Ἅλυος ποταμοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="367">δεινὸν ἐρεύγονται· μετὰ τὸν δʼ ἀγχίροος Ἶρις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="368">μειότερος λευκῇσιν ἑλίσσεται εἰς ἅλα δίναις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="369">κεῖθεν δὲ προτέρωσε μέγας καὶ ὑπείροχος ἀγκὼν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="370">ἐξανέχει γαίης· ἐπὶ δὲ στόμα Θερμώδοντος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="371">κόλπῳ ἐν εὐδιόωντι Θεμισκύρειον ὑπʼ ἄκρην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="372">μύρεται, εὐρείης διαειμένος ἠπείροιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="373">ἔνθα δὲ Δοίαντος πεδίον, σχεδόθεν δὲ πόληες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="374">τρισσαὶ Ἀμαζονίδων, μετά τε σμυγερώτατοι ἀνδρῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="375">τρηχεῖαν Χάλυβες καὶ ἀτειρέα γαῖαν ἔχουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="376">ἐργατίναι· τοὶ δʼ ἀμφὶ σιδήρεα ἔργα μέλονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="377">ἄγχι δὲ ϝαιετάουσι πολύρρηνες Τιβαρηνοὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="378">Ζηνὸς Ἐυξείνοιο Γενηταίην ὑπὲρ ἄκρην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="379">τῇ δʼ ἐπὶ Μοσσύνοικοι ὁμούριοι ὑλήεσσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="380">ἑξείης ἤπειρον, ὑπωρείας τε νέμονται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="381">δουρατέοις πύργοισιν ἐν οἰκία τεκτήναντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="382a">
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="317"><q rend="double; merge">πέτρας μὲν πάμπρωτον, ἀφορμηθέντες ἐμεῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="318"><q rend="double; merge">Κυανέας ὄψεσθε δύω ἁλὸς ἐν ξυνοχῇσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="319"><q rend="double; merge">τάων οὔτινά φημι διαμπερὲς ἐξαλέασθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="320"><q rend="double; merge">οὐ γάρ τε ῥίζῃσιν ἐρήρεινται νεάτῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="321"><q rend="double; merge">ἀλλὰ θαμὰ ξυνίασιν ἐναντίαι ἀλλήλῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="322"><q rend="double; merge">εἰς ἕν, ὕπερθε δὲ πολλὸν ἁλὸς κορθύεται ὕδωρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="323"><q rend="double; merge">βρασσόμενον· στρηνὲς δὲ περὶ στυφελῇ βρέμει ἀκτῇ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="324"><q rend="double; merge">τῶ νῦν ἡμετέρῃσι παραιφασίῃσι πίθεσθε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="325"><q rend="double; merge">εἰ ἐτεὸν πυκινῷ τε νόῳ μακάρων τʼ ἀλέγοντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="326"><q rend="double; merge">πείρετε· μηδʼ αὔτως αὐτάγρετον οἶτον ὄλησθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="327"><q rend="double; merge">ἀφραδέως, ἢ θύνετʼ ἐπισπόμενοι νεότητι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="328"><q rend="double; merge">οἰωνῷ δή πρόσθε πελειάδι πειρήσασθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="329"><q rend="double; merge">νηὸς ἄπο προμεθέντες ἐφιέμεν. ἢν δὲ διʼ αὐτῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="330"><q rend="double; merge">πετράων πόντονδε σόη πτερύγεσσι δίηται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="331"><q rend="double; merge">μηκέτι δὴν μηδʼ αὐτοὶ ἐρητύεσθε κελεύθου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="332"><q rend="double; merge">ἀλλʼ εὖ καρτύναντες ἑαῖς ἐνὶ χερσὶν ἐρετμὰ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="333"><q rend="double; merge">τέμνεθʼ ἁλὸς στεινωπόν· ἐπεὶ φάος οὔ νύ τι τόσσον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="334"><q rend="double; merge">ἔσσετʼ ἐν εὐχωλῇσιν, ὅσον τʼ ἐνὶ κάρτεϊ χειρῶν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="335"><q rend="double; merge">τῶ καὶ τἆλλα μεθέντες ὀνήιστον πονέεσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="336"><q rend="double; merge">θαρσαλέως· πρὶν δʼ οὔτι θεοὺς λίσσεσθαι ἐρύκω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="337"><q rend="double; merge">εἰ δέ κεν ἀντικρὺ πταμένη μεσσηγὺς ὄληται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="338"><q rend="double; merge">ἄψορροι στέλλεσθαι ἐπεὶ πολὺ βέλτερον εἶξαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="339"><q rend="double; merge">ἀθανάτοις. οὐ γάρ κε κακὸν μόρον ἐξαλέαισθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="340"><q rend="double; merge">πετράων, οὐδʼ εἴ κε σιδηρείη πέλοι Λ̓ργώ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="341"><q rend="double; merge">ὦ μέλεοι, μὴ τλῆτε παρὲξ ἐμὰ θέσφατα βῆναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="342"><q rend="double; merge">εἰ καί με τρὶς τόσσον ὀίεσθʼ Οὐρανίδῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="343"><q rend="double; merge">ὅσσον ἀνάρσιός εἰμι, καὶ εἰ πλεῖον στυγέεσθαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="344"><q rend="double; merge">μὴ τλῆτʼ οἰωνοῖο πάρεξ ἔτι νηὶ περῆσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="345"><q rend="double; merge">καὶ τὰ μὲν ὥς κε πέλῃ, τὼς ἔσσεται. ἢν δὲ φύγητε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="346"><q rend="double; merge">σύνδρομα πετράων ἀσκηθέες ἔνδοθι Πόντου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="347"><q rend="double; merge">αὐτίκα Βιθυνῶν ἐπὶ δεξιὰ γαῖαν ἔχοντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="348"><q rend="double; merge">πλώετε ῥηγμῖνας πεφυλαγμένοι, εἰσόκεν αὖτε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="349"><q rend="double; merge">Ῥήβαν ὠκυρόην ποταμὸν ἄκρην τε Μέλαιναν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="350"><q rend="double; merge">γνάμψαντες νήσου Θυνηίδος ὅρμον ἵκησθε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="351"><q rend="double; merge">κεῖθεν δʼ οὐ μάλα πουλὺ διὲξ ἁλὸς ἀντιπέραιαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="352"><q rend="double; merge">γῆν Μαριανδυνῶν ἐπικέλσετε νοστήσαντες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="353"><q rend="double; merge">ἔνθα μὲν εἰς Ἀίδαο καταιβάτις ἐστὶ κέλευθος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="354"><q rend="double; merge">ἄκρη τε προβλὴς Ἀχερουσιὰς ὑψόθι τείνει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="355"><q rend="double; merge">δινήεις τʼ Ἀχέρων αὐτὴν διὰ νειόθι τέμνων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="356"><q rend="double; merge">ἄκρην ἐκ μεγάλης προχοὰς ἵησι φάραγγος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="357"><q rend="double; merge">ἀγχίμολον δʼ ἐπὶ τῇ πολέας παρανεῖσθε κολωνοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="358"><q rend="double; merge">Παφλαγόνων, τοῖσίν τʼ Ἐνετήιος ἐμβασίλευσεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="359"><q rend="double; merge">πρῶτα Πέλοψ, τοῦ καί περ ἀφʼ αἵματος εὐχετόωνται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="360"><q rend="double; merge">ἔστι δέ τις ἄκρη Ἑλίκης κατεναντίον Ἄρκτου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="361"><q rend="double; merge">πάντοθεν ἠλίβατος, καί μιν καλέουσι Κάραμβιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="362"><q rend="double; merge">τῆς καὶ ὑπὲρ βορέαο περισχίζονται ἄελλαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="363"><q rend="double; merge">ὧδε μάλʼ ἂμ πέλαγος τετραμμένη αἰθέρι κύρει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="364"><q rend="double; merge">τήνδε περιγνάμψαντι πολὺς παρακέκλιται· ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="365"><q rend="double; merge">αἰγιαλός· πολέος δʼ ἐπὶ πείρασιν Αἰγιαλοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="366"><q rend="double; merge">ἀκτῇ ἐπὶ προβλῆτι ῥοαὶ Ἅλυος ποταμοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="367"><q rend="double; merge">δεινὸν ἐρεύγονται· μετὰ τὸν δʼ ἀγχίροος Ἶρις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="368"><q rend="double; merge">μειότερος λευκῇσιν ἑλίσσεται εἰς ἅλα δίναις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="369"><q rend="double; merge">κεῖθεν δὲ προτέρωσε μέγας καὶ ὑπείροχος ἀγκὼν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="370"><q rend="double; merge">ἐξανέχει γαίης· ἐπὶ δὲ στόμα Θερμώδοντος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="371"><q rend="double; merge">κόλπῳ ἐν εὐδιόωντι Θεμισκύρειον ὑπʼ ἄκρην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="372"><q rend="double; merge">μύρεται, εὐρείης διαειμένος ἠπείροιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="373"><q rend="double; merge">ἔνθα δὲ Δοίαντος πεδίον, σχεδόθεν δὲ πόληες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="374"><q rend="double; merge">τρισσαὶ Ἀμαζονίδων, μετά τε σμυγερώτατοι ἀνδρῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="375"><q rend="double; merge">τρηχεῖαν Χάλυβες καὶ ἀτειρέα γαῖαν ἔχουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="376"><q rend="double; merge">ἐργατίναι· τοὶ δʼ ἀμφὶ σιδήρεα ἔργα μέλονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="377"><q rend="double; merge">ἄγχι δὲ ϝαιετάουσι πολύρρηνες Τιβαρηνοὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="378"><q rend="double; merge">Ζηνὸς Ἐυξείνοιο Γενηταίην ὑπὲρ ἄκρην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="379"><q rend="double; merge">τῇ δʼ ἐπὶ Μοσσύνοικοι ὁμούριοι ὑλήεσσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="380"><q rend="double; merge">ἑξείης ἤπειρον, ὑπωρείας τε νέμονται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="381"><q rend="double; merge">δουρατέοις πύργοισιν ἐν οἰκία τεκτήναντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="382a"><q rend="double; merge">
 						            <del>κάλινα καὶ πύργους εὐπηγέας, οὓς καλέουσιν</del>
-					          </l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="383a">
+					          </q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="383a"><q rend="double; merge">
 						            <del>μόσσυνας· καὶ δʼ αὐτοὶ ἐπώνυμοι ἔνθεν ἔασιν.</del>
-					          </l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="382">τοὺς παραμειβόμενοι λισσῇ ἐπικέλσετε νήσῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="383">μήτι παντοίῃ μέγʼ ἀναιδέας ἐξελάσαντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="384">οἰωνούς, οἳ δῆθεν ἀπειρέσιοι ἐφέπουσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="385">νῆσον ἐρημαίην. τῇ μέν τʼ ἐνὶ νηὸν Ἄρηος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="386">λαΐνεον ποίησαν Ἀμαζονίδων βασίλειαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="387">Ὀτρηρή τε καὶ Ἀντιόπη, ὁπότε στρατόωντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="388">ἔνθα γὰρ ὔμμιν ὄνειαρ ἀδευκέος ἐξ ἁλὸς εἶσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="389">ἄρρητον· τῶ καί τε φίλα φρονέων ἀγορεύω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="390">ἰσχέμεν. ἀλλὰ τίη με πάλιν χρειὼ ἀλιτέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="391">μαντοσύνῃ τὰ ἕκαστα διηνεκὲς ἐξενέποντα;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="392">νήσου δὲ προτέρωσε καὶ ἠπείροιο περαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="393">φέρβονται Φίλυρες· Φιλύρων δʼ ἐφύπερθεν ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="394">Μάκρωνες· μετὰ δʼ αὖ περιώσια φῦλα Βεχείρων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="395">ἑξείης δὲ Σάπειρες ἐπὶ σφίσι ναιετάουσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="396">Βύζηρες δʼ ἐπὶ τοῖσιν ὁμώλακες, ὧν ὕπερ ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="397">αὐτοὶ Κόλχοι ἔχονται ἀρήιοι. ἀλλʼ ἐνὶ νηὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="398">πείρεθʼ, ἕως μυχάτῃ κεν ἐνιχρίμψητε θαλάσσῃ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="399">ἔνθα δʼ ἐπʼ ἠπείροιο Κυταιίδος, ἠδʼ Ἀμαραντῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="400">τηλόθεν ἐξ ὀρέων πεδίοιό τε Κιρκαίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="401">Φᾶσις δινήεις εὐρὺν ῥόον εἰς ἅλα βάλλει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="402">κείνου νῆʼ ἐλάοντες ἐπὶ προχοὰς ποταμοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="403">πύργους εἰσόψεσθε Κυταιέος Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="404">ἄλσος τε σκιόειν Ἄρεος, τόθι κῶας ἐπʼ ἄκρης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="405">πεπτάμενον φηγοῖο δράκων, τέρας αἰνὸν ἰδέσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="406">ἀμφὶς ὀπιπεύει δεδοκημένος· οὐδέ οἱ ἦμαρ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="407">οὐ κνέφας ἥδυμος ὕπνος ἀναιδέα δάμναται ὄσσε.’</l>
+					          </q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="382"><q rend="double; merge">τοὺς παραμειβόμενοι λισσῇ ἐπικέλσετε νήσῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="383"><q rend="double; merge">μήτι παντοίῃ μέγʼ ἀναιδέας ἐξελάσαντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="384"><q rend="double; merge">οἰωνούς, οἳ δῆθεν ἀπειρέσιοι ἐφέπουσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="385"><q rend="double; merge">νῆσον ἐρημαίην. τῇ μέν τʼ ἐνὶ νηὸν Ἄρηος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="386"><q rend="double; merge">λαΐνεον ποίησαν Ἀμαζονίδων βασίλειαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="387"><q rend="double; merge">Ὀτρηρή τε καὶ Ἀντιόπη, ὁπότε στρατόωντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="388"><q rend="double; merge">ἔνθα γὰρ ὔμμιν ὄνειαρ ἀδευκέος ἐξ ἁλὸς εἶσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="389"><q rend="double; merge">ἄρρητον· τῶ καί τε φίλα φρονέων ἀγορεύω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="390"><q rend="double; merge">ἰσχέμεν. ἀλλὰ τίη με πάλιν χρειὼ ἀλιτέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="391"><q rend="double; merge">μαντοσύνῃ τὰ ἕκαστα διηνεκὲς ἐξενέποντα;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="392"><q rend="double; merge">νήσου δὲ προτέρωσε καὶ ἠπείροιο περαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="393"><q rend="double; merge">φέρβονται Φίλυρες· Φιλύρων δʼ ἐφύπερθεν ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="394"><q rend="double; merge">Μάκρωνες· μετὰ δʼ αὖ περιώσια φῦλα Βεχείρων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="395"><q rend="double; merge">ἑξείης δὲ Σάπειρες ἐπὶ σφίσι ναιετάουσιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="396"><q rend="double; merge">Βύζηρες δʼ ἐπὶ τοῖσιν ὁμώλακες, ὧν ὕπερ ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="397"><q rend="double; merge">αὐτοὶ Κόλχοι ἔχονται ἀρήιοι. ἀλλʼ ἐνὶ νηὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="398"><q rend="double; merge">πείρεθʼ, ἕως μυχάτῃ κεν ἐνιχρίμψητε θαλάσσῃ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="399"><q rend="double; merge">ἔνθα δʼ ἐπʼ ἠπείροιο Κυταιίδος, ἠδʼ Ἀμαραντῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="400"><q rend="double; merge">τηλόθεν ἐξ ὀρέων πεδίοιό τε Κιρκαίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="401"><q rend="double; merge">Φᾶσις δινήεις εὐρὺν ῥόον εἰς ἅλα βάλλει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="402"><q rend="double; merge">κείνου νῆʼ ἐλάοντες ἐπὶ προχοὰς ποταμοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="403"><q rend="double; merge">πύργους εἰσόψεσθε Κυταιέος Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="404"><q rend="double; merge">ἄλσος τε σκιόειν Ἄρεος, τόθι κῶας ἐπʼ ἄκρης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="405"><q rend="double; merge">πεπτάμενον φηγοῖο δράκων, τέρας αἰνὸν ἰδέσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="406"><q rend="double; merge">ἀμφὶς ὀπιπεύει δεδοκημένος· οὐδέ οἱ ἦμαρ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="407"><q rend="double; merge">οὐ κνέφας ἥδυμος ὕπνος ἀναιδέα δάμναται ὄσσε.</q></l>
 					          <milestone n="408" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="408">ὧς ἄρʼ ἔφη· τοὺς δʼ εἶθαρ ἕλεν δέος
@@ -2084,23 +2084,23 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="409">δὴν δʼ ἔσαν ἀμφασίῃ βεβολημένοι· ὀψὲ δʼ ἔειπεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="410">ἥρως Αἴσονος υἱὸς ἀμηχανέων κακότητι·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="411">‘ὦ γέρον, ἤδη μέν τε διίκεο πείρατʼ ἀέθλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="412">ναυτιλίης καὶ τέκμαρ, ὅτῳ στυγερὰς διὰ πέτρας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="413">πειθόμενοι Πόντονδε περήσομεν· εἰ δέ κεν αὖτις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="414">τάσδʼ ἡμῖν προφυγοῦσιν ἐς Ἑλλάδα νόστος ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="415">ἔσσεται, ἀσπαστῶς κε παρὰ σέο καὶ τὸ δαείην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="416">πῶς ἔρδω, πῶς αὖτε τόσην ἁλὸς εἶμι κέλευθον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="417">νῆις ἐὼν ἑτάροις ἅμα νήισιν; αἶα δὲ Κολχὶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="418">Πόντου καὶ γαίης ἐπικέκλιται ἐσχατιῇσιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="411"><q rend="double">ὦ γέρον, ἤδη μέν τε διίκεο πείρατʼ ἀέθλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="412"><q rend="double; merge">ναυτιλίης καὶ τέκμαρ, ὅτῳ στυγερὰς διὰ πέτρας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="413"><q rend="double; merge">πειθόμενοι Πόντονδε περήσομεν· εἰ δέ κεν αὖτις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="414"><q rend="double; merge">τάσδʼ ἡμῖν προφυγοῦσιν ἐς Ἑλλάδα νόστος ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="415"><q rend="double; merge">ἔσσεται, ἀσπαστῶς κε παρὰ σέο καὶ τὸ δαείην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="416"><q rend="double; merge">πῶς ἔρδω, πῶς αὖτε τόσην ἁλὸς εἶμι κέλευθον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="417"><q rend="double; merge">νῆις ἐὼν ἑτάροις ἅμα νήισιν; αἶα δὲ Κολχὶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="418"><q rend="double; merge">Πόντου καὶ γαίης ἐπικέκλιται ἐσχατιῇσιν.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="419">ὧς φάτο· τὸν δʼ ὁ γεραιὸς ἀμειβόμενος
 						προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="420">‘ὦ τέκος, εὖτʼ ἂν πρῶτα φύγῃς ὀλοὰς διὰ πέτρας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="421">θάρσει· ἐπεὶ δαίμων ἕτερον πλόον ἡγεμονεύσει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="422">ἐξ Αἴης· μετὰ δʼ Αἶαν ἅλις πομπῆες ἔσονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="423">ἀλλά, φίλοι, φράζεσθε θεᾶς δολόεσσαν ἀρωγὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="424">Κύπριδος. ἐκ γὰρ τῆς κλυτὰ πείρατα κεῖται ἀέθλων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="425">καὶ δέ με μηκέτι τῶνδε περαιτέρω ἐξερέεσθε.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="420"><q rend="double">ὦ τέκος, εὖτʼ ἂν πρῶτα φύγῃς ὀλοὰς διὰ πέτρας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="421"><q rend="double; merge">θάρσει· ἐπεὶ δαίμων ἕτερον πλόον ἡγεμονεύσει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="422"><q rend="double; merge">ἐξ Αἴης· μετὰ δʼ Αἶαν ἅλις πομπῆες ἔσονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="423"><q rend="double; merge">ἀλλά, φίλοι, φράζεσθε θεᾶς δολόεσσαν ἀρωγὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="424"><q rend="double; merge">Κύπριδος. ἐκ γὰρ τῆς κλυτὰ πείρατα κεῖται ἀέθλων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="425"><q rend="double; merge">καὶ δέ με μηκέτι τῶνδε περαιτέρω ἐξερέεσθε.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="426">ὧς φάτʼ Ἀγηνορίδης· ἐπὶ δὲ σχεδὸν υἱέε δοιὼ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="427">Θρηικίου Βορέαο κατʼ αἰθέρος ἀίξαντε</l>
@@ -2115,17 +2115,17 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="436">αὐτός τʼ ἀγγελίῃ Φινεὺς πέλεν. ὦκα δὲ τόνγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="437">Αἰσονίδης περιπολλὸν ἐυφρονέων προσέειπεν·</l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="438">‘ἦ ἄρα δή τις ἔην, Φινεῦ, θεός, ὃς σέθεν ἄτης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="439">κήδετο λευγαλέης, καὶ δʼ ἡμέας αὖθι πέλασσεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="440">τηλόθεν, ὄφρα τοι υἷες ἀμύνειαν Βορέαο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="441">εἰ δὲ καὶ ὀφθαλμοῖσι φόως πόροι ἦ τʼ ἂν ὀίω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="442">γηθήσειν, ὅσον εἴπερ ὑπότροπος οἴκαδʼ ἱκοίμην.’</l>
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="438"><q rend="double">ἦ ἄρα δή τις ἔην, Φινεῦ, θεός, ὃς σέθεν ἄτης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="439"><q rend="double; merge">κήδετο λευγαλέης, καὶ δʼ ἡμέας αὖθι πέλασσεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="440"><q rend="double; merge">τηλόθεν, ὄφρα τοι υἷες ἀμύνειαν Βορέαο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="441"><q rend="double; merge">εἰ δὲ καὶ ὀφθαλμοῖσι φόως πόροι ἦ τʼ ἂν ὀίω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="442"><q rend="double; merge">γηθήσειν, ὅσον εἴπερ ὑπότροπος οἴκαδʼ ἱκοίμην.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="443">ὧς ἔφατʼ· αὐτὰρ ὁ τόνγε κατηφήσας προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="444">‘Αἰσονίδη, τὸ μὲν οὐ παλινάγρετον, οὐδέ τι μῆχος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="445">ἔστʼ ὀπίσω· κενεαὶ γὰρ ὑποσμύχονται ὀπωπαί.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="446">ἀντὶ δὲ τοῦ θάνατόν μοι ἄφαρ θεὸς ἐγγυαλίξαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="447">καί τε θανὼν πάσῃσι μετέσσομαι ἀγλαΐῃσιν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="444"><q rend="double">Αἰσονίδη, τὸ μὲν οὐ παλινάγρετον, οὐδέ τι μῆχος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="445"><q rend="double; merge">ἔστʼ ὀπίσω· κενεαὶ γὰρ ὑποσμύχονται ὀπωπαί.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="446"><q rend="double; merge">ἀντὶ δὲ τοῦ θάνατόν μοι ἄφαρ θεὸς ἐγγυαλίξαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="447"><q rend="double; merge">καί τε θανὼν πάσῃσι μετέσσομαι ἀγλαΐῃσιν.</q></l>
 					          <milestone unit="para"/>
                                 <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="448">ὧς τώγʼ ἀλλήλοισι παραβλήδην ἀγόρευον.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="449">αὐτίκα δʼ οὐ μετὰ δηρὸν ἀμειβομένων ἐφαάνθη</l>
@@ -2149,29 +2149,29 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="467">μειλιχίως ἐρέτῃσιν ὁμηγερέεσσι μετηύδα· </l>
                               <milestone n="468" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="468">‘ὦ φίλοι, οὐκ ἄρα πάντες ὑπέρβιοι ἄνδρες
-						ἔασιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="469">οὐδʼ εὐεργεσίης ἀμνήμονες. ὡς καὶ ὅδʼ ἀνὴρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="470">τοῖος ἐὼν δεῦρʼ ἦλθεν, ἑὸν μόρον ὄφρα δαείη.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="471">εὖτε γὰρ οὖν ὡς πλεῖστα κάμοι καὶ πλεῖστα μογήσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="472">δὴ τότε μιν περιπολλὸν ἐπασσυτέρη βιότοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="473">χρησμοσύνη τρύχεσκεν· ἐπʼ ἤματι δʼ ἦμαρ ὀρώρει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="474">κύντερον, οὐδέ τις ἦεν ἀνάπνευσις μογέοντι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="475">ἀλλʼ ὅγε πατρὸς ἑοῖο κακὴν τίνεσκεν ἀμοιβὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="476">ἀμπλακίης. ὁ γὰρ οἶος ἐν οὔρεσι δένδρεα τέμνων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="477">δή ποθʼ ἁμαδρυάδος νύμφης ἀθέριξε λιτάων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="478">ἥ μιν ὀδυρομένη ἀδινῷ μειλίσσετο μύθῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="479">μὴ ταμέειν πρέμνον δρυὸς ἥλικος, ᾗ ἔπι πουλὺν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="480">αἰῶνα τρίβεσκε διηνεκές· αὐτὰρ ὁ τήνγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="481">ἀφραδέως ἔτμηξεν ἀγηνορίῃ νεότητος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="482">τῷ δʼ ἄρα νηκερδῆ νύμφη πόρεν οἶτον ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="483">αὐτῷ καὶ τεκέεσσιν. ἔγωγε μέν, εὖτʼ ἀφίκανεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="484">ἀμπλακίην ἔγνων· βωμὸν δʼ ἐκέλευσα καμόντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="485">Θυνιάδος νύμφης, λωφήια ῥέξαι ἐπʼ αὐτῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="486">ἱερά, πατρῴην αἰτεύμενον αἶσαν ἀλύξαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="487">ἔνθʼ ἐπεὶ ἔκφυγε κῆρα θεήλατον, οὔποτʼ ἐμεῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="488">ἐκλάθετʼ, οὐδʼ ἀθέρισσε· μόλις δʼ ἀέκοντα θύραζε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="489">πέμπω, ἐπεὶ μέμονέν γε παρέμμεναι ἀσχαλόωντι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="468"><q rend="double">ὦ φίλοι, οὐκ ἄρα πάντες ὑπέρβιοι ἄνδρες
+						ἔασιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="469"><q rend="double; merge">οὐδʼ εὐεργεσίης ἀμνήμονες. ὡς καὶ ὅδʼ ἀνὴρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="470"><q rend="double; merge">τοῖος ἐὼν δεῦρʼ ἦλθεν, ἑὸν μόρον ὄφρα δαείη.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="471"><q rend="double; merge">εὖτε γὰρ οὖν ὡς πλεῖστα κάμοι καὶ πλεῖστα μογήσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="472"><q rend="double; merge">δὴ τότε μιν περιπολλὸν ἐπασσυτέρη βιότοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="473"><q rend="double; merge">χρησμοσύνη τρύχεσκεν· ἐπʼ ἤματι δʼ ἦμαρ ὀρώρει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="474"><q rend="double; merge">κύντερον, οὐδέ τις ἦεν ἀνάπνευσις μογέοντι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="475"><q rend="double; merge">ἀλλʼ ὅγε πατρὸς ἑοῖο κακὴν τίνεσκεν ἀμοιβὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="476"><q rend="double; merge">ἀμπλακίης. ὁ γὰρ οἶος ἐν οὔρεσι δένδρεα τέμνων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="477"><q rend="double; merge">δή ποθʼ ἁμαδρυάδος νύμφης ἀθέριξε λιτάων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="478"><q rend="double; merge">ἥ μιν ὀδυρομένη ἀδινῷ μειλίσσετο μύθῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="479"><q rend="double; merge">μὴ ταμέειν πρέμνον δρυὸς ἥλικος, ᾗ ἔπι πουλὺν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="480"><q rend="double; merge">αἰῶνα τρίβεσκε διηνεκές· αὐτὰρ ὁ τήνγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="481"><q rend="double; merge">ἀφραδέως ἔτμηξεν ἀγηνορίῃ νεότητος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="482"><q rend="double; merge">τῷ δʼ ἄρα νηκερδῆ νύμφη πόρεν οἶτον ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="483"><q rend="double; merge">αὐτῷ καὶ τεκέεσσιν. ἔγωγε μέν, εὖτʼ ἀφίκανεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="484"><q rend="double; merge">ἀμπλακίην ἔγνων· βωμὸν δʼ ἐκέλευσα καμόντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="485"><q rend="double; merge">Θυνιάδος νύμφης, λωφήια ῥέξαι ἐπʼ αὐτῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="486"><q rend="double; merge">ἱερά, πατρῴην αἰτεύμενον αἶσαν ἀλύξαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="487"><q rend="double; merge">ἔνθʼ ἐπεὶ ἔκφυγε κῆρα θεήλατον, οὔποτʼ ἐμεῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="488"><q rend="double; merge">ἐκλάθετʼ, οὐδʼ ἀθέρισσε· μόλις δʼ ἀέκοντα θύραζε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="489"><q rend="double; merge">πέμπω, ἐπεὶ μέμονέν γε παρέμμεναι ἀσχαλόωντι.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="490">ὧς φάτʼ Ἀγηνορίδης· ὁ δʼ ἐπισχεδὸν αὐτίκα
 						δοιὼ</l>
@@ -2302,45 +2302,45 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="610">σώεσθαι· Τῖφυς δὲ παροίτατος ἤρχετο μύθων·</l>
 					          <milestone n="611" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="611">‘ἔλπομαι αὐτῇ νηὶ τόγʼ ἔμπεδον ἐξαλέασθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="612">ἡμέας· οὐδέ τις ἄλλος ἐπαίτιος, ὅσσον Ἀθήνη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="613">ἥ οἱ ἐνέπνευσεν θεῖον μένος, εὖτέ μιν Ἄργος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="614">γόμφοισιν συνάρασσε· θέμις δʼ οὐκ ἔστιν ἁλῶναι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="615">Αἰσονίδη, τύνη δὲ τεοῦ βασιλῆος ἐφετμήν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="616">εὖτε διὲκ πέτρας φυγέειν θεὸς ἧμιν ὄπασσεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="617">μηκέτι δείδιθι τοῖον· ἐπεὶ μετόπισθεν ἀέθλους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="618">εὐπαλέας τελέεσθαι Ἀγηνορίδης φάτο Φινεύς.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="611"><q rend="double">ἔλπομαι αὐτῇ νηὶ τόγʼ ἔμπεδον ἐξαλέασθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="612"><q rend="double; merge">ἡμέας· οὐδέ τις ἄλλος ἐπαίτιος, ὅσσον Ἀθήνη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="613"><q rend="double; merge">ἥ οἱ ἐνέπνευσεν θεῖον μένος, εὖτέ μιν Ἄργος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="614"><q rend="double; merge">γόμφοισιν συνάρασσε· θέμις δʼ οὐκ ἔστιν ἁλῶναι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="615"><q rend="double; merge">Αἰσονίδη, τύνη δὲ τεοῦ βασιλῆος ἐφετμήν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="616"><q rend="double; merge">εὖτε διὲκ πέτρας φυγέειν θεὸς ἧμιν ὄπασσεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="617"><q rend="double; merge">μηκέτι δείδιθι τοῖον· ἐπεὶ μετόπισθεν ἀέθλους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="618"><q rend="double; merge">εὐπαλέας τελέεσθαι Ἀγηνορίδης φάτο Φινεύς.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="619">ἦ ῥʼ ἅμα, καὶ προτέρωσε παραὶ Βιθυνίδα γαῖαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="620">νῆα διὲκ πέλαγος σεῦεν μέσον. αὐτὰρ ὁ τόνγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="621">μειλιχίοις ἐπέεσσι παραβλήδην προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="622">‘Τῖφυ, τίη μοι ταῦτα παρηγορέεις ἀχέοντι;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="623">ἤμβροτον ἀασάμην τε κακὴν καὶ ἀμήχανον ἄτην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="624">χρῆν γὰρ ἐφιεμένοιο καταντικρὺ Πελίαο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="625">αὐτίκʼ ἀνήνασθαι τόνδε στόλον, εἰ καὶ ἔμελλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="626">νηλειῶς μελεϊστὶ κεδαιόμενος θανέεσθαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="627">νῦν δὲ περισσὸν δεῖμα καὶ ἀτλήτους μελεδῶνας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="628">ἄγκειμαι, στυγέων μὲν ἁλὸς κρυόεντα κέλευθα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="629">νηὶ διαπλώειν, στυγέων δʼ, ὅτʼ ἐπʼ ἠπείροιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="630">βαίνωμεν. πάντῃ γὰρ ἀνάρσιοι ἄνδρες ἔασιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="631">αἰεὶ δὲ στονόεσσαν ἐπʼ ἤματι νύκτα φυλάσσω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="632">ἐξότε τὸ πρώτιστον ἐμὴν χάριν ἠγερέθεσθε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="633">φραζόμενος τὰ ἕκαστα σὺ δʼ εὐμαρέως ἀγορεύεις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="634">οἶον ἑῆς ψυχῆς ἀλέγων ὕπερ· αὐτὰρ ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="635">εἷο μὲν οὐδʼ ἠβαιὸν ἀτύζομαι· ἀμφὶ δὲ τοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="636">καὶ τοῦ ὁμῶς, καὶ σεῖο, καὶ ἄλλων δείδιʼ ἑταίρων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="637">εἰ μὴ ἐς Ἑλλάδα γαῖαν ἀπήμονας ὔμμε κομίσσω.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="622"><q rend="double">Τῖφυ, τίη μοι ταῦτα παρηγορέεις ἀχέοντι;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="623"><q rend="double; merge">ἤμβροτον ἀασάμην τε κακὴν καὶ ἀμήχανον ἄτην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="624"><q rend="double; merge">χρῆν γὰρ ἐφιεμένοιο καταντικρὺ Πελίαο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="625"><q rend="double; merge">αὐτίκʼ ἀνήνασθαι τόνδε στόλον, εἰ καὶ ἔμελλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="626"><q rend="double; merge">νηλειῶς μελεϊστὶ κεδαιόμενος θανέεσθαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="627"><q rend="double; merge">νῦν δὲ περισσὸν δεῖμα καὶ ἀτλήτους μελεδῶνας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="628"><q rend="double; merge">ἄγκειμαι, στυγέων μὲν ἁλὸς κρυόεντα κέλευθα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="629"><q rend="double; merge">νηὶ διαπλώειν, στυγέων δʼ, ὅτʼ ἐπʼ ἠπείροιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="630"><q rend="double; merge">βαίνωμεν. πάντῃ γὰρ ἀνάρσιοι ἄνδρες ἔασιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="631"><q rend="double; merge">αἰεὶ δὲ στονόεσσαν ἐπʼ ἤματι νύκτα φυλάσσω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="632"><q rend="double; merge">ἐξότε τὸ πρώτιστον ἐμὴν χάριν ἠγερέθεσθε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="633"><q rend="double; merge">φραζόμενος τὰ ἕκαστα σὺ δʼ εὐμαρέως ἀγορεύεις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="634"><q rend="double; merge">οἶον ἑῆς ψυχῆς ἀλέγων ὕπερ· αὐτὰρ ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="635"><q rend="double; merge">εἷο μὲν οὐδʼ ἠβαιὸν ἀτύζομαι· ἀμφὶ δὲ τοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="636"><q rend="double; merge">καὶ τοῦ ὁμῶς, καὶ σεῖο, καὶ ἄλλων δείδιʼ ἑταίρων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="637"><q rend="double; merge">εἰ μὴ ἐς Ἑλλάδα γαῖαν ἀπήμονας ὔμμε κομίσσω.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="638">ὧς φάτʼ ἀριστήων πειρώμενος· οἱ δʼ ὁμάδησαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="639">θαρσαλέοις ἐπέεσσιν. ὁ δὲ φρένας ἔνδον ἰάνθη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="640">κεκλομένων, καί ῥʼ αὖτις ἐπιρρήδην μετέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="641">‘ὦ φίλοι, ὑμετέρῃ ἀρετῇ ἔνι θάρσος ἀέξω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="642">τούνεκα νῦν οὐδʼ εἴ κε διὲξ Ἀίδαο βερέθρων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="643">στελλοίμην, ἔτι τάρβος ἀνάψομαι, εὖτε πέλεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="644">ἔμπεδοι ἀργαλέοις ἐνὶ δείμασιν. ἀλλʼ ὅτε πέτρας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="645">Πληγάδας ἐξέπλωμεν, ὀίομαι οὐκ ἔτʼ ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="646">ἔσσεσθαι τοιόνδʼ ἕτερον φόβον, εἰ ἐτεόν γε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="647">φραδμοσύνῃ Φινῆος ἐπισπόμενοι νεόμεσθα.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="641"><q rend="double">ὦ φίλοι, ὑμετέρῃ ἀρετῇ ἔνι θάρσος ἀέξω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="642"><q rend="double; merge">τούνεκα νῦν οὐδʼ εἴ κε διὲξ Ἀίδαο βερέθρων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="643"><q rend="double; merge">στελλοίμην, ἔτι τάρβος ἀνάψομαι, εὖτε πέλεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="644"><q rend="double; merge">ἔμπεδοι ἀργαλέοις ἐνὶ δείμασιν. ἀλλʼ ὅτε πέτρας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="645"><q rend="double; merge">Πληγάδας ἐξέπλωμεν, ὀίομαι οὐκ ἔτʼ ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="646"><q rend="double; merge">ἔσσεσθαι τοιόνδʼ ἕτερον φόβον, εἰ ἐτεόν γε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="647"><q rend="double; merge">φραδμοσύνῃ Φινῆος ἐπισπόμενοι νεόμεσθα.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="648">ὧς φάτο, καὶ τοίων μὲν ἐλώφεον αὐτίκα μύθων,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="649">εἰρεσίῃ δʼ ἀλίαστον ἔχον πόνον· αἶψα δὲ τοίγε</l>
@@ -2384,14 +2384,14 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="684">βῆ ῥʼ ἴμεναι πόντονδε διʼ ἠέρος· ὀψὲ δὲ τοῖον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="685">Ὀρφεὺς ἔκφατο μῦθον ἀριστήεσσι πιφαύσκων·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="686">‘εἰ δʼ ἄγε δὴ νῆσον μὲν Ἑωίου Ἀπόλλωνος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="687">τήνδʼ ἱερὴν κλείωμεν, ἐπεὶ πάντεσσι φαάνθη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="688">ἠῷος μετιών· τὰ δὲ ῥέξομεν οἷα πάρεστιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="689">βωμὸν ἀναστήσαντες ἐπάκτιον· εἰ δʼ ἂν ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="690">γαῖαν ἐς Αἱμονίην ἀσκηθέα νόστον ὀπάσσῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="691">δὴ τότε οἱ κεραῶν ἐπὶ μηρία θήσομεν αἰγῶν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="692">νῦν δʼ αὔτως κνίσῃ λοιβῇσί τε μειλίξασθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="693">κέκλομαι. ἀλλʼ ἵληθι ἄναξ, ἵληθι φαανθείς.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="686"><q rend="double">εἰ δʼ ἄγε δὴ νῆσον μὲν Ἑωίου Ἀπόλλωνος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="687"><q rend="double; merge">τήνδʼ ἱερὴν κλείωμεν, ἐπεὶ πάντεσσι φαάνθη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="688"><q rend="double; merge">ἠῷος μετιών· τὰ δὲ ῥέξομεν οἷα πάρεστιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="689"><q rend="double; merge">βωμὸν ἀναστήσαντες ἐπάκτιον· εἰ δʼ ἂν ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="690"><q rend="double; merge">γαῖαν ἐς Αἱμονίην ἀσκηθέα νόστον ὀπάσσῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="691"><q rend="double; merge">δὴ τότε οἱ κεραῶν ἐπὶ μηρία θήσομεν αἰγῶν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="692"><q rend="double; merge">νῦν δʼ αὔτως κνίσῃ λοιβῇσί τε μειλίξασθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="693"><q rend="double; merge">κέκλομαι. ἀλλʼ ἵληθι ἄναξ, ἵληθι φαανθείς.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="694">ὧς ἄρʼ ἔφη· καὶ τοὶ μὲν ἄφαρ βωμὸν τετύκοντο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="695">χερμάσιν· οἱ δʼ ἀνὰ νῆσον ἐδίνεον, ἐξερέοντες</l>
@@ -2480,43 +2480,43 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="773">λειπομένῳ, καὶ τοῖον ἔπος πάντεσσι μετηύδα·</l>
 					          <milestone n="774" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="774">‘ὦ φίλοι, οἵου φωτὸς ἀποπλαγχθέντες ἀρωγῆς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="775">πείρετʼ ἐς Αἰήτην τόσσον πλόον. εὖ γὰρ ἐγώ μιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="776">Δασκύλου ἐν μεγάροισι καταυτόθι πατρὸς ἐμοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="777">οἶδʼ ἐσιδών, ὅτε δεῦρο διʼ Ἀσίδος ἠπείροιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="778">πεζὸς ἔβη ζωστῆρα φιλοπτολέμοιο κομίζων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="779">Ἱππολύτης· ἐμὲ δʼ εὗρε νέον χνοάοντα ἰούλους.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="780">ἔνθα δʼ ἐπὶ Πριόλαο κασιγνήτοιο θανόντος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="781">ἡμετέρου Μυσοῖσιν ὑπʼ ἀνδράσιν, ὅντινα λαὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="782">οἰκτίστοις ἐλέγοισιν ὀδύρεται ἐξέτι κείνου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="783">ἀθλεύων Τιτίην ἀπεκαίνυτο πυγμαχέοντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="784">καρτερόν, ὃς πάντεσσι μετέπρεπεν ἠιθέοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="785">εἶδός τʼ ἠδὲ βίην· χαμάδις δέ οἱ ἤλασʼ ὀδόντας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="786">αὐτὰρ ὁμοῦ Μυσοῖσιν ἐμῷ ὑπὸ πατρὶ δάμασσεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="787">καὶ Φρύγας, οἳ ναίουσιν ὁμώλακας ἧμιν ἀρούρας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="788">φῦλά τε Βιθυνῶν αὐτῇ κτεατίσσατο γαίῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="789">ἔστʼ ἐπὶ Ῥηβαίου προχοὰς σκόπελόν τε Κολώνης·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="790">Παφλαγόνες τʼ ἐπὶ τοῖς Πελοπήιοι εἴκαθον αὔτως,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="791">ὅσσους Βιλλαίοιο μέλαν περιάγνυται ὕδωρ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="792">ἀλλά με νῦν Βέβρυκες ὑπερβασίη τʼ Ἀμύκοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="793">τηλόθι ναιετάοντος, ἐνόσφισαν, Ἡρακλῆος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="794">δὴν ἀποτεμνόμενοι γαίης ἅλις, ὄφρʼ ἐβάλοντο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="795">οὖρα βαθυρρείοντος ὑφʼ εἱαμεναῖς Ὑπίοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="796">ἔμπης δʼ ἐξ ὑμέων ἔδοσαν τίσιν· οὐδέ ἕ φημι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="797">ἤματι τῷδʼ ἀέκητι θεῶν ἐπελάσσαι ἄρηα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="798">Τυνδαρίδην Βέβρυξιν, ὅτʼ ἀνέρα κεῖνον ἔπεφνεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="799">τῶ νῦν ἥντινʼ ἐγὼ τῖσαι χάριν ἄρκιός εἰμι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="800">τίσω προφρονέως. ἡ γὰρ θέμις ηπεοανοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="801">ἀνδράσιν, εὖτʼ ἄρξωσιν ἀρείονες ἄλλοι ὀφέλλειν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="802">ξυνῇ μὲν πάντεσσιν ὁμόστολον ὔμμιν ἕπεσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="803">Δάσκυλον ὀτρυνέω, ἐμὸν υἱέα· τοῖο δʼ ἰόντος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="804">ἦ τʼ ἂν ἐυξείνοισι διὲξ ἁλὸς ἀντιάοιτε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="805">ἀνδράσιν, ὄφρʼ αὐτοῖο ποτὶ στόμα Θερμώδοντος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="806">νόσφι δὲ Τυνδαρίδαις Ἀχερουσίδος ὑψόθεν ἄκρης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="807">εἵσομαι ἱερὸν αἰπύ· τὸ μὲν μάλα τηλόθι πάντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="808">ναυτίλοι ἂμ πέλαγος θηεύμενοι ἱλάξονται·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="809">καί κέ σφιν μετέπειτα πρὸ ἄστεος, οἷα θεοῖσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="810">πίονας εὐα·ρότοιο γύας πεδίοιο ταμοίμην.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="774"><q rend="double">ὦ φίλοι, οἵου φωτὸς ἀποπλαγχθέντες ἀρωγῆς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="775"><q rend="double; merge">πείρετʼ ἐς Αἰήτην τόσσον πλόον. εὖ γὰρ ἐγώ μιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="776"><q rend="double; merge">Δασκύλου ἐν μεγάροισι καταυτόθι πατρὸς ἐμοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="777"><q rend="double; merge">οἶδʼ ἐσιδών, ὅτε δεῦρο διʼ Ἀσίδος ἠπείροιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="778"><q rend="double; merge">πεζὸς ἔβη ζωστῆρα φιλοπτολέμοιο κομίζων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="779"><q rend="double; merge">Ἱππολύτης· ἐμὲ δʼ εὗρε νέον χνοάοντα ἰούλους.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="780"><q rend="double; merge">ἔνθα δʼ ἐπὶ Πριόλαο κασιγνήτοιο θανόντος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="781"><q rend="double; merge">ἡμετέρου Μυσοῖσιν ὑπʼ ἀνδράσιν, ὅντινα λαὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="782"><q rend="double; merge">οἰκτίστοις ἐλέγοισιν ὀδύρεται ἐξέτι κείνου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="783"><q rend="double; merge">ἀθλεύων Τιτίην ἀπεκαίνυτο πυγμαχέοντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="784"><q rend="double; merge">καρτερόν, ὃς πάντεσσι μετέπρεπεν ἠιθέοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="785"><q rend="double; merge">εἶδός τʼ ἠδὲ βίην· χαμάδις δέ οἱ ἤλασʼ ὀδόντας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="786"><q rend="double; merge">αὐτὰρ ὁμοῦ Μυσοῖσιν ἐμῷ ὑπὸ πατρὶ δάμασσεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="787"><q rend="double; merge">καὶ Φρύγας, οἳ ναίουσιν ὁμώλακας ἧμιν ἀρούρας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="788"><q rend="double; merge">φῦλά τε Βιθυνῶν αὐτῇ κτεατίσσατο γαίῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="789"><q rend="double; merge">ἔστʼ ἐπὶ Ῥηβαίου προχοὰς σκόπελόν τε Κολώνης·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="790"><q rend="double; merge">Παφλαγόνες τʼ ἐπὶ τοῖς Πελοπήιοι εἴκαθον αὔτως,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="791"><q rend="double; merge">ὅσσους Βιλλαίοιο μέλαν περιάγνυται ὕδωρ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="792"><q rend="double; merge">ἀλλά με νῦν Βέβρυκες ὑπερβασίη τʼ Ἀμύκοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="793"><q rend="double; merge">τηλόθι ναιετάοντος, ἐνόσφισαν, Ἡρακλῆος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="794"><q rend="double; merge">δὴν ἀποτεμνόμενοι γαίης ἅλις, ὄφρʼ ἐβάλοντο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="795"><q rend="double; merge">οὖρα βαθυρρείοντος ὑφʼ εἱαμεναῖς Ὑπίοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="796"><q rend="double; merge">ἔμπης δʼ ἐξ ὑμέων ἔδοσαν τίσιν· οὐδέ ἕ φημι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="797"><q rend="double; merge">ἤματι τῷδʼ ἀέκητι θεῶν ἐπελάσσαι ἄρηα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="798"><q rend="double; merge">Τυνδαρίδην Βέβρυξιν, ὅτʼ ἀνέρα κεῖνον ἔπεφνεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="799"><q rend="double; merge">τῶ νῦν ἥντινʼ ἐγὼ τῖσαι χάριν ἄρκιός εἰμι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="800"><q rend="double; merge">τίσω προφρονέως. ἡ γὰρ θέμις ηπεοανοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="801"><q rend="double; merge">ἀνδράσιν, εὖτʼ ἄρξωσιν ἀρείονες ἄλλοι ὀφέλλειν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="802"><q rend="double; merge">ξυνῇ μὲν πάντεσσιν ὁμόστολον ὔμμιν ἕπεσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="803"><q rend="double; merge">Δάσκυλον ὀτρυνέω, ἐμὸν υἱέα· τοῖο δʼ ἰόντος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="804"><q rend="double; merge">ἦ τʼ ἂν ἐυξείνοισι διὲξ ἁλὸς ἀντιάοιτε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="805"><q rend="double; merge">ἀνδράσιν, ὄφρʼ αὐτοῖο ποτὶ στόμα Θερμώδοντος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="806"><q rend="double; merge">νόσφι δὲ Τυνδαρίδαις Ἀχερουσίδος ὑψόθεν ἄκρης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="807"><q rend="double; merge">εἵσομαι ἱερὸν αἰπύ· τὸ μὲν μάλα τηλόθι πάντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="808"><q rend="double; merge">ναυτίλοι ἂμ πέλαγος θηεύμενοι ἱλάξονται·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="809"><q rend="double; merge">καί κέ σφιν μετέπειτα πρὸ ἄστεος, οἷα θεοῖσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="810"><q rend="double; merge">πίονας εὐα·ρότοιο γύας πεδίοιο ταμοίμην.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="811">ὧς τότε μὲν δαῖτʼ ἀμφὶ πανήμεροι ἑψιόωντο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="812">ἦρί γε μὴν ἐπὶ νῆα κατήισαν ἐγκονέοντες·</l>
@@ -2584,35 +2584,35 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="867">τίκτε Ποσειδάωνι· περιπρὸ γὰρ εὖ ἐκέκαστο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="868">ἰθύνειν, Πηλῆα δʼ ἐπεσσύμενος προσέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="869">‘Αἰακίδη, πῶς καλὸν ἀφειδήσαντας ἀέθλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="870">γαίῃ ἐν ἀλλοδαπῇ δὴν ἔμμεναι; οὐ μὲν ἄρηος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="871">ἴδριν ἐόντά με τόσσον ἄγει μετὰ κῶας Ἰήσων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="872">παρθενίης ἀπάνευθεν, ὅσον τʼ ἐπιίστορα νηῶν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="873">τῶ μή μοι τυτθόν γε δέος περὶ νηὶ πελέσθω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="874">ὧς δὲ καὶ ὧλλοι δεῦρο δαήμονες ἄνδρες ἔασιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="875">τῶν ὅτινα πρύμνης ἐπιβήσομεν, οὔτις ἰάψει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="876">ναυτιλίην. ἀλλʼ ὦκα, παραιφάμενος τάδε πάντα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="877">θαρσαλέως ὀρόθυνον ἐπιμνήσασθαι ἀέθλου.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="869"><q rend="double">Αἰακίδη, πῶς καλὸν ἀφειδήσαντας ἀέθλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="870"><q rend="double; merge">γαίῃ ἐν ἀλλοδαπῇ δὴν ἔμμεναι; οὐ μὲν ἄρηος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="871"><q rend="double; merge">ἴδριν ἐόντά με τόσσον ἄγει μετὰ κῶας Ἰήσων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="872"><q rend="double; merge">παρθενίης ἀπάνευθεν, ὅσον τʼ ἐπιίστορα νηῶν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="873"><q rend="double; merge">τῶ μή μοι τυτθόν γε δέος περὶ νηὶ πελέσθω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="874"><q rend="double; merge">ὧς δὲ καὶ ὧλλοι δεῦρο δαήμονες ἄνδρες ἔασιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="875"><q rend="double; merge">τῶν ὅτινα πρύμνης ἐπιβήσομεν, οὔτις ἰάψει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="876"><q rend="double; merge">ναυτιλίην. ἀλλʼ ὦκα, παραιφάμενος τάδε πάντα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="877"><q rend="double; merge">θαρσαλέως ὀρόθυνον ἐπιμνήσασθαι ἀέθλου.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="878">ὧς φάτο· τοῖο δὲ θυμὸς ὀρέξατο γηθοσύνῃσιν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="879">αὐτίκα δʼ οὐ μετὰ δηρὸν ἐνὶ μέσσοις ἀγόρευσεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="880">‘δαιμόνιοι, τί νυ πένθος ἐτώσιον ἴσχομεν αὔτως;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="881">οἱ μὲν γάρ ποθι τοῦτον, ὃν ἔλλαχον, οἶτον ὄλοντο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="882">ἡμῖν δʼ ἐν γὰρ ἔασι κυβερνητῆρες ὁμίλῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="883">καὶ πολέες. τῶ μή τι διατριβώμεθα πείρης·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="884">ἀλλʼ ἔγρεσθʼ εἰς ἔργον, ἀπορρίψαντες ἀνίας.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="880"><q rend="double">δαιμόνιοι, τί νυ πένθος ἐτώσιον ἴσχομεν αὔτως;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="881"><q rend="double; merge">οἱ μὲν γάρ ποθι τοῦτον, ὃν ἔλλαχον, οἶτον ὄλοντο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="882"><q rend="double; merge">ἡμῖν δʼ ἐν γὰρ ἔασι κυβερνητῆρες ὁμίλῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="883"><q rend="double; merge">καὶ πολέες. τῶ μή τι διατριβώμεθα πείρης·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="884"><q rend="double; merge">ἀλλʼ ἔγρεσθʼ εἰς ἔργον, ἀπορρίψαντες ἀνίας.</q></l>
 					          <milestone n="885" unit="card"/>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="885">τὸν δʼ αὖτʼ Αἴσονος υἱὸς ἀμηχανέων
 						προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="886">‘Αἰακίδη, πῇ δʼ οἵδε κυβερνητῆρες ἔασιν;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="887">οὓς μὲν γὰρ τὸ πάροιθε δαήμονας εὐχόμεθʼ εἶναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="888">οἱ δὲ κατηφήσαντες ἐμεῦ πλέον ἀσχαλόωσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="889">τῶ καὶ ὁμοῦ φθιμένοισι κακὴν προτιόσσομαι ἄτην,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="890">εἰ δὴ μήτʼ ὀλοοῖο μετὰ πτόλιν Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="891">ἔσσεται, ἠὲ καὶ αὖτις ἐς Ἑλλάδα γαῖαν ἱκέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="892">πετράων ἔκτοσθε, κατʼ αὐτόθι δʼ ἄμμε καλύψει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="893">ἀκλειῶς κακὸς οἶτος, ἐτώσια γηράσκοντας.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="886"><q rend="double">Αἰακίδη, πῇ δʼ οἵδε κυβερνητῆρες ἔασιν;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="887"><q rend="double; merge">οὓς μὲν γὰρ τὸ πάροιθε δαήμονας εὐχόμεθʼ εἶναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="888"><q rend="double; merge">οἱ δὲ κατηφήσαντες ἐμεῦ πλέον ἀσχαλόωσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="889"><q rend="double; merge">τῶ καὶ ὁμοῦ φθιμένοισι κακὴν προτιόσσομαι ἄτην,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="890"><q rend="double; merge">εἰ δὴ μήτʼ ὀλοοῖο μετὰ πτόλιν Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="891"><q rend="double; merge">ἔσσεται, ἠὲ καὶ αὖτις ἐς Ἑλλάδα γαῖαν ἱκέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="892"><q rend="double; merge">πετράων ἔκτοσθε, κατʼ αὐτόθι δʼ ἄμμε καλύψει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="893"><q rend="double; merge">ἀκλειῶς κακὸς οἶτος, ἐτώσια γηράσκοντας.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="894">ὧς ἔφατʼ· Ἀγκαῖος δὲ μάλʼ ἐσσυμένως ὑπέδεκτο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="895">νῆα θοὴν ἄξειν· δὴ γὰρ θεοῦ ἐτράπεθʼ ὁρμῇ.</l>
@@ -2784,27 +2784,27 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1045">πλῆξεν· δινηθεὶς δὲ θοῆς πέσεν ἀγχόθι νηός.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1046">τοῖσιν δʼ Ἀμφιδάμας μυθήσατο, παῖς Ἀλεοῖο·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1047">‘νῆσος μὲν πέλας ἧμιν Ἀρητιάς· ἴστε καὶ αὐτοὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1048">τούσδʼ ὄρνιθας ἰδόντες. ἐγὼ δʼ οὐκ ἔλπομαι ἰοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1049">τόσσον ἐπαρκέσσειν εἰς ἔκβασιν. ἀλλά τινʼ ἄλλην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1050">μῆτιν πορσύνωμεν ἐπίρροθον, εἴ γʼ ἐπικέλσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1051">μέλλετε, Φινῆος μεμνημένοι, ὡς ἐπέτελλεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1052">οὐδὲ γὰρ Ἡρακλέης, ὁπότʼ ἤλυθεν Ἀρκαδίηνδε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1053">πλωίδας ὄρνιθας Στυμφαλίδας ἔσθενε λίμνης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1054">ὤσασθαι τόξοισι, τὸ μέν τʼ ἐγὼ αὐτὸς ὄπωπα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1055">ἀλλʼ ὅγε χαλκείην πλατάγην ἐνὶ χερσὶ τινάσσων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1056">δούπει ἐπὶ σκοπιῆς περιμήκεος· αἱ δʼ ἐφέβοντο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1057">τηλοῦ, ἀτυζηλῷ ὑπὸ δείματι κεκληγυῖαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1058">τῶ καὶ νῦν τοίην τινʼ ἐπιφραζώμεθα μῆτιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1059">αὐτὸς δʼ ἂν τὸ πάροιθεν ἐπιφρασθεὶς ἐνέποιμι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1060">ἀνθέμενοι κεφαλῇσιν ἀερσιλόφους τρυφαλείας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1061">ἡμίσεες μὲν ἐρέσσετʼ ἀμοιβαδίς, ἡμίσεες δὲ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1062">δούρασί τε ξυστοῖσι καὶ ἀσπίσιν ἄρσετε νῆα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1063">αὐτὰρ πασσυδίῃ περιώσιον ὄρνυτʼ ἀυτὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1064">ἀθρόοι, ὄφρα κολῳὸν ἀηθείῃ φοβέωνται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1065">νεύοντάς τε λόφους καὶ ἐπήορα δούραθʼ ὕπερθεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1066">εἰ δέ κεν αὐτὴν νῆσον ἱκώμεθα, δὴ τότʼ ἔπειτα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1067">σὺν κελάδῳ σακέεσσι πελώριον ὄρσετε δοῦπον.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1047"><q rend="double">νῆσος μὲν πέλας ἧμιν Ἀρητιάς· ἴστε καὶ αὐτοὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1048"><q rend="double; merge">τούσδʼ ὄρνιθας ἰδόντες. ἐγὼ δʼ οὐκ ἔλπομαι ἰοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1049"><q rend="double; merge">τόσσον ἐπαρκέσσειν εἰς ἔκβασιν. ἀλλά τινʼ ἄλλην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1050"><q rend="double; merge">μῆτιν πορσύνωμεν ἐπίρροθον, εἴ γʼ ἐπικέλσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1051"><q rend="double; merge">μέλλετε, Φινῆος μεμνημένοι, ὡς ἐπέτελλεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1052"><q rend="double; merge">οὐδὲ γὰρ Ἡρακλέης, ὁπότʼ ἤλυθεν Ἀρκαδίηνδε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1053"><q rend="double; merge">πλωίδας ὄρνιθας Στυμφαλίδας ἔσθενε λίμνης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1054"><q rend="double; merge">ὤσασθαι τόξοισι, τὸ μέν τʼ ἐγὼ αὐτὸς ὄπωπα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1055"><q rend="double; merge">ἀλλʼ ὅγε χαλκείην πλατάγην ἐνὶ χερσὶ τινάσσων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1056"><q rend="double; merge">δούπει ἐπὶ σκοπιῆς περιμήκεος· αἱ δʼ ἐφέβοντο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1057"><q rend="double; merge">τηλοῦ, ἀτυζηλῷ ὑπὸ δείματι κεκληγυῖαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1058"><q rend="double; merge">τῶ καὶ νῦν τοίην τινʼ ἐπιφραζώμεθα μῆτιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1059"><q rend="double; merge">αὐτὸς δʼ ἂν τὸ πάροιθεν ἐπιφρασθεὶς ἐνέποιμι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1060"><q rend="double; merge">ἀνθέμενοι κεφαλῇσιν ἀερσιλόφους τρυφαλείας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1061"><q rend="double; merge">ἡμίσεες μὲν ἐρέσσετʼ ἀμοιβαδίς, ἡμίσεες δὲ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1062"><q rend="double; merge">δούρασί τε ξυστοῖσι καὶ ἀσπίσιν ἄρσετε νῆα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1063"><q rend="double; merge">αὐτὰρ πασσυδίῃ περιώσιον ὄρνυτʼ ἀυτὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1064"><q rend="double; merge">ἀθρόοι, ὄφρα κολῳὸν ἀηθείῃ φοβέωνται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1065"><q rend="double; merge">νεύοντάς τε λόφους καὶ ἐπήορα δούραθʼ ὕπερθεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1066"><q rend="double; merge">εἰ δέ κεν αὐτὴν νῆσον ἱκώμεθα, δὴ τότʼ ἔπειτα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1067"><q rend="double; merge">σὺν κελάδῳ σακέεσσι πελώριον ὄρσετε δοῦπον.</q></l>
 					          <milestone n="1068" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1068">ὧς ἄρʼ ἔφη· πάντεσσι δʼ ἐπίρροθος ἥνδανε
@@ -2867,57 +2867,57 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1122">ἀλλήλοις, Ἄργος δὲ παροίτατος ἔκφατο μῦθον·</l>
 					          <milestone n="1123" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1123">‘Ἀντόμεθα πρὸς Ζηνὸς Ἐποψίου, οἵτινές ἐστε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1124">ἀνδρῶν, εὐμενέειν τε καὶ ἀρκέσσαι χατέουσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1125">πόντῳ γὰρ τρηχεῖαι ἐπιβρίσασαι ἄελλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1126">νηὸς ἀεικελίης διὰ δούρατα πάντʼ ἐκέδασσαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1127">ᾗ ἔνι πείρομεν οἶμον ἐπὶ χρέος ἐμβεβαῶτες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1128">τούνεκα νῦν ὑμέας γουναζόμεθʼ, αἴ κε πίθησθε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1129">δοῦναι ὅσον τʼ εἴλυμα περὶ χροός, ἠδὲ κομίσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1130">ἀνέρας οἰκτείραντας ὁμήλικας ἐν κακότητι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1131">ἀλλʼ ἱκέτας ξείνους Διὸς εἵνεκεν αἰδέσσασθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1132">ξεινίου Ἱκεσίου τε· Διὸς δʼ ἄμφω ἱκέται τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1133">καὶ ξεῖνοι· ὁ δέ που καὶ ἐπόψιος ἄμμι τέτυκται.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1123"><q rend="double">Ἀντόμεθα πρὸς Ζηνὸς Ἐποψίου, οἵτινές ἐστε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1124"><q rend="double; merge">ἀνδρῶν, εὐμενέειν τε καὶ ἀρκέσσαι χατέουσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1125"><q rend="double; merge">πόντῳ γὰρ τρηχεῖαι ἐπιβρίσασαι ἄελλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1126"><q rend="double; merge">νηὸς ἀεικελίης διὰ δούρατα πάντʼ ἐκέδασσαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1127"><q rend="double; merge">ᾗ ἔνι πείρομεν οἶμον ἐπὶ χρέος ἐμβεβαῶτες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1128"><q rend="double; merge">τούνεκα νῦν ὑμέας γουναζόμεθʼ, αἴ κε πίθησθε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1129"><q rend="double; merge">δοῦναι ὅσον τʼ εἴλυμα περὶ χροός, ἠδὲ κομίσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1130"><q rend="double; merge">ἀνέρας οἰκτείραντας ὁμήλικας ἐν κακότητι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1131"><q rend="double; merge">ἀλλʼ ἱκέτας ξείνους Διὸς εἵνεκεν αἰδέσσασθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1132"><q rend="double; merge">ξεινίου Ἱκεσίου τε· Διὸς δʼ ἄμφω ἱκέται τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1133"><q rend="double; merge">καὶ ξεῖνοι· ὁ δέ που καὶ ἐπόψιος ἄμμι τέτυκται.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1134">τὸν δʼ αὖτʼ Αἴσονος υἱὸς ἐπιφραδέως ἐρέεινεν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1135">μαντοσύνας Φινῆος ὀισσάμενος τελέεσθαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1136">‘ταῦτα μὲν αὐτίκα πάντα παρέξομεν εὐμενέοντες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1137">ἀλλʼ ἄγε μοι κατάλεξον ἐτήτυμον, ὁππόθι γαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1138">ναίετε, καὶ χρέος οἷον ὑπεὶρ ἅλα νεῖσθαι ἀνώγει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1139">αὐτῶν θʼ ὑμείων ὄνομα κλυτόν, ἠδὲ γενέθλην.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1136"><q rend="double">ταῦτα μὲν αὐτίκα πάντα παρέξομεν εὐμενέοντες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1137"><q rend="double; merge">ἀλλʼ ἄγε μοι κατάλεξον ἐτήτυμον, ὁππόθι γαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1138"><q rend="double; merge">ναίετε, καὶ χρέος οἷον ὑπεὶρ ἅλα νεῖσθαι ἀνώγει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1139"><q rend="double; merge">αὐτῶν θʼ ὑμείων ὄνομα κλυτόν, ἠδὲ γενέθλην.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1140">τὸν δʼ Ἄργος προσέειπεν ἀμηχανέων
 						κακότητι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1141">‘Αἰολίδην Φρίξον τινʼ ἀφʼ Ἑλλάδος Αἶαν ἱκέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1142">ἀτρεκέως δοκέω που ἀκούετε καὶ πάρος αὐτοί,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1143">Φρίξον, ὅτις πτολίεθρον ἀνήλυθεν Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1144">κριοῦ ἐπεμβεβαώς, τόν ῥα χρύσειον ἔθηκεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1145">Ἑρμείας· κῶας δὲ καὶ εἰσέτι νῦν κεν ἴδοισθε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1146">τὸν μὲν ἔπειτʼ ἔρρεξεν ἑῇς ὑποθημοσύνῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1147">Φυξίῳ ἐκ πάντων Κρονίδῃ Διί. καί μιν ἔδεκτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1148">Αἰήτης μεγάρῳ, κούρην τέ οἱ ἐγγυάλιξεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1149">Χαλκιόπην ἀνάεδνον ἐυφροσύνῃσι νόοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1150">τῶν ἐξ ἀμφοτέρων εἰμὲν γένος. ἀλλʼ ὁ μὲν ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1151">γηραιὸς θάνε Φρίξος ἐν Λἰήταο δόμοισιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1152">ἡμεῖς δʼ αὐτίκα πατρὸς ἐφετμάων ἀλέγοντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1153">νεύμεθʼ ἐς Ὀρχομενὸν κτεάνων Ἀθάμαντος ἕκητι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1154">εἰ δὲ καὶ οὔνομα δῆθεν ἐπιθύεις δεδαῆσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1155">τῷδε Κυτίσσωρος πέλει οὔνομα, τῷ δέ τε Φρόντις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1156">τῷ δὲ Μέλας· ἐμὲ δʼ αὐτὸν ἐπικλείοιτέ κεν Ἄργον.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1141"><q rend="double">Αἰολίδην Φρίξον τινʼ ἀφʼ Ἑλλάδος Αἶαν ἱκέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1142"><q rend="double; merge">ἀτρεκέως δοκέω που ἀκούετε καὶ πάρος αὐτοί,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1143"><q rend="double; merge">Φρίξον, ὅτις πτολίεθρον ἀνήλυθεν Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1144"><q rend="double; merge">κριοῦ ἐπεμβεβαώς, τόν ῥα χρύσειον ἔθηκεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1145"><q rend="double; merge">Ἑρμείας· κῶας δὲ καὶ εἰσέτι νῦν κεν ἴδοισθε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1146"><q rend="double; merge">τὸν μὲν ἔπειτʼ ἔρρεξεν ἑῇς ὑποθημοσύνῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1147"><q rend="double; merge">Φυξίῳ ἐκ πάντων Κρονίδῃ Διί. καί μιν ἔδεκτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1148"><q rend="double; merge">Αἰήτης μεγάρῳ, κούρην τέ οἱ ἐγγυάλιξεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1149"><q rend="double; merge">Χαλκιόπην ἀνάεδνον ἐυφροσύνῃσι νόοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1150"><q rend="double; merge">τῶν ἐξ ἀμφοτέρων εἰμὲν γένος. ἀλλʼ ὁ μὲν ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1151"><q rend="double; merge">γηραιὸς θάνε Φρίξος ἐν Λἰήταο δόμοισιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1152"><q rend="double; merge">ἡμεῖς δʼ αὐτίκα πατρὸς ἐφετμάων ἀλέγοντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1153"><q rend="double; merge">νεύμεθʼ ἐς Ὀρχομενὸν κτεάνων Ἀθάμαντος ἕκητι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1154"><q rend="double; merge">εἰ δὲ καὶ οὔνομα δῆθεν ἐπιθύεις δεδαῆσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1155"><q rend="double; merge">τῷδε Κυτίσσωρος πέλει οὔνομα, τῷ δέ τε Φρόντις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1156"><q rend="double; merge">τῷ δὲ Μέλας· ἐμὲ δʼ αὐτὸν ἐπικλείοιτέ κεν Ἄργον.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1157">ὧς φάτʼ· ἀριστῆες δὲ συνηβολίῃ κεχάροντο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1158">καί σφεας ἀμφίεπον περιθαμβέες. αὐτὰρ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1159">ἐξαῦτις κατὰ μοῖραν ἀμείψατο τοῖσδʼ ἐπέεσσιν·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1160">‘ἦ ἄρα δὴ γνωτοὶ πατρώιοι ἄμμιν
-						ἐόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1161">λίσσεσθʼ εὐμενέοντας ἐπαρκέσσαι κακότητα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1162">Κρηθεὺς γάρ ῥʼ Ἀθάμας τε κασίγνητοι γεγάασιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1163">Κρηθῆος δʼ υἱωνὸς ἐγὼ σὺν τοισίδʼ ἑταίροις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1164">Ἑλλάδος ἐξ αὐτῆς νέομʼ ἐς πόλιν Αἰήταο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1165">ἀλλὰ τὰ μὲν καὶ ἐσαῦτις ἐνίφομεν ἀλλήλοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1166">νῦν δʼ ἕσσασθε πάροιθεν· ὑπʼ ἐννεσίῃσι δʼ ὀίω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1167">ἀθανάτων ἐς χεῖρας ἐμὰς χατέοντας ἱκέσθαι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1160"><q rend="double">ἦ ἄρα δὴ γνωτοὶ πατρώιοι ἄμμιν
+						ἐόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1161"><q rend="double; merge">λίσσεσθʼ εὐμενέοντας ἐπαρκέσσαι κακότητα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1162"><q rend="double; merge">Κρηθεὺς γάρ ῥʼ Ἀθάμας τε κασίγνητοι γεγάασιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1163"><q rend="double; merge">Κρηθῆος δʼ υἱωνὸς ἐγὼ σὺν τοισίδʼ ἑταίροις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1164"><q rend="double; merge">Ἑλλάδος ἐξ αὐτῆς νέομʼ ἐς πόλιν Αἰήταο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1165"><q rend="double; merge">ἀλλὰ τὰ μὲν καὶ ἐσαῦτις ἐνίφομεν ἀλλήλοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1166"><q rend="double; merge">νῦν δʼ ἕσσασθε πάροιθεν· ὑπʼ ἐννεσίῃσι δʼ ὀίω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1167"><q rend="double; merge">ἀθανάτων ἐς χεῖρας ἐμὰς χατέοντας ἱκέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1168">ἦ ῥα, καὶ ἐκ νηὸς δῶκέ σφισιν εἵματα δῦναι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1169">πασσυδίῃ δἤπειτα κίον μετὰ νηὸν Ἄρηος,</l>
@@ -2932,59 +2932,59 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1178">δὴ τότ ἄρʼ Αἰσονίδης μετεφώνεεν, ἦρχέ τε μύθων·</l>
 					          <milestone n="1179" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1179">‘Ζεὺς ἐτεῇ τὰ ἕκαστʼ ἐπιδέρκεται· οὐδέ μιν
-						ἄνδρες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1180">λήθομεν ἔμπεδον, οἵ τε θεουδέες οὐδὲ δίκαιοι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1181">ὡς μὲν γὰρ πατέρʼ ὑμὸν ὑπεξείρυτο φόνοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1182">μητρυιῆς, καὶ νόσφιν ἀπειρέσιον πόρεν ὄλβον·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1183">ὧς δὲ καὶ ὑμέας αὖτις ἀπήμονας ἐξεσάωσεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1184">χείματος οὐλομένοιο. πάρεστι δὲ τῆσδʼ ἐπὶ νηὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1185">ἔνθα καὶ ἔνθα νέεσθαι, ὅπῃ φίλον, εἴτε μετʼ Αἶαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1186">εἶτε μετʼ ἀφνειὴν θείου πόλιν Ὀρχομενοῖο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1187">τὴν γὰρ Ἀθηναίη τεχνήσατο, καὶ τάμε χαλκῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1188">δούρατα Πηλιάδος κορυφῆς πέρι· σὺν δέ οἱ Ἄργος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1189">τεῦξεν. ἀτὰρ κείνην γε κακὸν διὰ κῦμʼ ἐκέδασσεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1190">πρὶν καὶ πετράων σχεδὸν ἐλθεῖν, αἵ τʼ ἐνὶ πόντῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1191">στεινωπῷ συνίασι πανήμεροι ἀλλήλῃσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1192">ἀλλʼ ἄγεθʼ ὧδε καὶ αὐτοὶ ἐς Ἑλλάδα μαιομένοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1193">κῶας ἄγειν χρύσειον ἐπίρροθοι ἄμμι πέλεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1194">καὶ πλόου ἡγεμονῆες, ἐπεὶ Φρίξοιο θυηλὰς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1195">στέλλομαι ἀμπλήσων, Ζηνὸς χόλον Αἰολίδῃσιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1179"><q rend="double">Ζεὺς ἐτεῇ τὰ ἕκαστʼ ἐπιδέρκεται· οὐδέ μιν
+						ἄνδρες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1180"><q rend="double; merge">λήθομεν ἔμπεδον, οἵ τε θεουδέες οὐδὲ δίκαιοι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1181"><q rend="double; merge">ὡς μὲν γὰρ πατέρʼ ὑμὸν ὑπεξείρυτο φόνοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1182"><q rend="double; merge">μητρυιῆς, καὶ νόσφιν ἀπειρέσιον πόρεν ὄλβον·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1183"><q rend="double; merge">ὧς δὲ καὶ ὑμέας αὖτις ἀπήμονας ἐξεσάωσεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1184"><q rend="double; merge">χείματος οὐλομένοιο. πάρεστι δὲ τῆσδʼ ἐπὶ νηὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1185"><q rend="double; merge">ἔνθα καὶ ἔνθα νέεσθαι, ὅπῃ φίλον, εἴτε μετʼ Αἶαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1186"><q rend="double; merge">εἶτε μετʼ ἀφνειὴν θείου πόλιν Ὀρχομενοῖο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1187"><q rend="double; merge">τὴν γὰρ Ἀθηναίη τεχνήσατο, καὶ τάμε χαλκῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1188"><q rend="double; merge">δούρατα Πηλιάδος κορυφῆς πέρι· σὺν δέ οἱ Ἄργος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1189"><q rend="double; merge">τεῦξεν. ἀτὰρ κείνην γε κακὸν διὰ κῦμʼ ἐκέδασσεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1190"><q rend="double; merge">πρὶν καὶ πετράων σχεδὸν ἐλθεῖν, αἵ τʼ ἐνὶ πόντῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1191"><q rend="double; merge">στεινωπῷ συνίασι πανήμεροι ἀλλήλῃσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1192"><q rend="double; merge">ἀλλʼ ἄγεθʼ ὧδε καὶ αὐτοὶ ἐς Ἑλλάδα μαιομένοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1193"><q rend="double; merge">κῶας ἄγειν χρύσειον ἐπίρροθοι ἄμμι πέλεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1194"><q rend="double; merge">καὶ πλόου ἡγεμονῆες, ἐπεὶ Φρίξοιο θυηλὰς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1195"><q rend="double; merge">στέλλομαι ἀμπλήσων, Ζηνὸς χόλον Αἰολίδῃσιν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1196">ἴσκε παρηγορέων· οἱ δʼ ἔστυγον εἰσαΐοντες.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1197">οὐ γὰρ ἔφαν τεύξεσθαι ἐνηέος Αἰήταο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1198">κῶας ἄγειν κριοῖο μεμαότας, ὧδε δʼ ἔειπεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1199">Ἄργος, ἀτεμβόμενος τοῖον στόλον ἀμφιπένεσθαι·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1200">‘ὦ φίλοι, ἡμέτερον μὲν ὅσον σθένος, οὔποτʼ
-						ἀρωγῆς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1201">σχήσεται, οὐδʼ ἠβαιόν, ὅτε χρειώ τις ἵκηται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1202">ἀλλʼ αἰνῶς ὀλοῇσιν ἀπηνείῃσιν ἄρηρεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1203">Αἰήτης· τῶ καὶ περιδείδια ναυτίλλεσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1204">στεῦται δʼ Ἠελίου γόνος ἔμμεναι· ἀμφὶ δὲ Κόλχων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1205">ἔθνεα ναιετάουσιν ἀπείρονα· καὶ δέ κεν Ἄρει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1206">σμερδαλέην ἐνοπὴν μέγα τε σθένος ἰσοφαρίζοι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1207">οὐ μὰν οὐδʼ ἀπάνευθεν ἑλεῖν δέρος Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1208">ῥηίδιον, τοῖός μιν ὄφις περί τʼ ἀμφί τʼ ἔρυται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1209">ἀθάνατος καὶ ἄυπνος, ὃν αὐτὴ Γαῖʼ ἀνέφυσεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1210">Καυκάσου ἐν κνημοῖσι, Τυφαονίη ὅθι πέτρη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1211">ἔνθα Τυφάονά φασι Διὸς Κρονίδαο κεραυνῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1212">βλήμενον, ὁππότε οἱ στιβαρὰς ἐπορέξατο χεῖρας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1213">θερμὸν ἀπὸ κρατὸς στάξαι φόνον· ἵκετο δʼ αὔτως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1214">οὔρεα καὶ πεδίον Νυσήιον, ἔνθʼ ἔτι νῦν περ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1215">κεῖται ὑποβρύχιος Σερβωνίδος ὕδασι λίμνης.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1200"><q rend="double">ὦ φίλοι, ἡμέτερον μὲν ὅσον σθένος, οὔποτʼ
+						ἀρωγῆς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1201"><q rend="double; merge">σχήσεται, οὐδʼ ἠβαιόν, ὅτε χρειώ τις ἵκηται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1202"><q rend="double; merge">ἀλλʼ αἰνῶς ὀλοῇσιν ἀπηνείῃσιν ἄρηρεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1203"><q rend="double; merge">Αἰήτης· τῶ καὶ περιδείδια ναυτίλλεσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1204"><q rend="double; merge">στεῦται δʼ Ἠελίου γόνος ἔμμεναι· ἀμφὶ δὲ Κόλχων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1205"><q rend="double; merge">ἔθνεα ναιετάουσιν ἀπείρονα· καὶ δέ κεν Ἄρει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1206"><q rend="double; merge">σμερδαλέην ἐνοπὴν μέγα τε σθένος ἰσοφαρίζοι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1207"><q rend="double; merge">οὐ μὰν οὐδʼ ἀπάνευθεν ἑλεῖν δέρος Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1208"><q rend="double; merge">ῥηίδιον, τοῖός μιν ὄφις περί τʼ ἀμφί τʼ ἔρυται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1209"><q rend="double; merge">ἀθάνατος καὶ ἄυπνος, ὃν αὐτὴ Γαῖʼ ἀνέφυσεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1210"><q rend="double; merge">Καυκάσου ἐν κνημοῖσι, Τυφαονίη ὅθι πέτρη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1211"><q rend="double; merge">ἔνθα Τυφάονά φασι Διὸς Κρονίδαο κεραυνῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1212"><q rend="double; merge">βλήμενον, ὁππότε οἱ στιβαρὰς ἐπορέξατο χεῖρας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1213"><q rend="double; merge">θερμὸν ἀπὸ κρατὸς στάξαι φόνον· ἵκετο δʼ αὔτως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1214"><q rend="double; merge">οὔρεα καὶ πεδίον Νυσήιον, ἔνθʼ ἔτι νῦν περ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1215"><q rend="double; merge">κεῖται ὑποβρύχιος Σερβωνίδος ὕδασι λίμνης.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1216">ὧς ἄρʼ ἔφη· πολέεσσι δʼ ἐπὶ χλόος εἷλε παρειὰς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1217">αὐτίκα, τοῖον ἄεθλον ὅτʼ ἔκλυον. αἶψα δὲ Πηλεὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1218">θαρσαλέοις ἐπέεσσιν ἀμείψατο, φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1219">‘μηδʼ οὕτως, ἠθεῖε, λίην δειδίσσεο θυμῷ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1220">οὔτε γὰρ ὧδʼ ἀλκὴν ἐπιδευόμεθʼ, ὥστε χερείους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1221">ἔμμεναι Αἰήταο σὺν ἔντεσι πειρηθῆναι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1222">ἀλλὰ καὶ ἡμέας οἴω ἐπισταμένους πολέμοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1223">κεῖσε μολεῖν, μακάρων σχεδὸν αἵματος ἐκγεγαῶτας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1224">τῶ εἰ μὴ φιλότητι δέρος χρύσειον ὀπάσσει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1225">οὔ οἱ χραισμήσειν ἐπιέλπομαι ἔθνεα Κόλχων.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1219"><q rend="double">μηδʼ οὕτως, ἠθεῖε, λίην δειδίσσεο θυμῷ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1220"><q rend="double; merge">οὔτε γὰρ ὧδʼ ἀλκὴν ἐπιδευόμεθʼ, ὥστε χερείους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1221"><q rend="double; merge">ἔμμεναι Αἰήταο σὺν ἔντεσι πειρηθῆναι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1222"><q rend="double; merge">ἀλλὰ καὶ ἡμέας οἴω ἐπισταμένους πολέμοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1223"><q rend="double; merge">κεῖσε μολεῖν, μακάρων σχεδὸν αἵματος ἐκγεγαῶτας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1224"><q rend="double; merge">τῶ εἰ μὴ φιλότητι δέρος χρύσειον ὀπάσσει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1225"><q rend="double; merge">οὔ οἱ χραισμήσειν ἐπιέλπομαι ἔθνεα Κόλχων.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1226">ὧς οἵγʼ ἀλλήλοισιν ἀμοιβαδὸν ἠγορόωντο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1227">μέσφʼ αὖτις δόρποιο κορεσσάμενοι κατέδαρθεν.</l>
@@ -3042,10 +3042,10 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1275">εὐμενέως, καὶ νηὸς ἐναίσιμα πείσματα δέχθαι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1276">αὐτίκα δʼ Ἀγκαῖος τοῖον μετὰ μῦθον ἔειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1277">‘Κολχίδα μὲν δὴ γαῖαν ἱκάνομεν ἠδὲ ῥέεθρα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1278">Φάσιδος· ὥρη δʼ ἧμιν ἐνὶ σφίσι μητιάασθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1279">εἴτʼ οὖν μειλιχίῃ πειρησόμεθʼ Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1280">εἴτε καὶ ἀλλοίη τις ἐπήβολος ἔσσεται ὁρμή.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1277"><q rend="double">Κολχίδα μὲν δὴ γαῖαν ἱκάνομεν ἠδὲ ῥέεθρα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1278"><q rend="double; merge">Φάσιδος· ὥρη δʼ ἧμιν ἐνὶ σφίσι μητιάασθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1279"><q rend="double; merge">εἴτʼ οὖν μειλιχίῃ πειρησόμεθʼ Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1280"><q rend="double; merge">εἴτε καὶ ἀλλοίη τις ἐπήβολος ἔσσεται ὁρμή.</q></l>
 					          <milestone n="1281" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1281">ὧς ἔφατʼ· Ἄργου δʼ αὖτε παρηγορίῃσιν Ἰήσων</l>
@@ -3068,35 +3068,35 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="9">ἀθανάτων ἀπονόσφι θεῶν θάλαμόνδε κιοῦσαι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="10">βούλευον· πείραζε δʼ Ἀθηναίην πάρος Ἥρη·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="11">‘αὐτὴ νῦν προτέρη, θύγατερ Διός, ἄρχεο βουλῆς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="12">τί χρέος; ἠὲ δόλον τινὰ μήσεαι, ᾧ κεν ἑλόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="13">χρύσεον Αἰήταο μεθʼ Ἑλλάδα κῶας ἄγοιντο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="14">ἦ καὶ τόνγʼ ἐπέεσσι παραιφάμενοι πεπίθοιεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="15">μειλιχίοις; ἦ γὰρ ὅγʼ ὑπερφίαλος πέλει αἰνῶς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="16">ἔμπης δʼ οὔτινα πεῖραν ἀποτρωπᾶσθαι ἔοικεν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="11"><q rend="double">αὐτὴ νῦν προτέρη, θύγατερ Διός, ἄρχεο βουλῆς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="12"><q rend="double; merge">τί χρέος; ἠὲ δόλον τινὰ μήσεαι, ᾧ κεν ἑλόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="13"><q rend="double; merge">χρύσεον Αἰήταο μεθʼ Ἑλλάδα κῶας ἄγοιντο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="14"><q rend="double; merge">ἦ καὶ τόνγʼ ἐπέεσσι παραιφάμενοι πεπίθοιεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="15"><q rend="double; merge">μειλιχίοις; ἦ γὰρ ὅγʼ ὑπερφίαλος πέλει αἰνῶς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="16"><q rend="double; merge">ἔμπης δʼ οὔτινα πεῖραν ἀποτρωπᾶσθαι ἔοικεν.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="17">ὧς φάτο· τὴν δὲ παρᾶσσον Ἀθηναίη προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="18">‘καὶ δʼ αὐτὴν ἐμὲ τοῖα μετὰ φρεσὶν ὁρμαίνουσαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="19">Ἤρη, ἀπηλεγέως ἐξείρεαι. ἀλλά τοι οὔπω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="20">φράσσασθαι νοέω τοῦτον δόλον, ὅστις ὀνήσει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="21">θυμὸν ἀριστήων· πολέας δʼ ἐπεδοίασα βουλάς.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="18"><q rend="double">καὶ δʼ αὐτὴν ἐμὲ τοῖα μετὰ φρεσὶν ὁρμαίνουσαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="19"><q rend="double; merge">Ἤρη, ἀπηλεγέως ἐξείρεαι. ἀλλά τοι οὔπω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="20"><q rend="double; merge">φράσσασθαι νοέω τοῦτον δόλον, ὅστις ὀνήσει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="21"><q rend="double; merge">θυμὸν ἀριστήων· πολέας δʼ ἐπεδοίασα βουλάς.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="22">ἦ, καὶ ἐπʼ οὔδεος αἵγε ποδῶν πάρος ὄμματʼ
 						ἔπηξαν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="23">ἄνδιχα πορφύρουσαι ἐνὶ σφίσιν· αὐτίκα δʼ Ἥρη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="24">τοῖον μητιόωσα παροιτέρη ἔκφατο μῦθον·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="25">‘δεῦρʼ ἴομεν μετὰ Κύπριν· ἐπιπλόμεναι δέ μιν ἄμφω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="26">παιδὶ ἑῷ εἰπεῖν ὀτρύνομεν, αἴ κε πίθηται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="27">κούρην Αἰήτεω πολυφάρμακον οἷσι βέλεσσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="28">θέλξαι ὀιστεύσας ἐπʼ Ἰήσονι. τὸν δʼ ἂν ὀίω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="29">κείνης ἐννεσίῃσιν ἐς Ἑλλάδα κῶας ἀνάξειν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="25"><q rend="double">δεῦρʼ ἴομεν μετὰ Κύπριν· ἐπιπλόμεναι δέ μιν ἄμφω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="26"><q rend="double; merge">παιδὶ ἑῷ εἰπεῖν ὀτρύνομεν, αἴ κε πίθηται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="27"><q rend="double; merge">κούρην Αἰήτεω πολυφάρμακον οἷσι βέλεσσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="28"><q rend="double; merge">θέλξαι ὀιστεύσας ἐπʼ Ἰήσονι. τὸν δʼ ἂν ὀίω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="29"><q rend="double; merge">κείνης ἐννεσίῃσιν ἐς Ἑλλάδα κῶας ἀνάξειν.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="30">ὧς ἄρʼ ἔφη· πυκινὴ δὲ συνεύαδε μῆτις
 						Ἀθήνῃ,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="31">καί μιν ἔπειτʼ ἐξαῦτις ἀμείβετο μειλιχίοισιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="32">‘Ἥρη, νήιδα μέν με πατὴρ τέκε τοῖο βολάων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="33">οὐδέ τινα χρειὼ θελκτήριον οἶδα πόθοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="34">εἰ δέ σοι αὐτῇ μῦθος ἐφανδάνει, ἦ τʼ ἂν ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="35">ἑσποίμην· σὺ δέ κεν φαίης ἔπος ἀντιόωσα.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="32"><q rend="double">Ἥρη, νήιδα μέν με πατὴρ τέκε τοῖο βολάων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="33"><q rend="double; merge">οὐδέ τινα χρειὼ θελκτήριον οἶδα πόθοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="34"><q rend="double; merge">εἰ δέ σοι αὐτῇ μῦθος ἐφανδάνει, ἦ τʼ ἂν ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="35"><q rend="double; merge">ἑσποίμην· σὺ δέ κεν φαίης ἔπος ἀντιόωσα.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="36">ἦ, καὶ ἀναΐξασαι ἐπὶ μέγα δῶμα νέοντο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="37">Κύπριδος, ὅ ῥά τέ οἱ δεῖμεν πόσις ἀμφιγυήεις,</l>
@@ -3116,75 +3116,75 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="51">τοῖα δὲ μειδιόωσα προσέννεπεν αἱμυλίοισιν· </l>
                               <milestone n="52" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="52">‘Ἠθεῖαι, τίς δεῦρο νόος χρειω τε κομίζει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="53">δηναιὰς αὔτως; τί δʼ ἱκάνετον, οὔτι πάρος γε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="54">λίην φοιτίζουσαι, ἐπεὶ περίεστε θεάων;’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="52"><q rend="double">Ἠθεῖαι, τίς δεῦρο νόος χρειω τε κομίζει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="53"><q rend="double; merge">δηναιὰς αὔτως; τί δʼ ἱκάνετον, οὔτι πάρος γε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="54"><q rend="double; merge">λίην φοιτίζουσαι, ἐπεὶ περίεστε θεάων;</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="55">τὴν δʼ Ἥρη τοίοισιν ἀμειβομένη
 						προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="56">‘Κερτομέεις· νῶιν δὲ κέαρ συνορίνεται ἄτῃ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="57">ἤδη γὰρ ποταμῷ ἐνὶ Φάσιδι νῆα κατίσχει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="58">Αἰσονίδης, ἠδʼ ἄλλοι ὅσοι μετὰ κῶας ἕπονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="59">τῶν ἤτοι πάντων μέν, ἐπεὶ πέλας ἔργον ὄρωρεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="60">δείδιμεν ἐκπάγλως, περὶ δʼ Αἰσονίδαο μάλιστα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="61">τὸν μὲν ἐγών, εἰ καί περ ἐς Ἄιδα ναυτίλληται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="62">λυσόμενος χαλκέων Ἰξίονα νειόθι δεσμῶν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="63">ῥύσομαι, ὅσσον ἐμοῖσιν ἐνὶ σθένος ἔπλετο γυίοις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="64">ὄφρα μὴ ἐγγελάσῃ Πελίης κακὸν οἶτον ἀλύξας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="65">ὅς μʼ ὑπερηνορέῃ θυέων ἀγέραστον ἔθηκεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="66">καὶ δʼ ἄλλως ἔτι καὶ πρὶν ἐμοὶ μέγα φίλατʼ Ἰήσων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="67">ἐξότʼ ἐπὶ προχοῇσιν ἅλις πλήθοντος Ἀναύρου</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="68">ἀνδρῶν εὐνομίης πειρωμένῃ ἀντεβόλησεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="69">θήρης ἐξανιών· νιφετῷ δʼ ἐπαλύνετο πάντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="70">οὔρεα καὶ σκοπιαὶ περιμήκεες, οἱ δὲ κατʼ αὐτῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="71">χείμαρροι καναχηδὰ κυλινδόμενοι φορέοντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="72">γρηὶ δέ μʼ εἰσαμένην ὀλοφύρατο, καί μʼ ἀναείρας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="73">αὐτὸς ἑοῖς ὤμοισι διὲκ προαλὲς φέρεν ὕδωρ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="74">τῶ νύ μοι ἄλληκτον περιτίεται· οὐδέ κε λώβην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="75">τίσειεν Πελίης, εἰ μή σύ γε νόστον ὀπάσσεις.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="56"><q rend="double">Κερτομέεις· νῶιν δὲ κέαρ συνορίνεται ἄτῃ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="57"><q rend="double; merge">ἤδη γὰρ ποταμῷ ἐνὶ Φάσιδι νῆα κατίσχει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="58"><q rend="double; merge">Αἰσονίδης, ἠδʼ ἄλλοι ὅσοι μετὰ κῶας ἕπονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="59"><q rend="double; merge">τῶν ἤτοι πάντων μέν, ἐπεὶ πέλας ἔργον ὄρωρεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="60"><q rend="double; merge">δείδιμεν ἐκπάγλως, περὶ δʼ Αἰσονίδαο μάλιστα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="61"><q rend="double; merge">τὸν μὲν ἐγών, εἰ καί περ ἐς Ἄιδα ναυτίλληται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="62"><q rend="double; merge">λυσόμενος χαλκέων Ἰξίονα νειόθι δεσμῶν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="63"><q rend="double; merge">ῥύσομαι, ὅσσον ἐμοῖσιν ἐνὶ σθένος ἔπλετο γυίοις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="64"><q rend="double; merge">ὄφρα μὴ ἐγγελάσῃ Πελίης κακὸν οἶτον ἀλύξας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="65"><q rend="double; merge">ὅς μʼ ὑπερηνορέῃ θυέων ἀγέραστον ἔθηκεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="66"><q rend="double; merge">καὶ δʼ ἄλλως ἔτι καὶ πρὶν ἐμοὶ μέγα φίλατʼ Ἰήσων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="67"><q rend="double; merge">ἐξότʼ ἐπὶ προχοῇσιν ἅλις πλήθοντος Ἀναύρου</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="68"><q rend="double; merge">ἀνδρῶν εὐνομίης πειρωμένῃ ἀντεβόλησεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="69"><q rend="double; merge">θήρης ἐξανιών· νιφετῷ δʼ ἐπαλύνετο πάντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="70"><q rend="double; merge">οὔρεα καὶ σκοπιαὶ περιμήκεες, οἱ δὲ κατʼ αὐτῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="71"><q rend="double; merge">χείμαρροι καναχηδὰ κυλινδόμενοι φορέοντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="72"><q rend="double; merge">γρηὶ δέ μʼ εἰσαμένην ὀλοφύρατο, καί μʼ ἀναείρας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="73"><q rend="double; merge">αὐτὸς ἑοῖς ὤμοισι διὲκ προαλὲς φέρεν ὕδωρ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="74"><q rend="double; merge">τῶ νύ μοι ἄλληκτον περιτίεται· οὐδέ κε λώβην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="75"><q rend="double; merge">τίσειεν Πελίης, εἰ μή σύ γε νόστον ὀπάσσεις.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="76">ὧς ηὔδα· Κύπριν δʼ ἐνεοστασίη λάβε μύθων.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="77">ἅζετο δʼ ἀντομένην Ἥρην ἕθεν εἰσορόωσα,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="78">καί μιν ἔπειτʼ ἀγανοῖσι προσέννεπεν ἥγʼ ἐπέεσσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="79">‘πότνα θεά, μή τοί τι κακώτερον ἄλλο πέλοιτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="80">Κύπριδος, εἰ δὴ σεῖο λιλαιομένης ἀθερίζω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="81">ἢ ἔπος ἠέ τι ἔργον, ὅ κεν χέρες αἵγε κάμοιεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="82">ἠπεδαναί· καὶ μή τις ἀμοιβαίη χάρις ἔστω.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="79"><q rend="double">πότνα θεά, μή τοί τι κακώτερον ἄλλο πέλοιτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="80"><q rend="double; merge">Κύπριδος, εἰ δὴ σεῖο λιλαιομένης ἀθερίζω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="81"><q rend="double; merge">ἢ ἔπος ἠέ τι ἔργον, ὅ κεν χέρες αἵγε κάμοιεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="82"><q rend="double; merge">ἠπεδαναί· καὶ μή τις ἀμοιβαίη χάρις ἔστω.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="83">ὧς ἔφαθʼ· Ἥρη δʼ αὖτις ἐπιφραδέως ἀγορευσεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="84">‘οὔτι βίης χατέουσαι ἱκάνομεν, οὐδέ τι χειρῶν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="85">ἀλλʼ αὔτως ἀκέουσα τεῷ ἐπικέκλεο παιδὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="86">παρθένον Αἰήτεω θέλξαι πόθῳ Αἰσονίδαο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="87">εἰ γάρ οἱ κείνη συμφράσσεται εὐμενέουσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="88">ῥηιδίως μιν ἑλόντα δέρος χρύσειον ὀίω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="89">νοστήσειν ἐς Ἰωλκόν, ἐπεὶ δολόεσσα τέτυκται.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="84"><q rend="double">οὔτι βίης χατέουσαι ἱκάνομεν, οὐδέ τι χειρῶν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="85"><q rend="double; merge">ἀλλʼ αὔτως ἀκέουσα τεῷ ἐπικέκλεο παιδὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="86"><q rend="double; merge">παρθένον Αἰήτεω θέλξαι πόθῳ Αἰσονίδαο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="87"><q rend="double; merge">εἰ γάρ οἱ κείνη συμφράσσεται εὐμενέουσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="88"><q rend="double; merge">ῥηιδίως μιν ἑλόντα δέρος χρύσειον ὀίω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="89"><q rend="double; merge">νοστήσειν ἐς Ἰωλκόν, ἐπεὶ δολόεσσα τέτυκται.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="90">ὧς ἄρʼ ἔφη· Κύπρις δὲ μετʼ ἀμφοτέρῃσιν
 						ἔειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="91">‘Ἥρη, Ἀθηναίη τε, πίθοιτό κεν ὔμμι μάλιστα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="92">ἢ ἐμοί. ὑμείων γὰρ ἀναιδήτῳ περ ἐόντι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="93">τυτθή γʼ αἰδὼς ἔσσετʼ ἐν ὄμμασιν· αὐτὰρ ἐμεῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="94">οὐκ ὄθεται, μάλα δʼ αἰὲν ἐριδμαίνων ἀθερίζει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="95">καὶ δή οἱ μενέηνα, περισχομένη κακότητι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="96">αὐτοῖσιν τόξοισι δυσηχέας ἆξαι ὀιστοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="97">ἀμφαδίην. τοῖον γὰρ ἐπηπείλησε χαλεφθείς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="98">εἰ μὴ τηλόθι χεῖρας, ἕως ἔτι θυμὸν ἐρύκει,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="99">ἕξω ἐμάς, μετέπειτά γʼ ἀτεμβοίμην ἑοῖ αὐτῇ.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="91"><q rend="double">Ἥρη, Ἀθηναίη τε, πίθοιτό κεν ὔμμι μάλιστα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="92"><q rend="double; merge">ἢ ἐμοί. ὑμείων γὰρ ἀναιδήτῳ περ ἐόντι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="93"><q rend="double; merge">τυτθή γʼ αἰδὼς ἔσσετʼ ἐν ὄμμασιν· αὐτὰρ ἐμεῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="94"><q rend="double; merge">οὐκ ὄθεται, μάλα δʼ αἰὲν ἐριδμαίνων ἀθερίζει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="95"><q rend="double; merge">καὶ δή οἱ μενέηνα, περισχομένη κακότητι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="96"><q rend="double; merge">αὐτοῖσιν τόξοισι δυσηχέας ἆξαι ὀιστοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="97"><q rend="double; merge">ἀμφαδίην. τοῖον γὰρ ἐπηπείλησε χαλεφθείς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="98"><q rend="double; merge">εἰ μὴ τηλόθι χεῖρας, ἕως ἔτι θυμὸν ἐρύκει,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="99"><q rend="double; merge">ἕξω ἐμάς, μετέπειτά γʼ ἀτεμβοίμην ἑοῖ αὐτῇ.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="100">ὧς φάτο· μείδησαν δὲ θεαί, καὶ ἐσέδρακον
 						ἄντην</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="101">ἀλλήλαις. ἡ δʼ αὖτις ἀκηχεμένη προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="102">‘ἄλλοις ἄλγεα τἀμὰ γέλως πέλει· οὐδέ τί με χρὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="103">μυθεῖσθαι πάντεσσιν· ἅλις εἰδυῖα καὶ αὐτή.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="104">νῦν δʼ ἐπεὶ ὔμμι φίλον τόδε δὴ πέλει ἀμφοτέρῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="105">πειρήσω, καί μιν μειλίξομαι, οὐδʼ ἀπιθήσει.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="102"><q rend="double">ἄλλοις ἄλγεα τἀμὰ γέλως πέλει· οὐδέ τί με χρὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="103"><q rend="double; merge">μυθεῖσθαι πάντεσσιν· ἅλις εἰδυῖα καὶ αὐτή.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="104"><q rend="double; merge">νῦν δʼ ἐπεὶ ὔμμι φίλον τόδε δὴ πέλει ἀμφοτέρῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="105"><q rend="double; merge">πειρήσω, καί μιν μειλίξομαι, οὐδʼ ἀπιθήσει.</q></l>
 					          <milestone n="106" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="106">ὧς φάτο· τὴν δʼ Ἥρη ῥαδινῆς ἐπεμάσσατο χειρός,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="107">ἦκα δὲ μειδιόωσα παραβλήδην προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="108">‘οὕτω νῦν, Κυθέρεια, τόδε χρέος, ὡς ἀγορεύεις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="109">ἔρξον ἄφαρ· καὶ μή τι χαλέπτεο, μηδʼ ἐρίδαινε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="110">χωομένη σῷ παιδί· μεταλλήξει γὰρ ὀπίσσω.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="108"><q rend="double">οὕτω νῦν, Κυθέρεια, τόδε χρέος, ὡς ἀγορεύεις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="109"><q rend="double; merge">ἔρξον ἄφαρ· καὶ μή τι χαλέπτεο, μηδʼ ἐρίδαινε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="110"><q rend="double; merge">χωομένη σῷ παιδί· μεταλλήξει γὰρ ὀπίσσω.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="111">ἦ ῥα, καὶ ἔλλιπε θῶκον· ἐφωμάρτησε δʼ Ἀθήνη·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="112">ἐκ δʼ ἴσαν ἄμφω ταίγε παλίσσυτοι. ἡ δὲ καὶ αὐτὴ</l>
@@ -3205,22 +3205,22 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="127">Κύπριν ἐπιπλομένην. ἡ δʼ ἀντίη ἵστατο παιδός,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="128">καί μιν ἄφαρ γναθμοῖο κατασχομένη προσέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="129">‘τίπτʼ ἐπιμειδιάᾳς, ἄφατον κακόν; ἦέ μιν αὔτως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="130">ἤπαφες, οὐδὲ δίκῃ περιέπλεο νῆιν ἐόντα;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="131">εἰ δʼ ἄγε μοι πρόφρων τέλεσον χρέος, ὅττι κεν εἴπω·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="132">καί κέν τοι ὀπάσαιμι Διὸς περικαλλὲς ἄθυρμα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="133">κεῖνο, τό οἱ ποίησε φίλη τροφὸς Ἀδρήστεια</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="134">ἄντρῳ ἐν Ἰδαίῳ ἔτι νήπια κουρίζοντι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="135">σφαῖραν ἐυτρόχαλον, τῆς οὐ σύγε μείλιον ἄλλο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="136">χειρῶν Ἡφαίστοιο κατακτεατίσσῃ ἄρειον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="137">χρύσεα μέν οἱ κύκλα τετεύχαται· ἀμφὶ δʼ ἑκάστῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="138">διπλόαι ἁψῖδες περιηγέες εἱλίσσονται·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="139">κρυπταὶ δὲ ῥαφαί εἰσιν· ἕλιξ δʼ ἐπιδέδρομε πάσαις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="140">κυανέη. ἀτὰρ εἴ μιν ἑαῖς ἐνὶ χερσὶ βάλοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="141">ἀστὴρ ὥς, φλεγέθοντα διʼ ἠέρος ὁλκὸν ἵησιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="142">τήν τοι ἐγὼν ὀπάσω· σὺ δὲ παρθένον Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="143">θέλξον ὀιστεύσας ἐπʼ Ἰήσονι· μηδέ τις ἔστω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="144">ἀμβολίη. δὴ γάρ κεν ἀφαυροτέρη χάρις εἴη.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="129"><q rend="double">τίπτʼ ἐπιμειδιάᾳς, ἄφατον κακόν; ἦέ μιν αὔτως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="130"><q rend="double; merge">ἤπαφες, οὐδὲ δίκῃ περιέπλεο νῆιν ἐόντα;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="131"><q rend="double; merge">εἰ δʼ ἄγε μοι πρόφρων τέλεσον χρέος, ὅττι κεν εἴπω·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="132"><q rend="double; merge">καί κέν τοι ὀπάσαιμι Διὸς περικαλλὲς ἄθυρμα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="133"><q rend="double; merge">κεῖνο, τό οἱ ποίησε φίλη τροφὸς Ἀδρήστεια</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="134"><q rend="double; merge">ἄντρῳ ἐν Ἰδαίῳ ἔτι νήπια κουρίζοντι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="135"><q rend="double; merge">σφαῖραν ἐυτρόχαλον, τῆς οὐ σύγε μείλιον ἄλλο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="136"><q rend="double; merge">χειρῶν Ἡφαίστοιο κατακτεατίσσῃ ἄρειον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="137"><q rend="double; merge">χρύσεα μέν οἱ κύκλα τετεύχαται· ἀμφὶ δʼ ἑκάστῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="138"><q rend="double; merge">διπλόαι ἁψῖδες περιηγέες εἱλίσσονται·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="139"><q rend="double; merge">κρυπταὶ δὲ ῥαφαί εἰσιν· ἕλιξ δʼ ἐπιδέδρομε πάσαις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="140"><q rend="double; merge">κυανέη. ἀτὰρ εἴ μιν ἑαῖς ἐνὶ χερσὶ βάλοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="141"><q rend="double; merge">ἀστὴρ ὥς, φλεγέθοντα διʼ ἠέρος ὁλκὸν ἵησιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="142"><q rend="double; merge">τήν τοι ἐγὼν ὀπάσω· σὺ δὲ παρθένον Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="143"><q rend="double; merge">θέλξον ὀιστεύσας ἐπʼ Ἰήσονι· μηδέ τις ἔστω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="144"><q rend="double; merge">ἀμβολίη. δὴ γάρ κεν ἀφαυροτέρη χάρις εἴη.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="145">ὧς φάτο· τῷ δʼ ἀσπαστὸν ἔπος γένετʼ
 						εἰσαΐοντι.</l>
@@ -3230,9 +3230,9 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="149">ἀντομένη μύθοισιν, ἐπειρύσσασα παρειάς,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="150">κύσσε ποτισχομένη, καὶ ἀμείβετο μειδιόωσα·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="151">‘ἴστω νῦν τόδε σεῖο φίλον κάρη ἠδʼ ἐμὸν αὐτῆς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="152">ἦ μέν τοι δῶρόν γε παρέξομαι, οὐδʼ ἀπατήσω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="153">εἴ κεν ἐνισκίμψῃς κούρῃ βέλος Αἰήταο.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="151"><q rend="double">ἴστω νῦν τόδε σεῖο φίλον κάρη ἠδʼ ἐμὸν αὐτῆς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="152"><q rend="double; merge">ἦ μέν τοι δῶρόν γε παρέξομαι, οὐδʼ ἀπατήσω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="153"><q rend="double; merge">εἴ κεν ἐνισκίμψῃς κούρῃ βέλος Αἰήταο.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="154">φῆ· ὁ δʼ ἄρʼ ἀστραγάλους συναμήσατο, κὰδ δὲ
 						φαεινῷ</l>
@@ -3254,29 +3254,29 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="168">ἐν ποταμῷ καθʼ ἕλος λελοχημένοι ἠγορόωντο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="169">αὐτὸς δʼ Αἰσονίδης μετεφώνεεν· οἱ δʼ ὑπάκουον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="170">ἠρέμας ᾗ ἐνὶ χώρῃ ἐπισχερὼ ἑδριόωντες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="171">‘ὦ φίλοι, ἤτοι ἐγὼ μὲν ὅ μοι ἐπιανδάνει αὐτῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="172">ἐξερέω· τοῦ δʼ ὔμμι τέλος κρηῆναι ἔοικεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="173">ξυνὴ γὰρ χρειώ, ξυνοὶ δέ τε μῦθοι ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="174">πᾶσιν ὁμῶς· ὁ δὲ σῖγα νόον βουλήν τʼ ἀπερύκων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="175">ἴστω καὶ νόστου τόνδε στόλον οἶος ἀπούρας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="176">ὧλλοι μὲν κατὰ νῆα σὺν ἔντεσι μίμνεθʼ ἕκηλοι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="177">αὐτὰρ ἐγὼν ἐς δώματʼ ἐλεύσομαι Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="178">υἷας ἑλὼν Φρίξοιο δύω δʼ ἐπὶ τοῖσιν ἑταίρους.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="179">πειρήσω δʼ ἐπέεσσι παροίτερον ἀντιβολήσας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="180">εἴ κʼ ἐθέλοι φιλότητι δέρος χρύσειον ὀπάσσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="181">ἦε καὶ οὔ, πίσυνος δὲ βίῃ μετιόντας ἀτίσσει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="182">ὧδε γὰρ ἐξ αὐτοῖο πάρος κακότητα δαέντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="183">φρασσόμεθʼ, εἴτʼ ἄρηι συνοισόμεθʼ εἴτε τις ἄλλη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="184">μῆτις ἐπίρροθος ἔσται ἐεργομένοισιν ἀυτῆς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="185">μηδʼ αὔτως ἀλκῇ, πρὶν ἔπεσσί γε πειρηθῆναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="186">τόνδʼ ἀπαμείρωμεν σφέτερον κτέρας. ἀλλὰ πάροιθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="187">λωίτερον μύθῳ μιν ἀρέσσασθαι μετιόντας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="188">πολλάκι τοι ῥέα μῦθος, ὅ κεν μόλις ἐξανύσειεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="189">ἠνορέη, τόδʼ ἔρεξε κατὰ χρέος, ᾗπερ ἐῴκει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="190">πρηΰνας. ὁ δὲ καί ποτʼ ἀμύμονα Φρίξον ἔδεκτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="191">μητρυιῆς φεύγοντα δόλον πατρός τε θυηλάς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="192">πάντες ἐπεὶ πάντῃ καὶ ὅτις μάλα κύντατος ἀνδρῶν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="193">ξεινίου αἰδεῖται Ζηνὸς θέμιν ἠδʼ ἀλεγίζει.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="171"><q rend="double">ὦ φίλοι, ἤτοι ἐγὼ μὲν ὅ μοι ἐπιανδάνει αὐτῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="172"><q rend="double; merge">ἐξερέω· τοῦ δʼ ὔμμι τέλος κρηῆναι ἔοικεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="173"><q rend="double; merge">ξυνὴ γὰρ χρειώ, ξυνοὶ δέ τε μῦθοι ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="174"><q rend="double; merge">πᾶσιν ὁμῶς· ὁ δὲ σῖγα νόον βουλήν τʼ ἀπερύκων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="175"><q rend="double; merge">ἴστω καὶ νόστου τόνδε στόλον οἶος ἀπούρας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="176"><q rend="double; merge">ὧλλοι μὲν κατὰ νῆα σὺν ἔντεσι μίμνεθʼ ἕκηλοι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="177"><q rend="double; merge">αὐτὰρ ἐγὼν ἐς δώματʼ ἐλεύσομαι Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="178"><q rend="double; merge">υἷας ἑλὼν Φρίξοιο δύω δʼ ἐπὶ τοῖσιν ἑταίρους.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="179"><q rend="double; merge">πειρήσω δʼ ἐπέεσσι παροίτερον ἀντιβολήσας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="180"><q rend="double; merge">εἴ κʼ ἐθέλοι φιλότητι δέρος χρύσειον ὀπάσσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="181"><q rend="double; merge">ἦε καὶ οὔ, πίσυνος δὲ βίῃ μετιόντας ἀτίσσει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="182"><q rend="double; merge">ὧδε γὰρ ἐξ αὐτοῖο πάρος κακότητα δαέντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="183"><q rend="double; merge">φρασσόμεθʼ, εἴτʼ ἄρηι συνοισόμεθʼ εἴτε τις ἄλλη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="184"><q rend="double; merge">μῆτις ἐπίρροθος ἔσται ἐεργομένοισιν ἀυτῆς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="185"><q rend="double; merge">μηδʼ αὔτως ἀλκῇ, πρὶν ἔπεσσί γε πειρηθῆναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="186"><q rend="double; merge">τόνδʼ ἀπαμείρωμεν σφέτερον κτέρας. ἀλλὰ πάροιθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="187"><q rend="double; merge">λωίτερον μύθῳ μιν ἀρέσσασθαι μετιόντας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="188"><q rend="double; merge">πολλάκι τοι ῥέα μῦθος, ὅ κεν μόλις ἐξανύσειεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="189"><q rend="double; merge">ἠνορέη, τόδʼ ἔρεξε κατὰ χρέος, ᾗπερ ἐῴκει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="190"><q rend="double; merge">πρηΰνας. ὁ δὲ καί ποτʼ ἀμύμονα Φρίξον ἔδεκτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="191"><q rend="double; merge">μητρυιῆς φεύγοντα δόλον πατρός τε θυηλάς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="192"><q rend="double; merge">πάντες ἐπεὶ πάντῃ καὶ ὅτις μάλα κύντατος ἀνδρῶν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="193"><q rend="double; merge">ξεινίου αἰδεῖται Ζηνὸς θέμιν ἠδʼ ἀλεγίζει.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="194">ὧς φάτʼ· ἐπῄνησαν δὲ νέοι ἔπος Αἰσονίδαο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="195">πασσυδίῃ, οὐδʼ ἔσκε παρὲξ ὅτις ἄλλο κελεύοι.</l>
@@ -3347,15 +3347,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="259">γηθόσυνοι· τοῖον δὲ κινυρομένη φάτο μῦθον· </l>
                               <milestone n="260" unit="card"/>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="260">‘ἔμπης οὐκ ἄρʼ ἐμέλλετʼ ἀκηδείῃ με
-						λιπόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="261">τηλόθι πλάγξασθαι· μετὰ δʼ ὑμέας ἔτραπεν αἶσα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="262">δειλὴ ἐγώ, οἷον πόθον Ἑλλάδος ἔκποθεν ἄτης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="263">λευγαλέης Φρίξοιο ἐφημοσύνῃσιν ἕλεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="264">πατρός. ὁ μὲν θνῄσκων στυγερὰς ἐπετείλατʼ ἀνίας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="265">ἡμετέρῃ κραδίῃ. τί δέ κεν πόλιν Ὀρχομενοῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="266">ὅστις ὅδʼ Ὀρχομενός, κτεάνων Ἀθάμαντος ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="267">μητέρʼ ἑὴν ἀχέουσαν ἀποπρολιπόντες, ἵκοισθε;’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="260"><q rend="double">ἔμπης οὐκ ἄρʼ ἐμέλλετʼ ἀκηδείῃ με
+						λιπόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="261"><q rend="double; merge">τηλόθι πλάγξασθαι· μετὰ δʼ ὑμέας ἔτραπεν αἶσα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="262"><q rend="double; merge">δειλὴ ἐγώ, οἷον πόθον Ἑλλάδος ἔκποθεν ἄτης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="263"><q rend="double; merge">λευγαλέης Φρίξοιο ἐφημοσύνῃσιν ἕλεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="264"><q rend="double; merge">πατρός. ὁ μὲν θνῄσκων στυγερὰς ἐπετείλατʼ ἀνίας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="265"><q rend="double; merge">ἡμετέρῃ κραδίῃ. τί δέ κεν πόλιν Ὀρχομενοῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="266"><q rend="double; merge">ὅστις ὅδʼ Ὀρχομενός, κτεάνων Ἀθάμαντος ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="267"><q rend="double; merge">μητέρʼ ἑὴν ἀχέουσαν ἀποπρολιπόντες, ἵκοισθε;</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="268">ὧς ἔφατʼ· Αἰήτης δὲ πανύστατος ὦρτο θύραζε,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="269">ἐκ δʼ αὐτὴ Εἰδυῖα δάμαρ κίεν Αἰήταο,</l>
@@ -3397,74 +3397,74 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="302">ἐκ δὲ τοῦ Αἰήτης σφετέρης ἐρέεινε θυγατρὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="303">υἱῆας τοίοισι παρηγορέων ἐπέεσσιν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="304">‘παιδὸς ἐμῆς κοῦροι Φρίξοιό τε, τὸν περὶ
-						πάντων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="305">ξείνων ἡμετέροισιν ἐνὶ μεγάροισιν ἔτισα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="306">πῶς Αἶάνδε νέεσθε παλίσσυτοι; ἦέ τις ἄτη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="307">σωομένοις μεσσηγὺς ἐνέκλασεν; οὐ μὲν ἐμεῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="308">πείθεσθε προφέροντος ἀπείρονα μέτρα κελεύθου.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="309">ᾔδειν γάρ ποτε πατρὸς ἐν ἅρμασιν Ἠελίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="310">δινεύσας, ὅτʼ ἐμεῖο κασιγνήτην ἐκόμιζεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="311">Κίρκην ἑσπερίης εἴσω χθονός, ἐκ δʼ ἱκόμεσθα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="312">ἀκτὴν ἠπείρου Τυρσηνίδος, ἔνθʼ ἔτι νῦν περ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="313">ναιετάει, μάλα πολλὸν ἀπόπροθι Κολχίδος αἴης.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="314">ἀλλὰ τί μύθων ἦδος; ἃ δʼ ἐν ποσὶν ὗμιν ὄρωρεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="315">εἴπατʼ ἀριφραδέως, ἠδʼ οἵτινες οἵδʼ ἐφέπονται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="316">ἀνέρες, ὅππῃ τε γλαφυρῆς ἐκ νηὸς ἔβητε.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="304"><q rend="double">παιδὸς ἐμῆς κοῦροι Φρίξοιό τε, τὸν περὶ
+						πάντων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="305"><q rend="double; merge">ξείνων ἡμετέροισιν ἐνὶ μεγάροισιν ἔτισα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="306"><q rend="double; merge">πῶς Αἶάνδε νέεσθε παλίσσυτοι; ἦέ τις ἄτη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="307"><q rend="double; merge">σωομένοις μεσσηγὺς ἐνέκλασεν; οὐ μὲν ἐμεῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="308"><q rend="double; merge">πείθεσθε προφέροντος ἀπείρονα μέτρα κελεύθου.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="309"><q rend="double; merge">ᾔδειν γάρ ποτε πατρὸς ἐν ἅρμασιν Ἠελίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="310"><q rend="double; merge">δινεύσας, ὅτʼ ἐμεῖο κασιγνήτην ἐκόμιζεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="311"><q rend="double; merge">Κίρκην ἑσπερίης εἴσω χθονός, ἐκ δʼ ἱκόμεσθα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="312"><q rend="double; merge">ἀκτὴν ἠπείρου Τυρσηνίδος, ἔνθʼ ἔτι νῦν περ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="313"><q rend="double; merge">ναιετάει, μάλα πολλὸν ἀπόπροθι Κολχίδος αἴης.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="314"><q rend="double; merge">ἀλλὰ τί μύθων ἦδος; ἃ δʼ ἐν ποσὶν ὗμιν ὄρωρεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="315"><q rend="double; merge">εἴπατʼ ἀριφραδέως, ἠδʼ οἵτινες οἵδʼ ἐφέπονται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="316"><q rend="double; merge">ἀνέρες, ὅππῃ τε γλαφυρῆς ἐκ νηὸς ἔβητε.</q></l>
 					          <milestone n="317" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="317">τοῖά μιν ἐξερέοντα κασιγνήτων προπάροιθεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="318">Ἄργος ὑποδδείσας ἀμφὶ στόλῳ Αἰσονίδαο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="319">μειλιχίως προσέειπεν, ἐπεὶ προγενέστερος ἦεν·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="320">‘Αἰήτη, κείνην μὲν ἄφαρ διέχευαν
-						ἄελλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="321">ζαχρηεῖς· αὐτοὺς δʼ ἐπὶ δούρασι πεπτηῶτας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="322">νήσου Ἐνυαλίοιο ποτὶ ξερὸν ἔκβαλε κῦμα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="323">λυγαίῃ ὑπὸ νυκτί· θεὸς δέ τις ἄμμʼ ἐσάωσεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="324">οὐδὲ γὰρ αἳ τὸ πάροιθεν ἐρημαίην κατὰ νῆσον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="325">ηὐλίζοντʼ ὄρνιθες Ἀρήιαι, οὐδʼ ἔτι κείνας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="326">εὕρομεν. ἀλλʼ οἵγʼ ἄνδρες ἀπήλασαν, ἐξαποβάντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="327">νηὸς ἑῆς προτέρῳ ἐνὶ ἤματι· καί σφʼ ἀπέρυκεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="328">ἡμέας οἰκτείρων Ζηνὸς νόος, ἠέ τις αἶσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="329">αὐτίκʼ ἐπεὶ καὶ βρῶσιν ἅλις καὶ εἵματʼ ἔδωκαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="330">οὔνομά τε Φρίξοιο περικλεὲς εἰσαΐοντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="331">ἠδʼ αὐτοῖο σέθεν· μετὰ γὰρ τεὸν ἄστυ νέονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="332">χρειὼ δʼ ἢν ἐθέλῃς ἐξίδμεναι, οὔ σʼ ἐπικεύσω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="333">τόνδε τις ἱέμενος πάτρης ἀπάνευθεν ἐλάσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="334">καὶ κτεάνων βασιλεὺς περιώσιον, οὕνεκεν ἀλκῇ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="335">σφωιτέρῃ τάντεσσι μετέπρεπεν Αἰολίδῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="336">πέμπει δεῦρο νέεσθαι ἀμήχανον· οὐδʼ ὑπαλύξειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="337">στεῦται ἀμειλίκτοιο Διὸς θυμαλγέα μῆνιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="338">καὶ χόλον, οὐδʼ ἄτλητον ἄγος Φρίξοιό τε ποινὰς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="339">Αἰολιδέων γενεήν, πρὶν ἐς Ἑλλάδα κῶας ἱκέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="340">νῆα δʼ Ἀθηναίη Παλλὰς κάμεν, οὐ μάλα τοίην,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="341">οἷαί περ Κόλχοισι μετʼ ἀνδράσι νῆες ἔασιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="342">τάων αἰνοτάτης ἐπεκύρσαμεν. ἤλιθα γάρ μιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="343">λάβρον ὕδωρ πνοιή τε διέτμαγεν· ἡ δʼ ἐνὶ γόμφοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="344">ἴσχεται, ἢν καὶ πᾶσαι ἐπιβρίσωσιν ἄελλαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="345">ἶσον δʼ ἐξ ἀνέμοιο θέει καὶ ὅτʼ ἀνέρες αὐτοὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="346">νωλεμέως χείρεσσιν ἐπισπέρχωσιν ἐρετμοῖς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="347">τῇ δʼ ἐναγειράμενος Παναχαιίδος εἴ τι φέριστον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="348">ἡρώων, τεὸν ἄστυ μετήλυθε, πόλλʼ ἐπαληθεὶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="349">ἄστεα καὶ πελάγη στυγερῆς ἁλός, εἴ οἱ ὀπάσσαις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="350">αὐτῷ δʼ ὥς κεν ἅδῃ, τὼς ἔσσεται· οὐ γὰρ ἱκάνει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="351">χερσὶ βιησόμενος· μέμονεν δέ τοι ἄξια τίσειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="352">δωτίνης, ἀίων ἐμέθεν μέγα δυσμενέοντας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="353">Σαυρομάτας, τοὺς σοῖσιν ὑπὸ σκήπτροισι δαμάσσει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="354">εἰ δὲ καὶ οὔνομα δῆθεν ἐπιθύεις γενεήν τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="355">ἴδμεναι, οἵτινές εἰσιν, ἕκαστά γε μυθησαίμην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="356">τόνδε μέν, οἷό περ οὕνεκʼ ἀφʼ Ἑλλάδος ὧλλοι ἄγερθεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="357">κλείουσʼ Αἴσονος υἱὸν Ἰήσονα Κρηθεΐδαο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="358">εἰ δʼ αὐτοῦ Κρηθῆος ἐτήτυμόν ἐστι γενέθλης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="359">οὕτω κεν γνωτὸς πατρώιος ἄμμι πέλοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="360">ἄμφω γὰρ Κρηθεὺς Ἀθάμας τʼ ἔσαν Αἰόλου υἷες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="361">Φρίξος δʼ αὖτʼ Ἀθάμαντος ἔην πάις Αἰολίδαο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="362">τόνδε δʼ ἄρʼ, Ἠελίου γόνον ἔμμεναι εἴ τινʼ ἀκούεις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="363">δέρκεαι Αὐγείην· Τελαμὼν δʼ ὅγε, κυδίστοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="364">Αἰακοῦ ἐκγεγαώς· Ζεὺς δʼ Αἰακὸν αὐτὸς ἔτικτεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="365">ὧς δὲ καὶ ὧλλοι πάντες, ὅσοι συνέπονται ἑταῖροι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="366">ἀθανάτων υἷές τε καὶ υἱωνοὶ γεγάασιν.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="320"><q rend="double">Αἰήτη, κείνην μὲν ἄφαρ διέχευαν
+						ἄελλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="321"><q rend="double; merge">ζαχρηεῖς· αὐτοὺς δʼ ἐπὶ δούρασι πεπτηῶτας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="322"><q rend="double; merge">νήσου Ἐνυαλίοιο ποτὶ ξερὸν ἔκβαλε κῦμα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="323"><q rend="double; merge">λυγαίῃ ὑπὸ νυκτί· θεὸς δέ τις ἄμμʼ ἐσάωσεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="324"><q rend="double; merge">οὐδὲ γὰρ αἳ τὸ πάροιθεν ἐρημαίην κατὰ νῆσον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="325"><q rend="double; merge">ηὐλίζοντʼ ὄρνιθες Ἀρήιαι, οὐδʼ ἔτι κείνας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="326"><q rend="double; merge">εὕρομεν. ἀλλʼ οἵγʼ ἄνδρες ἀπήλασαν, ἐξαποβάντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="327"><q rend="double; merge">νηὸς ἑῆς προτέρῳ ἐνὶ ἤματι· καί σφʼ ἀπέρυκεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="328"><q rend="double; merge">ἡμέας οἰκτείρων Ζηνὸς νόος, ἠέ τις αἶσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="329"><q rend="double; merge">αὐτίκʼ ἐπεὶ καὶ βρῶσιν ἅλις καὶ εἵματʼ ἔδωκαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="330"><q rend="double; merge">οὔνομά τε Φρίξοιο περικλεὲς εἰσαΐοντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="331"><q rend="double; merge">ἠδʼ αὐτοῖο σέθεν· μετὰ γὰρ τεὸν ἄστυ νέονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="332"><q rend="double; merge">χρειὼ δʼ ἢν ἐθέλῃς ἐξίδμεναι, οὔ σʼ ἐπικεύσω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="333"><q rend="double; merge">τόνδε τις ἱέμενος πάτρης ἀπάνευθεν ἐλάσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="334"><q rend="double; merge">καὶ κτεάνων βασιλεὺς περιώσιον, οὕνεκεν ἀλκῇ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="335"><q rend="double; merge">σφωιτέρῃ τάντεσσι μετέπρεπεν Αἰολίδῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="336"><q rend="double; merge">πέμπει δεῦρο νέεσθαι ἀμήχανον· οὐδʼ ὑπαλύξειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="337"><q rend="double; merge">στεῦται ἀμειλίκτοιο Διὸς θυμαλγέα μῆνιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="338"><q rend="double; merge">καὶ χόλον, οὐδʼ ἄτλητον ἄγος Φρίξοιό τε ποινὰς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="339"><q rend="double; merge">Αἰολιδέων γενεήν, πρὶν ἐς Ἑλλάδα κῶας ἱκέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="340"><q rend="double; merge">νῆα δʼ Ἀθηναίη Παλλὰς κάμεν, οὐ μάλα τοίην,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="341"><q rend="double; merge">οἷαί περ Κόλχοισι μετʼ ἀνδράσι νῆες ἔασιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="342"><q rend="double; merge">τάων αἰνοτάτης ἐπεκύρσαμεν. ἤλιθα γάρ μιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="343"><q rend="double; merge">λάβρον ὕδωρ πνοιή τε διέτμαγεν· ἡ δʼ ἐνὶ γόμφοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="344"><q rend="double; merge">ἴσχεται, ἢν καὶ πᾶσαι ἐπιβρίσωσιν ἄελλαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="345"><q rend="double; merge">ἶσον δʼ ἐξ ἀνέμοιο θέει καὶ ὅτʼ ἀνέρες αὐτοὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="346"><q rend="double; merge">νωλεμέως χείρεσσιν ἐπισπέρχωσιν ἐρετμοῖς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="347"><q rend="double; merge">τῇ δʼ ἐναγειράμενος Παναχαιίδος εἴ τι φέριστον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="348"><q rend="double; merge">ἡρώων, τεὸν ἄστυ μετήλυθε, πόλλʼ ἐπαληθεὶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="349"><q rend="double; merge">ἄστεα καὶ πελάγη στυγερῆς ἁλός, εἴ οἱ ὀπάσσαις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="350"><q rend="double; merge">αὐτῷ δʼ ὥς κεν ἅδῃ, τὼς ἔσσεται· οὐ γὰρ ἱκάνει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="351"><q rend="double; merge">χερσὶ βιησόμενος· μέμονεν δέ τοι ἄξια τίσειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="352"><q rend="double; merge">δωτίνης, ἀίων ἐμέθεν μέγα δυσμενέοντας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="353"><q rend="double; merge">Σαυρομάτας, τοὺς σοῖσιν ὑπὸ σκήπτροισι δαμάσσει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="354"><q rend="double; merge">εἰ δὲ καὶ οὔνομα δῆθεν ἐπιθύεις γενεήν τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="355"><q rend="double; merge">ἴδμεναι, οἵτινές εἰσιν, ἕκαστά γε μυθησαίμην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="356"><q rend="double; merge">τόνδε μέν, οἷό περ οὕνεκʼ ἀφʼ Ἑλλάδος ὧλλοι ἄγερθεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="357"><q rend="double; merge">κλείουσʼ Αἴσονος υἱὸν Ἰήσονα Κρηθεΐδαο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="358"><q rend="double; merge">εἰ δʼ αὐτοῦ Κρηθῆος ἐτήτυμόν ἐστι γενέθλης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="359"><q rend="double; merge">οὕτω κεν γνωτὸς πατρώιος ἄμμι πέλοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="360"><q rend="double; merge">ἄμφω γὰρ Κρηθεὺς Ἀθάμας τʼ ἔσαν Αἰόλου υἷες·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="361"><q rend="double; merge">Φρίξος δʼ αὖτʼ Ἀθάμαντος ἔην πάις Αἰολίδαο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="362"><q rend="double; merge">τόνδε δʼ ἄρʼ, Ἠελίου γόνον ἔμμεναι εἴ τινʼ ἀκούεις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="363"><q rend="double; merge">δέρκεαι Αὐγείην· Τελαμὼν δʼ ὅγε, κυδίστοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="364"><q rend="double; merge">Αἰακοῦ ἐκγεγαώς· Ζεὺς δʼ Αἰακὸν αὐτὸς ἔτικτεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="365"><q rend="double; merge">ὧς δὲ καὶ ὧλλοι πάντες, ὅσοι συνέπονται ἑταῖροι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="366"><q rend="double; merge">ἀθανάτων υἷές τε καὶ υἱωνοὶ γεγάασιν.</q></l>
 					          <milestone n="367" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="367">τοῖα παρέννεπεν Ἄργος· ἄναξ δʼ ἐπεχώσατο
@@ -3474,32 +3474,32 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="370">Χαλκιόπης· τῶν γάρ σφε μετελθέμεν οὕνεκʼ ἐώλπει·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="371">ἐκ δέ οἱ ὄμματʼ ἔλαμψεν ὑπʼ ὀφρύσιν ἱεμένοιο·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="372">‘οὐκ ἄφαρ ὀφθαλμῶν μοι ἀπόπροθι, λωβητῆρες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="373">νεῖσθʼ αὐτοῖσι δόλοισι παλίσσυτοι ἔκτοθι γαίης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="374">πρίν τινα λευγαλέον τε δέρος καὶ Φρίξον ἰδέσθαι;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="375">αὐτίχʼ ὁμαρτήσαντες ἀφʼ Ἑλλάδος, οὐκ ἐπὶ κῶας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="376">σκῆπτρα δὲ καὶ τιμὴν βασιληίδα δεῦρο νέεσθε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="377">εἰ δέ κε μὴ προπάροιθεν ἐμῆς ἥψασθε τραπέζης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="378">ἦ τʼ ἂν ἀπὸ γλώσσας τε ταμὼν καὶ χεῖρε κεάσσας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="379">ἀμφοτέρας, οἴοισιν ἐπιπροέηκα πόδεσσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="380">ὥς κεν ἐρητύοισθε καὶ ὕστερον ὁρμηθῆναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="381">οἷα δὲ καὶ μακάρεσσιν ἐπεψεύσασθε θεοῖσιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="372"><q rend="double">οὐκ ἄφαρ ὀφθαλμῶν μοι ἀπόπροθι, λωβητῆρες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="373"><q rend="double; merge">νεῖσθʼ αὐτοῖσι δόλοισι παλίσσυτοι ἔκτοθι γαίης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="374"><q rend="double; merge">πρίν τινα λευγαλέον τε δέρος καὶ Φρίξον ἰδέσθαι;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="375"><q rend="double; merge">αὐτίχʼ ὁμαρτήσαντες ἀφʼ Ἑλλάδος, οὐκ ἐπὶ κῶας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="376"><q rend="double; merge">σκῆπτρα δὲ καὶ τιμὴν βασιληίδα δεῦρο νέεσθε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="377"><q rend="double; merge">εἰ δέ κε μὴ προπάροιθεν ἐμῆς ἥψασθε τραπέζης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="378"><q rend="double; merge">ἦ τʼ ἂν ἀπὸ γλώσσας τε ταμὼν καὶ χεῖρε κεάσσας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="379"><q rend="double; merge">ἀμφοτέρας, οἴοισιν ἐπιπροέηκα πόδεσσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="380"><q rend="double; merge">ὥς κεν ἐρητύοισθε καὶ ὕστερον ὁρμηθῆναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="381"><q rend="double; merge">οἷα δὲ καὶ μακάρεσσιν ἐπεψεύσασθε θεοῖσιν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="382">φῆ ῥα χαλεψάμενος· μέγα δὲ φρένες Αἰακίδαο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="383">νειόθεν οἰδαίνεσκον· ἐέλδετο δʼ ἔνδοθι θυμὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="384">ἀντιβίην ὀλοὸν φάσθαι ἔπος· ἀλλʼ ἀπέρυκεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="385">Αἰσονίδης· πρὸ γὰρ αὐτὸς ἀμείψατο μειλιχίοισιν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="386">‘Αἰήτη, σχέο μοι τῷδε στόλῳ. οὔτι γὰρ αὔτως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="387">ἄστυ τεὸν καὶ δώμαθʼ ἱκάνομεν, ὥς που ἔολπας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="388">οὐδὲ μὲν ἱέμενοι. τίς δʼ ἂν τόσον οἶδμα περῆσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="389">τλαίη ἑκὼν ὀθνεῖον ἐπὶ κτέρας; ἀλλά με δαίμων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="390">καὶ κρυερὴ βασιλῆος ἀτασθάλου ὦρσεν ἐφετμή.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="391">δὸς χάριν ἀντομένοισι· σέθεν δʼ ἐγὼ Ἑλλάδι πάσῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="392">θεσπεσιην οἴσω κληηδόνα· καὶ δέ τοι ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="393">πρόφρονές εἰμεν ἄρηι θοὴν ἀποτῖσαι ἀμοιβήν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="394">εἴτʼ οὖν Σαυρομάτας γε λιλαίεαι, εἴτε τινʼ ἄλλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="395">δῆμον σφωιτέροισιν ὑπὸ σκήπτροισι δαμάσσαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="386"><q rend="double">Αἰήτη, σχέο μοι τῷδε στόλῳ. οὔτι γὰρ αὔτως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="387"><q rend="double; merge">ἄστυ τεὸν καὶ δώμαθʼ ἱκάνομεν, ὥς που ἔολπας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="388"><q rend="double; merge">οὐδὲ μὲν ἱέμενοι. τίς δʼ ἂν τόσον οἶδμα περῆσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="389"><q rend="double; merge">τλαίη ἑκὼν ὀθνεῖον ἐπὶ κτέρας; ἀλλά με δαίμων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="390"><q rend="double; merge">καὶ κρυερὴ βασιλῆος ἀτασθάλου ὦρσεν ἐφετμή.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="391"><q rend="double; merge">δὸς χάριν ἀντομένοισι· σέθεν δʼ ἐγὼ Ἑλλάδι πάσῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="392"><q rend="double; merge">θεσπεσιην οἴσω κληηδόνα· καὶ δέ τοι ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="393"><q rend="double; merge">πρόφρονές εἰμεν ἄρηι θοὴν ἀποτῖσαι ἀμοιβήν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="394"><q rend="double; merge">εἴτʼ οὖν Σαυρομάτας γε λιλαίεαι, εἴτε τινʼ ἄλλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="395"><q rend="double; merge">δῆμον σφωιτέροισιν ὑπὸ σκήπτροισι δαμάσσαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="396">Ἴσκεν ὑποσσαίνων ἀγανῇ ὀπί· τοῖο δὲ θυμὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="397">διχθαδίην πόρφυρεν ἐνὶ στήθεσσι μενοινήν,</l>
@@ -3507,27 +3507,27 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="399">ἦ ὅγε πειρήσαιτο βίης. τό οἱ εἴσατʼ ἄρειον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="400">φραζομένῳ· καὶ δή μιν ὑποβλήδην προσέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="401">‘ξεῖνε, τί κεν τὰ ἕκαστα διηνεκέως ἀγορεύοις;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="402">εἰ γὰρ ἐτήτυμόν ἐστε θεῶν γένος, ἠὲ καὶ ἄλλως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="403">οὐδὲν ἐμεῖο χέρηες ἐπʼ ὀθνείοισιν ἔβητε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="404">δώσω τοι χρύσειον ἄγειν δέρος, αἴ κʼ ἐθέλῃσθα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="405">πειρηθείς. ἐσθλοῖς γὰρ ἐπʼ ἀνδράσιν οὔτι μεγαίρω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="406">ὡς αὐτοὶ μυθεῖσθε τὸν Ἑλλάδι κοιρανέοντα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="407">πεῖρα δέ τοι μένεός τε καὶ ἀλκῆς ἔσσετʼ ἄεθλος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="408">τόν ῥʼ αὐτὸς περίειμι χεροῖν ὀλοόν περ ἐόντα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="409">δοιώ μοι πεδίον τὸ Ἀρήιον ἀμφινέμονται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="410">ταύρω χαλκόποδε, στόματι φλόγα φυσιόωντες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="411">τοὺς ἐλάω ζεύξας στυφελὴν κατὰ νειὸν Ἄρηος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="412">τετράγυον, τὴν αἶψα ταμὼν ἐπὶ τέλσον ἀρότρῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="413">οὐ σπόρον ὁλκοῖσιν Δηοῦς ἐνιβᾴλλομαι ἀκτήν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="414">ἀλλʼ ὄφιος δεινοῖο μεταλδήσκοντας ὀδόντας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="415">ἀνδράσι τευχηστῇσι δέμας. τοὺς δʼ αὖθι δαΐζων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="416">κείρω ἐμῷ ὑπὸ δουρὶ περισταδὸν ἀντιόωντας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="417">ἠέριος ζεύγνυμι βόας, καὶ δείελον ὥρην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="418">παύομαι ἀμήτοιο. σύ δʼ, εἰ τάδε τοῖα τελέσσεις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="419">αὐτῆμαρ τόδε κῶας ἀποίσεαι εἰς βασιλῆος·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="420">πρὶν δέ κεν οὐ δοίην, μηδʼ ἔλπεο. δὴ γὰρ ἀεικὲς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="421">ἄνδρʼ ἀγαθὸν γεγαῶτα κακωτέρῳ ἀνέρι εἶξαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="401"><q rend="double">ξεῖνε, τί κεν τὰ ἕκαστα διηνεκέως ἀγορεύοις;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="402"><q rend="double; merge">εἰ γὰρ ἐτήτυμόν ἐστε θεῶν γένος, ἠὲ καὶ ἄλλως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="403"><q rend="double; merge">οὐδὲν ἐμεῖο χέρηες ἐπʼ ὀθνείοισιν ἔβητε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="404"><q rend="double; merge">δώσω τοι χρύσειον ἄγειν δέρος, αἴ κʼ ἐθέλῃσθα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="405"><q rend="double; merge">πειρηθείς. ἐσθλοῖς γὰρ ἐπʼ ἀνδράσιν οὔτι μεγαίρω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="406"><q rend="double; merge">ὡς αὐτοὶ μυθεῖσθε τὸν Ἑλλάδι κοιρανέοντα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="407"><q rend="double; merge">πεῖρα δέ τοι μένεός τε καὶ ἀλκῆς ἔσσετʼ ἄεθλος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="408"><q rend="double; merge">τόν ῥʼ αὐτὸς περίειμι χεροῖν ὀλοόν περ ἐόντα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="409"><q rend="double; merge">δοιώ μοι πεδίον τὸ Ἀρήιον ἀμφινέμονται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="410"><q rend="double; merge">ταύρω χαλκόποδε, στόματι φλόγα φυσιόωντες·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="411"><q rend="double; merge">τοὺς ἐλάω ζεύξας στυφελὴν κατὰ νειὸν Ἄρηος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="412"><q rend="double; merge">τετράγυον, τὴν αἶψα ταμὼν ἐπὶ τέλσον ἀρότρῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="413"><q rend="double; merge">οὐ σπόρον ὁλκοῖσιν Δηοῦς ἐνιβᾴλλομαι ἀκτήν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="414"><q rend="double; merge">ἀλλʼ ὄφιος δεινοῖο μεταλδήσκοντας ὀδόντας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="415"><q rend="double; merge">ἀνδράσι τευχηστῇσι δέμας. τοὺς δʼ αὖθι δαΐζων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="416"><q rend="double; merge">κείρω ἐμῷ ὑπὸ δουρὶ περισταδὸν ἀντιόωντας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="417"><q rend="double; merge">ἠέριος ζεύγνυμι βόας, καὶ δείελον ὥρην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="418"><q rend="double; merge">παύομαι ἀμήτοιο. σύ δʼ, εἰ τάδε τοῖα τελέσσεις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="419"><q rend="double; merge">αὐτῆμαρ τόδε κῶας ἀποίσεαι εἰς βασιλῆος·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="420"><q rend="double; merge">πρὶν δέ κεν οὐ δοίην, μηδʼ ἔλπεο. δὴ γὰρ ἀεικὲς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="421"><q rend="double; merge">ἄνδρʼ ἀγαθὸν γεγαῶτα κακωτέρῳ ἀνέρι εἶξαι.</q></l>
 					          <milestone n="422" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="422">ὧς ἄρʼ ἔφη· ὁ δὲ σῖγα ποδῶν πάρος ὄμματα πήξας</l>
@@ -3536,19 +3536,19 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="425">θαρσαλέως ὑποδέχθαι, ἐπεὶ μέγα φαίνετο ἔργον·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="426">ὀψε δʼ ἀμειβόμενος προσελέξατο κερδαλέοισιν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="427">‘Αἰήτη, μάλα τοί με δίκῃ περιπολλὸν ἐέργεις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="428">τῶ καὶ ἐγὼ τὸν ἄεθλον ὑπερφίαλόν περ ἐόντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="429">τλήσομαι, εἰ καί μοι θανέειν μόρος. οὐ γὰρ ἔτʼ ἄλλο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="430">ῥίγιον ἀνθρώποισι κακῆς ἐπικείσετʼ ἀνάγκης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="431">ἥ με καὶ ἐνθάδε νεῖσθαι ἐπέχραεν ἐκ βασιλῆος.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="427"><q rend="double">Αἰήτη, μάλα τοί με δίκῃ περιπολλὸν ἐέργεις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="428"><q rend="double; merge">τῶ καὶ ἐγὼ τὸν ἄεθλον ὑπερφίαλόν περ ἐόντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="429"><q rend="double; merge">τλήσομαι, εἰ καί μοι θανέειν μόρος. οὐ γὰρ ἔτʼ ἄλλο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="430"><q rend="double; merge">ῥίγιον ἀνθρώποισι κακῆς ἐπικείσετʼ ἀνάγκης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="431"><q rend="double; merge">ἥ με καὶ ἐνθάδε νεῖσθαι ἐπέχραεν ἐκ βασιλῆος.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="432">ὧς φάτʼ ἀμηχανίῃ βεβολημένος· αὐτὰρ ὁ τόνγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="433">σμερδαλέοις ἐπέεσσι προσέννεπεν ἀσχαλόωντα·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="434">‘ἔρχεο νῦν μεθʼ ὅμιλον, ἐπεὶ μέμονάς γε πόνοιο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="435">εἰ δὲ σύγε ζυγὰ βουσὶν ὑποδδείσαις ἐπαεῖραι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="436">ἠὲ καὶ οὐλομένου μεταχάσσεαι ἀμήτοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="437">αὐτῷ κεν τὰ ἕκαστα μέλοιτό μοι, ὄφρα καὶ ἄλλος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="438">ἀνὴρ ἐρρίγῃσιν ἀρείονα φῶτα μετελθεῖν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="434"><q rend="double">ἔρχεο νῦν μεθʼ ὅμιλον, ἐπεὶ μέμονάς γε πόνοιο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="435"><q rend="double; merge">εἰ δὲ σύγε ζυγὰ βουσὶν ὑποδδείσαις ἐπαεῖραι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="436"><q rend="double; merge">ἠὲ καὶ οὐλομένου μεταχάσσεαι ἀμήτοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="437"><q rend="double; merge">αὐτῷ κεν τὰ ἕκαστα μέλοιτό μοι, ὄφρα καὶ ἄλλος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="438"><q rend="double; merge">ἀνὴρ ἐρρίγῃσιν ἀρείονα φῶτα μετελθεῖν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="439">Ἴσκεν ἀπηλεγέως· ὁ δʼ ἀπὸ θρόνου ὤρνυτʼ Ἰήσων,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="440">Αὐγείης Τελαμών τε παρασχεδόν· εἵπετο δʼ Ἄργος</l>
@@ -3576,14 +3576,14 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="462">δάκρυον αἰνοτάτῳ ἐλέῳ ῥέε κηδοσύνῃσιν·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="463">ἦκα δὲ μυρομένη λιγέως ἀνενείκατο μῦθον·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="464">‘τίπτε με δειλαίην τόδʼ ἔχει ἄχος; εἴθʼ ὅγε
-						πάντων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="465">φθίσεται ἡρώων προφερέστατος, εἴτε χερείων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="466">ἐρρέτω. ἦ μὲν ὄφελλεν ἀκήριος ἐξαλέασθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="467">ναὶ δὴ τοῦτό γε, πότνα θεὰ Περσηί, πέλοιτο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="468">οἴκαδε νοστήσειε φυγὼν μόρον· εἰ δέ μιν αἶσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="469">δμηθῆναι ὑπὸ βουσί, τόδε προπάροιθε δαείη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="470">οὕνεκεν οὔ οἱ ἔγωγε κακῇ ἐπαγαίομαι ἄτῃ.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="464"><q rend="double">τίπτε με δειλαίην τόδʼ ἔχει ἄχος; εἴθʼ ὅγε
+						πάντων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="465"><q rend="double; merge">φθίσεται ἡρώων προφερέστατος, εἴτε χερείων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="466"><q rend="double; merge">ἐρρέτω. ἦ μὲν ὄφελλεν ἀκήριος ἐξαλέασθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="467"><q rend="double; merge">ναὶ δὴ τοῦτό γε, πότνα θεὰ Περσηί, πέλοιτο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="468"><q rend="double; merge">οἴκαδε νοστήσειε φυγὼν μόρον· εἰ δέ μιν αἶσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="469"><q rend="double; merge">δμηθῆναι ὑπὸ βουσί, τόδε προπάροιθε δαείη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="470"><q rend="double; merge">οὕνεκεν οὔ οἱ ἔγωγε κακῇ ἐπαγαίομαι ἄτῃ.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="471">ἡ μὲν ἄρʼ ὧς ἐόλητο νόον μελεδήμασι κούρη.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="472">οἱ δʼ ἐπεὶ οὖν δήμου τε καὶ ἄστεος ἐκτὸς ἔβησαν</l>
@@ -3591,52 +3591,52 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="474">δὴ τότʼ Ἰήσονα τοῖσδε προσέννεπεν Ἄργος ἔπεσσιν·</l>
 					          <milestone n="475" unit="card"/>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="475">‘Αἰσονίδη, μῆτιν μὲν ὀνόσσεαι, ἥντινʼ
-						ἐνίψω·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="476">πείρης δʼ οὐ μάλʼ ἔοικε μεθιέμεν ἐν κακότητι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="477">κούρην δή τινα πρόσθεν ὑπέκλυες αὐτὸς ἐμεῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="478">φαρμάσσειν Ἑκάτης Περσηίδος ἐννεσίῃσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="479">τὴν εἴ κεν πεπίθοιμεν, ὀίομαι, οὐκέτι τάρβος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="480">ἔσσετʼ ἀεθλεύοντι δαμήμεναι· ἀλλὰ μάλʼ αἰνῶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="481">δείδω, μή πως οὔ μοι ὑποσταίη τόγε μήτηρ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="482">ἔμπης δʼ ἐξαῦτις μετελεύσομαι ἀντιβολήσων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="483">ξυνὸς ἐπεὶ πάντεσσιν ἐπικρέμαθʼ ἧμιν ὄλεθρος.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="475"><q rend="double">Αἰσονίδη, μῆτιν μὲν ὀνόσσεαι, ἥντινʼ
+						ἐνίψω·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="476"><q rend="double; merge">πείρης δʼ οὐ μάλʼ ἔοικε μεθιέμεν ἐν κακότητι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="477"><q rend="double; merge">κούρην δή τινα πρόσθεν ὑπέκλυες αὐτὸς ἐμεῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="478"><q rend="double; merge">φαρμάσσειν Ἑκάτης Περσηίδος ἐννεσίῃσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="479"><q rend="double; merge">τὴν εἴ κεν πεπίθοιμεν, ὀίομαι, οὐκέτι τάρβος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="480"><q rend="double; merge">ἔσσετʼ ἀεθλεύοντι δαμήμεναι· ἀλλὰ μάλʼ αἰνῶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="481"><q rend="double; merge">δείδω, μή πως οὔ μοι ὑποσταίη τόγε μήτηρ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="482"><q rend="double; merge">ἔμπης δʼ ἐξαῦτις μετελεύσομαι ἀντιβολήσων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="483"><q rend="double; merge">ξυνὸς ἐπεὶ πάντεσσιν ἐπικρέμαθʼ ἧμιν ὄλεθρος.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="484">Ἴσκεν ἐυφρονέων· ὁ δʼ ἀμείβετο τοῖσδʼ
 						ἐπέεσσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="485">‘ὦ πέπον, εἴ νύ τοι αὐτῷ ἐφανδάνει, οὔτι μεγαίρω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="486">βάσκʼ ἴθι καὶ πυκινοῖσι τεὴν παρὰ μητέρα μύθοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="487">ὄρνυθι λισσόμενος· μελέη γε μὲν ἧμιν ὄρωρεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="488">ἐλπωρή, ὅτε νόστον ἐπετραπόμεσθα γυναιξίν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="485"><q rend="double">ὦ πέπον, εἴ νύ τοι αὐτῷ ἐφανδάνει, οὔτι μεγαίρω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="486"><q rend="double; merge">βάσκʼ ἴθι καὶ πυκινοῖσι τεὴν παρὰ μητέρα μύθοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="487"><q rend="double; merge">ὄρνυθι λισσόμενος· μελέη γε μὲν ἧμιν ὄρωρεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="488"><q rend="double; merge">ἐλπωρή, ὅτε νόστον ἐπετραπόμεσθα γυναιξίν.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="489">ὧς ἔφατʼ· ὦκα δʼ ἕλος μετεκίαθον. αὐτὰρ ἑταῖροι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="490">γηθόσυνοι ἐρέεινον, ὅπως παρεόντας ἴδοντο·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="491">τοῖσιν δʼ Αἰσονίδης τετιημένος ἔκφατο μῦθον·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="492">‘ὦ φίλοι, Αἰήταο ἀπηνέος ἄμμι φίλον κῆρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="493">ἀντικρὺ κεχόλωται, ἕκαστα γὰρ οὔ νύ τι τέκμωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="494">οὔτʼ ἐμοί, οὔτε κεν ὔμμι διειρομένοισι πέλοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="495">φῆ δὲ δύω πεδίον τὸ Ἀρήιον ἀμφινέμεσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="496">ταύρω χαλκόποδε, στόματι φλόγα φυσιόωντας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="497">τετράγυον δʼ ἐπὶ τοῖσιν ἐφίετο νειὸν ἀρόσσαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="498">δώσειν δʼ ἐξ ὄφιος γενύων σπόρον, ὅς ῥʼ ἀνίῃσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="499">γηγενέας χαλκέοις σὺν τεύχεσιν· ἤματι δʼ αὐτῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="500">χρειὼ τούσγε δαΐξαι. ὃ δή νύ οἱ—οὔτι γὰρ ἄλλο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="501">βέλτερον ἦν φράσσασθαι—ἀπηλεγέως ὑποέστην.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="492"><q rend="double">ὦ φίλοι, Αἰήταο ἀπηνέος ἄμμι φίλον κῆρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="493"><q rend="double; merge">ἀντικρὺ κεχόλωται, ἕκαστα γὰρ οὔ νύ τι τέκμωρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="494"><q rend="double; merge">οὔτʼ ἐμοί, οὔτε κεν ὔμμι διειρομένοισι πέλοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="495"><q rend="double; merge">φῆ δὲ δύω πεδίον τὸ Ἀρήιον ἀμφινέμεσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="496"><q rend="double; merge">ταύρω χαλκόποδε, στόματι φλόγα φυσιόωντας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="497"><q rend="double; merge">τετράγυον δʼ ἐπὶ τοῖσιν ἐφίετο νειὸν ἀρόσσαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="498"><q rend="double; merge">δώσειν δʼ ἐξ ὄφιος γενύων σπόρον, ὅς ῥʼ ἀνίῃσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="499"><q rend="double; merge">γηγενέας χαλκέοις σὺν τεύχεσιν· ἤματι δʼ αὐτῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="500"><q rend="double; merge">χρειὼ τούσγε δαΐξαι. ὃ δή νύ οἱ—οὔτι γὰρ ἄλλο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="501"><q rend="double; merge">βέλτερον ἦν φράσσασθαι—ἀπηλεγέως ὑποέστην.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="502">ὧς ἄρʼ ἔφη· πάντεσσι δʼ ἀνήνυτος εἴσατʼ
 						ἄεθλος,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="503">δὴν δʼ ἄνεῳ καὶ ἄναυδοι ἐς ἀλλήλους ὁρόωντο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="504">ἄτῃ ἀμηχανίῃ τε κατηφέες· ὀψὲ δὲ Πηλεὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="505">θαρσαλέως μετὰ πᾶσιν ἀριστήεσσιν ἔειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="506">‘ὥρη μητιάασθαι ὅ κʼ ἔρξομεν. οὐ μὲν ἔολπα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="507">βουλῆς εἶναι ὄνειαρ, ὅσον τʼ ἐπὶ κάρτεϊ χειρῶν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="508">εἰ μέν νυν τύνη ζεῦξαι βόας Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="509">ἥρως Αἰσονίδη, φρονέεις, μέμονάς τε πόνοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="510">ἦ τʼ ἂν ὑποσχεσίην πεφυλαγμένος ἐντύναιο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="511">εἰ δʼ οὔ τοι μάλα θυμὸς ἑῇ ἐπὶ πάγχυ πέποιθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="512">ἠνορέῃ, μήτʼ αὐτὸς ἐπείγεο, μήτε τινʼ ἄλλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="513">τῶνδʼ ἀνδρῶν πάπταινε παρήμενος. οὐ γὰρ ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="514">σχήσομʼ, ἐπεὶ θάνατός γε τὸ κύντατον ἔσσεται ἄλγος.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="506"><q rend="double">ὥρη μητιάασθαι ὅ κʼ ἔρξομεν. οὐ μὲν ἔολπα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="507"><q rend="double; merge">βουλῆς εἶναι ὄνειαρ, ὅσον τʼ ἐπὶ κάρτεϊ χειρῶν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="508"><q rend="double; merge">εἰ μέν νυν τύνη ζεῦξαι βόας Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="509"><q rend="double; merge">ἥρως Αἰσονίδη, φρονέεις, μέμονάς τε πόνοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="510"><q rend="double; merge">ἦ τʼ ἂν ὑποσχεσίην πεφυλαγμένος ἐντύναιο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="511"><q rend="double; merge">εἰ δʼ οὔ τοι μάλα θυμὸς ἑῇ ἐπὶ πάγχυ πέποιθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="512"><q rend="double; merge">ἠνορέῃ, μήτʼ αὐτὸς ἐπείγεο, μήτε τινʼ ἄλλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="513"><q rend="double; merge">τῶνδʼ ἀνδρῶν πάπταινε παρήμενος. οὐ γὰρ ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="514"><q rend="double; merge">σχήσομʼ, ἐπεὶ θάνατός γε τὸ κύντατον ἔσσεται ἄλγος.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="515">ὧς ἔφατʼ Αἰακίδης· Τελαμῶνι δὲ θυμὸς
 						ὀρίνθη·</l>
@@ -3648,24 +3648,24 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="521">οἱ δʼ ἄλλοι εἴξαντες ἀκὴν ἔχον. αὐτίκα δʼ Ἄργος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="522">τοῖον ἔπος μετέειπεν ἐελδομένοισιν ἀέθλου·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="523">‘ὦ φίλοι, ἤτοι μὲν τόδε λοίσθιον. ἀλλά τινʼ
-						οἴω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="524">μητρὸς ἐμῆς ἔσσεσθαι ἐναίσιμον ὔμμιν ἀρωγήν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="525">τῶ καί περ μεμαῶτες, ἐρητύοισθʼ ἐνὶ νηὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="526">τυτθὸν ἔθʼ, ὡς τὸ πάροιθεν, ἐπεὶ καὶ ἐπισχέμεν ἔμπης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="527">λώιον, ἢ κακὸν οἶτον ἀφειδήσαντας ἑλέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="528">κούρη τις μεγάροισιν ἐνιτρέφετʼ Αἰήταο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="529">τὴν Ἑκάτη περίαλλα θεὰ δάε τεχνήσασθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="530">φάρμαχʼ, ὅσʼ ἤπειρός τε φύει καὶ νήχυτον ὕδωρ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="531">τοῖσι καὶ ἀκαμάτοιο πυρὸς μειλίσσετʼ ἀυτμή,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="532">καὶ ποταμοὺς ἵστησιν ἄφαρ κελαδεινὰ ῥέοντας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="533">ἄστρα τε καὶ μήνης ἱερῆς ἐπέδησε κελεύθους.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="534">τῆς μὲν ἀπὸ μεγάροιο κατὰ στίβον ἐνθάδʼ ἰόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="535">μνησάμεθʼ, εἴ κε δύναιτο, κασιγνήτη γεγαυῖα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="536">μήτηρ ἡμετέρη πεπιθεῖν ἐπαρῆξαι ἀέθλῳ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="537">εἰ δὲ καὶ αὐτοῖσιν τόδʼ ἐφανδάνει, ἦ τʼ ἂν ἱκοίμην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="538">ἤματι τῷδʼ αὐτῷ πάλιν εἰς δόμον Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="539">πειρήσων· τάχα δʼ ἂν σὺν δαίμονι πειρηθείην.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="523"><q rend="double">ὦ φίλοι, ἤτοι μὲν τόδε λοίσθιον. ἀλλά τινʼ
+						οἴω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="524"><q rend="double; merge">μητρὸς ἐμῆς ἔσσεσθαι ἐναίσιμον ὔμμιν ἀρωγήν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="525"><q rend="double; merge">τῶ καί περ μεμαῶτες, ἐρητύοισθʼ ἐνὶ νηὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="526"><q rend="double; merge">τυτθὸν ἔθʼ, ὡς τὸ πάροιθεν, ἐπεὶ καὶ ἐπισχέμεν ἔμπης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="527"><q rend="double; merge">λώιον, ἢ κακὸν οἶτον ἀφειδήσαντας ἑλέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="528"><q rend="double; merge">κούρη τις μεγάροισιν ἐνιτρέφετʼ Αἰήταο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="529"><q rend="double; merge">τὴν Ἑκάτη περίαλλα θεὰ δάε τεχνήσασθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="530"><q rend="double; merge">φάρμαχʼ, ὅσʼ ἤπειρός τε φύει καὶ νήχυτον ὕδωρ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="531"><q rend="double; merge">τοῖσι καὶ ἀκαμάτοιο πυρὸς μειλίσσετʼ ἀυτμή,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="532"><q rend="double; merge">καὶ ποταμοὺς ἵστησιν ἄφαρ κελαδεινὰ ῥέοντας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="533"><q rend="double; merge">ἄστρα τε καὶ μήνης ἱερῆς ἐπέδησε κελεύθους.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="534"><q rend="double; merge">τῆς μὲν ἀπὸ μεγάροιο κατὰ στίβον ἐνθάδʼ ἰόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="535"><q rend="double; merge">μνησάμεθʼ, εἴ κε δύναιτο, κασιγνήτη γεγαυῖα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="536"><q rend="double; merge">μήτηρ ἡμετέρη πεπιθεῖν ἐπαρῆξαι ἀέθλῳ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="537"><q rend="double; merge">εἰ δὲ καὶ αὐτοῖσιν τόδʼ ἐφανδάνει, ἦ τʼ ἂν ἱκοίμην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="538"><q rend="double; merge">ἤματι τῷδʼ αὐτῷ πάλιν εἰς δόμον Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="539"><q rend="double; merge">πειρήσων· τάχα δʼ ἂν σὺν δαίμονι πειρηθείην.</q></l>
 					          <milestone n="540" unit="card"/>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="540">ὧς φάτο· τοῖσι δὲ σῆμα θεοὶ δόσαν
@@ -3674,37 +3674,37 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="542">ὑψόθεν Αἰσονίδεω πεφοβημένη ἔμπεσε κόλποις·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="543">κίρκος δʼ ἀφλάστῳ περικάππεσεν. ὦκα δὲ Μόψος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="544">τοῖον ἔπος μετὰ πᾶσι θεοπροπέων ἀγόρευσεν·</l>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="545">‘ὔμμι, φίλοι, τόδε σῆμα θεῶν ἰότητι
-						τέτυκται·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="546">οὐδέ τῃ ἄλλως ἐστὶν ὑποκρίνασθαι ἄρειον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="547">παρθενικὴν δʼ ἐπέεσσι μετελθέμεν ἀμφιέποντας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="548">μήτι παντοίῃ. δοκέω δέ μιν οὐκ ἀθερίζειν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="549">εἰ ἐτεὸν Φινεύς γε θεᾷ ἐνὶ Κύπριδι νόστον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="550">πέφραδεν ἔσσεσθαι. κείνης δʼ ὅγε μείλιχος ὄρνις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="551">πότμον ὑπεξήλυξε· κέαρ δέ μοι ὡς ἐνὶ θυμῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="552">τόνδε κατʼ οἰωνὸν προτιόσσεται, ὧς δὲ πέλοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="553">ἀλλά, φίλοι, Κυθέρειαν ἐπικλείοντες ἀμύνειν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="554">ἤδη νῦν Ἄργοιο παραιφασίῃσι πίθεσθε.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="545"><q rend="double">ὔμμι, φίλοι, τόδε σῆμα θεῶν ἰότητι
+						τέτυκται·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="546"><q rend="double; merge">οὐδέ τῃ ἄλλως ἐστὶν ὑποκρίνασθαι ἄρειον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="547"><q rend="double; merge">παρθενικὴν δʼ ἐπέεσσι μετελθέμεν ἀμφιέποντας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="548"><q rend="double; merge">μήτι παντοίῃ. δοκέω δέ μιν οὐκ ἀθερίζειν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="549"><q rend="double; merge">εἰ ἐτεὸν Φινεύς γε θεᾷ ἐνὶ Κύπριδι νόστον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="550"><q rend="double; merge">πέφραδεν ἔσσεσθαι. κείνης δʼ ὅγε μείλιχος ὄρνις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="551"><q rend="double; merge">πότμον ὑπεξήλυξε· κέαρ δέ μοι ὡς ἐνὶ θυμῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="552"><q rend="double; merge">τόνδε κατʼ οἰωνὸν προτιόσσεται, ὧς δὲ πέλοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="553"><q rend="double; merge">ἀλλά, φίλοι, Κυθέρειαν ἐπικλείοντες ἀμύνειν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="554"><q rend="double; merge">ἤδη νῦν Ἄργοιο παραιφασίῃσι πίθεσθε.</q></l>
 					          <milestone unit="para"/>
 				              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="555">Ἴσκεν· ἐπῄνησαν δὲ νέοι, Φινῆος
 						ἐφετμὰς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="556">μνησάμενοι· μοῦνος δʼ Ἀφαρήιος ἄνθορεν Ἴδας,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="557">δείνʼ ἐπαλαστήσας μεγάλῃ ὀπί, φώνησέν τε·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="558">‘ὦ πόποι, ἦ ῥα γυναιξὶν ὁμόστολοι ἐνθάδʼ ἔβημεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="559">οἳ Κύπριν καλέουσιν ἐπίρροθον ἄμμι πέλεσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="560">οὐκέτʼ Ἐνυαλίοιο μέγα σθένος; ἐς δὲ πελείας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="561">καὶ κίρκους λεύσσοντες ἐρητύεσθε ἀέθλων;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="562">ἔρρετε, μηδʼ ὔμμιν πολεμήια ἔργα μέλοιτο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="563">παρθενικὰς δὲ λιτῇσιν ἀνάλκιδας ἠπεροπεύειν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="558"><q rend="double">ὦ πόποι, ἦ ῥα γυναιξὶν ὁμόστολοι ἐνθάδʼ ἔβημεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="559"><q rend="double; merge">οἳ Κύπριν καλέουσιν ἐπίρροθον ἄμμι πέλεσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="560"><q rend="double; merge">οὐκέτʼ Ἐνυαλίοιο μέγα σθένος; ἐς δὲ πελείας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="561"><q rend="double; merge">καὶ κίρκους λεύσσοντες ἐρητύεσθε ἀέθλων;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="562"><q rend="double; merge">ἔρρετε, μηδʼ ὔμμιν πολεμήια ἔργα μέλοιτο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="563"><q rend="double; merge">παρθενικὰς δὲ λιτῇσιν ἀνάλκιδας ἠπεροπεύειν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="564">ὧς ηὔδα μεμαώς· πολέες δʼ ὁμάδησαν ἑταῖροι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="565">ἦκα μάλʼ, οὐδʼ ἄρα τίς οἱ ἐναντίον ἔκφατο μῦθον.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="566">χωόμενος δʼ ὅγʼ ἔπειτα καθέζετο· τοῖσι δʼ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="567">αὐτίκʼ ἐποτρύνων τὸν ἑὸν νόον ὧδʼ ἀγόρευεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="568">‘Ἄργος μὲν παρὰ νηός, ἐπεὶ τόδε πᾶσιν ἕαδεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="569">στελλέσθω· ἀτὰρ αὐτοὶ ἐπὶ χθονὸς ἐκ ποταμοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="570">ἀμφαδὸν ἤδη πείσματʼ ἀνάψομεν. ἦ γὰρ ἔοικεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="571">μηκέτι δὴν κρύπτεσθαι ὑποπτήσσοντας ἀυτήν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="568"><q rend="double">Ἄργος μὲν παρὰ νηός, ἐπεὶ τόδε πᾶσιν ἕαδεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="569"><q rend="double; merge">στελλέσθω· ἀτὰρ αὐτοὶ ἐπὶ χθονὸς ἐκ ποταμοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="570"><q rend="double; merge">ἀμφαδὸν ἤδη πείσματʼ ἀνάψομεν. ἦ γὰρ ἔοικεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="571"><q rend="double; merge">μηκέτι δὴν κρύπτεσθαι ὑποπτήσσοντας ἀυτήν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="572">ὧς ἄρʼ ἔφη· καὶ τὸν μὲν ἄφαρ προΐαλλε νέεσθαι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="573">καρπαλίμως ἐξαῦτις ἀνὰ πτόλιν· οἱ δʼ ἐπὶ νηὸς</l>
@@ -3775,15 +3775,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="634">πάπτηνεν θαλάμοιο· μόλις δʼ ἐσαγείρατο θυμὸν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="635">ὡς πάρος ἐν στέρνοις, ἀδινὴν δʼ ἀνενείκατο φωνήν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="636">‘δειλὴ ἐγών, οἷόν με βαρεῖς ἐφόβησαν ὄνειροι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="637">δείδια, μὴ μέγα δή τι φέρῃ κακὸν ἥδε κέλευθος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="638">ἡρώων. περί μοι ξείνῳ φρένες ἠερέθονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="639">μνάσθω ἑὸν κατὰ δῆμον Ἀχαιίδα τηλόθι κούρην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="640">ἄμμι δὲ παρθενίη τε μέλοι καὶ δῶμα τοκήων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="641">ἔμπα γε μὴν θεμένη κύνεον κέαρ, οὐκέτʼ ἄνευθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="642">αὐτοκασιγνήτης πειρήσομαι, εἴ κέ μʼ ἀέθλῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="643">χραισμεῖν ἀντιάσῃσιν, ἐπὶ σφετέροις ἀχέουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="644">παισί· τό κέν μοι λυγρὸν ἐνὶ κραδίῃ σβέσαι ἄλγος.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="636"><q rend="double">δειλὴ ἐγών, οἷόν με βαρεῖς ἐφόβησαν ὄνειροι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="637"><q rend="double; merge">δείδια, μὴ μέγα δή τι φέρῃ κακὸν ἥδε κέλευθος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="638"><q rend="double; merge">ἡρώων. περί μοι ξείνῳ φρένες ἠερέθονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="639"><q rend="double; merge">μνάσθω ἑὸν κατὰ δῆμον Ἀχαιίδα τηλόθι κούρην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="640"><q rend="double; merge">ἄμμι δὲ παρθενίη τε μέλοι καὶ δῶμα τοκήων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="641"><q rend="double; merge">ἔμπα γε μὴν θεμένη κύνεον κέαρ, οὐκέτʼ ἄνευθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="642"><q rend="double; merge">αὐτοκασιγνήτης πειρήσομαι, εἴ κέ μʼ ἀέθλῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="643"><q rend="double; merge">χραισμεῖν ἀντιάσῃσιν, ἐπὶ σφετέροις ἀχέουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="644"><q rend="double; merge">παισί· τό κέν μοι λυγρὸν ἐνὶ κραδίῃ σβέσαι ἄλγος.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="645">ἦ ῥα, καὶ ὀρθωθεῖσα θύρας ὤιξε δόμοιο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="646">νήλιπος, οἰέανος· καὶ δὴ λελίητο νέεσθαι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="647">αὐτοκασιγνήτηνδε, καὶ ἕρκεος οὐδὸν ἄμειψεν.</l>
@@ -3815,14 +3815,14 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="673">ὡς δʼ ἴδε δάκρυσιν ὄσσε πεφυρμένα, φώνησέν μιν·</l>
 					          <milestone n="674" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="674">‘Ὤι μοι ἐγώ, Μήδεια, τί δὴ τάδε δάκρυα
-						λείβεις;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="675">τίπτʼ ἔπαθες; τί τοι αἰνὸν ὑπὸ φρένας ἵκετο πένθος;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="676">ἤ νύ σε θευμορίη περιδέδρομεν ἅψεα νοῦσος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="677">ἦέ τινʼ οὐλομένην ἐδάης ἐκ πατρὸς ἐνιπὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="678">ἀμφί τʼ ἐμοὶ καὶ παισίν; ὄφελλέ με μήτε τοκήων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="679">δῶμα τόδʼ εἰσοράαν, μηδὲ πτόλιν, ἀλλʼ ἐπὶ γαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="680">πείρασι ναιετάειν, ἵνα μηδέ περ οὔνομα Κόλχων.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="674"><q rend="double">Ὤι μοι ἐγώ, Μήδεια, τί δὴ τάδε δάκρυα
+						λείβεις;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="675"><q rend="double; merge">τίπτʼ ἔπαθες; τί τοι αἰνὸν ὑπὸ φρένας ἵκετο πένθος;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="676"><q rend="double; merge">ἤ νύ σε θευμορίη περιδέδρομεν ἅψεα νοῦσος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="677"><q rend="double; merge">ἦέ τινʼ οὐλομένην ἐδάης ἐκ πατρὸς ἐνιπὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="678"><q rend="double; merge">ἀμφί τʼ ἐμοὶ καὶ παισίν; ὄφελλέ με μήτε τοκήων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="679"><q rend="double; merge">δῶμα τόδʼ εἰσοράαν, μηδὲ πτόλιν, ἀλλʼ ἐπὶ γαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="680"><q rend="double; merge">πείρασι ναιετάειν, ἵνα μηδέ περ οὔνομα Κόλχων.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="681">ὧς φάτο· τῆς δʼ ἐρύθηνε παρήια· δὴν δέ μιν
 						αἰδὼς</l>
@@ -3833,24 +3833,24 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="686">φθογγῇ δʼ οὐ προύβαινε παροιτέρω· ὀψὲ δʼ ἔειπεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="687">τοῖα δόλῳ· θρασέες γὰρ ἐπεκλονέεσκον Ἔρωτες·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="688">‘Χαλκιόπη, περί μοι παίδων σέο θυμὸς ἄηται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="689">μή σφε πατὴρ ξείνοισι σὺν ἀνδράσιν αὐτίκʼ ὀλέσσῃ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="690">τοῖα κατακνώσσουσα μινυνθαδίῳ νέον ὕπνῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="691">λεύσσω ὀνείρατα λυγρά, τά τις θεὸς ἀκράαντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="692">θείη, μηδʼ ἀλεγεινὸν ἐφʼ υἱάσι κῆδος ἕλοιο.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="688"><q rend="double">Χαλκιόπη, περί μοι παίδων σέο θυμὸς ἄηται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="689"><q rend="double; merge">μή σφε πατὴρ ξείνοισι σὺν ἀνδράσιν αὐτίκʼ ὀλέσσῃ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="690"><q rend="double; merge">τοῖα κατακνώσσουσα μινυνθαδίῳ νέον ὕπνῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="691"><q rend="double; merge">λεύσσω ὀνείρατα λυγρά, τά τις θεὸς ἀκράαντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="692"><q rend="double; merge">θείη, μηδʼ ἀλεγεινὸν ἐφʼ υἱάσι κῆδος ἕλοιο.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="693">φῆ ῥα, κασιγνήτης πειρωμένη, εἴ κέ μιν αὐτὴ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="694">ἀντιάσειε πάροιθεν ἑοῖς τεκέεσσιν ἀμύνειν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="695">τὴν δʼ αἰνῶς ἄτλητος ἐπέκλυσε θυμὸν ἀνίη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="696">δείματι, τοῖʼ ἐσάκουσεν· ἀμείβετο δʼ ὧδʼ ἐπέεσσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="697">‘καὶ δʼ αὐτὴ τάδε πάντα μετήλυθον ὁρμαίνουσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="698">εἴ τινα συμφράσσαιο καὶ ἀρτύνειας ἀρωγήν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="699">ἀλλʼ ὄμοσον Γαῖάν τε καὶ Οὐρανόν, ὅττι τοι εἴπω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="700">σχήσειν ἐν θυμῷ, σύν τε δρήστειρα πέλεσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="701">λίσσομʼ ὑπὲρ μακάρων σέο τʼ αὐτῆς ἠδὲ τοκήων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="702">μή σφε κακῇ ὑπὸ κηρὶ διαρραισθέντας ἰδέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="703">λευγαλέως· ἢ σοίγε φίλοις σὺν παισὶ θανοῦσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="704">εἴην ἐξ Ἀίδεω στυγερὴ μετόπισθεν Ἐρινύς.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="697"><q rend="double">καὶ δʼ αὐτὴ τάδε πάντα μετήλυθον ὁρμαίνουσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="698"><q rend="double; merge">εἴ τινα συμφράσσαιο καὶ ἀρτύνειας ἀρωγήν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="699"><q rend="double; merge">ἀλλʼ ὄμοσον Γαῖάν τε καὶ Οὐρανόν, ὅττι τοι εἴπω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="700"><q rend="double; merge">σχήσειν ἐν θυμῷ, σύν τε δρήστειρα πέλεσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="701"><q rend="double; merge">λίσσομʼ ὑπὲρ μακάρων σέο τʼ αὐτῆς ἠδὲ τοκήων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="702"><q rend="double; merge">μή σφε κακῇ ὑπὸ κηρὶ διαρραισθέντας ἰδέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="703"><q rend="double; merge">λευγαλέως· ἢ σοίγε φίλοις σὺν παισὶ θανοῦσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="704"><q rend="double; merge">εἴην ἐξ Ἀίδεω στυγερὴ μετόπισθεν Ἐρινύς.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="705">ὧς ἄρʼ ἔφη, τὸ δὲ πολλὸν ὑπεξέχυτʼ αὐτίκα
 						δάκρυ·</l>
@@ -3860,38 +3860,38 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="709">λεπταλέη διὰ δώματʼ ὀδυρομένων ἀχέεσσιν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="710">τὴν δὲ πάρος Μήδεια προσέννεπεν ἀσχαλόωσα·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="711">‘δαιμονίη, τί νύ τοι ῥέξω ἄκος, οἷʼ ἀγορεύεις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="712">ἀράς τε στυγερὰς καὶ Ἐρινύας; αἲ γὰρ ὄφελλεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="713">ἔμπεδον εἶναι ἐπʼ ἄμμι τεοὺς υἱῆας ἔρυσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="714">ἴστω Κόλχων ὅρκος ὑπέρβιος ὅντινʼ ὀμόσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="715">αὐτὴ ἐποτρύνεις, μέγας Οὐρανός, ἥ θʼ ὑπένερθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="716">γαῖα, θεῶν μήτηρ, ὅσσον σθένος ἐστὶν ἐμεῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="717">μή σʼ ἐπιδευήσεσθαι, ἀνυστά περ ἀντιόωσαν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="711"><q rend="double">δαιμονίη, τί νύ τοι ῥέξω ἄκος, οἷʼ ἀγορεύεις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="712"><q rend="double; merge">ἀράς τε στυγερὰς καὶ Ἐρινύας; αἲ γὰρ ὄφελλεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="713"><q rend="double; merge">ἔμπεδον εἶναι ἐπʼ ἄμμι τεοὺς υἱῆας ἔρυσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="714"><q rend="double; merge">ἴστω Κόλχων ὅρκος ὑπέρβιος ὅντινʼ ὀμόσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="715"><q rend="double; merge">αὐτὴ ἐποτρύνεις, μέγας Οὐρανός, ἥ θʼ ὑπένερθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="716"><q rend="double; merge">γαῖα, θεῶν μήτηρ, ὅσσον σθένος ἐστὶν ἐμεῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="717"><q rend="double; merge">μή σʼ ἐπιδευήσεσθαι, ἀνυστά περ ἀντιόωσαν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="718">φῆ ἄρα· Χαλκιόπη δʼ ἠμείβετο τοῖσδʼ ἐπέεσσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="719">‘οὐκ ἂν δὴ ξείνῳ τλαίης χατέοντι καὶ αὐτῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="720">ἢ δόλον, ἤ τινα μῆτιν ἐπιφράσσασθαι ἀέθλου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="721">παίδων εἵνεκʼ ἐμεῖο; καὶ ἐκ κείνοιο δʼ ἱκάνει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="722">Ἄργος, ἐποτρύνων με τεῆς πειρῆσαι ἀρωγῆς·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="723">μεσσηγὺς μὲν τόνγε δόμῳ λίπον ἐνθάδʼ ἰοῦσα.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="719"><q rend="double">οὐκ ἂν δὴ ξείνῳ τλαίης χατέοντι καὶ αὐτῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="720"><q rend="double; merge">ἢ δόλον, ἤ τινα μῆτιν ἐπιφράσσασθαι ἀέθλου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="721"><q rend="double; merge">παίδων εἵνεκʼ ἐμεῖο; καὶ ἐκ κείνοιο δʼ ἱκάνει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="722"><q rend="double; merge">Ἄργος, ἐποτρύνων με τεῆς πειρῆσαι ἀρωγῆς·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="723"><q rend="double; merge">μεσσηγὺς μὲν τόνγε δόμῳ λίπον ἐνθάδʼ ἰοῦσα.</q></l>
 					          <milestone n="724" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="724">ὧς φάτο· τῇ δʼ ἔντοσθεν ἀνέπτατο χάρματι
 						θυμός,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="725">φοινίχθη δʼ ἄμυδις καλὸν χρόα, κὰδ δέ μιν ἀχλὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="726">εἷλεν ἰαινομένην, τοῖον δʼ ἐπὶ μῦθον ἔειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="727">‘Χαλκιόπη, ὡς ὔμμι φίλον τερπνόν τε τέτυκται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="728">ὧς ἔρξω. μὴ γάρ μοι ἐν ὀφθαλμοῖσι φαείνοι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="729">ἠώς, μηδέ με δηρὸν ἔτι ζώουσαν ἴδοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="730">εἴ γέ τι σῆς ψυχῆς προφερέστερον, ἠέ τι παίδων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="731">σῶν θείην, οἳ δή μοι ἀδελφειοὶ γεγάασιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="732">κηδεμόνες τε φίλοι καὶ ὁμήλικες. ὧς δὲ καὶ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="733">φημὶ κασιγνήτη τε σέθεν κούρη τε πέλεσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="734">ἶσον ἐπεὶ κείνοις με τεῷ ἐπαείραο μαζῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="735">νηπυτίην, ὡς αἰὲν ἐγώ ποτε μητρὸς ἄκουον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="736">ἀλλʼ ἴθι, κεῦθε δʼ ἐμὴν σιγῇ χάριν, ὄφρα τοκῆας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="737">λήσομαι ἐντύνουσα ὑπόσχεσιν· ἦρι δὲ νηὸν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="738">οἴσομαι εἰς Ἑκάτης θελκτήρια φάρμακα ταύρων.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="727"><q rend="double">Χαλκιόπη, ὡς ὔμμι φίλον τερπνόν τε τέτυκται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="728"><q rend="double; merge">ὧς ἔρξω. μὴ γάρ μοι ἐν ὀφθαλμοῖσι φαείνοι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="729"><q rend="double; merge">ἠώς, μηδέ με δηρὸν ἔτι ζώουσαν ἴδοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="730"><q rend="double; merge">εἴ γέ τι σῆς ψυχῆς προφερέστερον, ἠέ τι παίδων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="731"><q rend="double; merge">σῶν θείην, οἳ δή μοι ἀδελφειοὶ γεγάασιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="732"><q rend="double; merge">κηδεμόνες τε φίλοι καὶ ὁμήλικες. ὧς δὲ καὶ αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="733"><q rend="double; merge">φημὶ κασιγνήτη τε σέθεν κούρη τε πέλεσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="734"><q rend="double; merge">ἶσον ἐπεὶ κείνοις με τεῷ ἐπαείραο μαζῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="735"><q rend="double; merge">νηπυτίην, ὡς αἰὲν ἐγώ ποτε μητρὸς ἄκουον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="736"><q rend="double; merge">ἀλλʼ ἴθι, κεῦθε δʼ ἐμὴν σιγῇ χάριν, ὄφρα τοκῆας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="737"><q rend="double; merge">λήσομαι ἐντύνουσα ὑπόσχεσιν· ἦρι δὲ νηὸν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="738"><q rend="double; merge">οἴσομαι εἰς Ἑκάτης θελκτήρια φάρμακα ταύρων.</q></l>
 					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="740">ὧς ἥγʼ ἐκ θαλάμοιο πάλιν κίε, παισί τʼ
 						ἀρωγὴν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="741">αὐτοκασιγνήτης διεπέφραδε. τὴν δέ μιν αὖτις</l>
@@ -3927,37 +3927,37 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="769">ἀλλʼ αὔτως εὔκηλος ἑὴν ὀτλησέμεν ἄτην.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="770">ἑζομένη δἤπειτα δοάσσατο, φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="771">‘δειλὴ ἐγώ, νῦν ἔνθα κακῶν ἢ ἔνθα γένωμαι;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="772">πάντῃ μοι φρένες εἰσὶν ἀμήχανοι· οὐδέ τις ἀλκὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="773">πήματος· ἀλλʼ αὔτως φλέγει ἔμπεδον. ὡς ὄφελόν γε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="774">Ἀρτέμιδος κραιπνοῖσι πάρος βελέεσσι δαμῆναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="775">πρὶν τόνγʼ εἰσιδέειν, πρὶν Ἀχαιίδα γαῖαν ἱκέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="776">Χαλκιόπης υἷας. τοὺς μὲν θεὸς ἤ τις Ἐρινὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="777">ἄμμι πολυκλαύτους δεῦρʼ ἤγαγε κεῖθεν ἀνίας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="778">φθίσθω ἀεθλεύων, εἴ οἱ κατὰ νειὸν ὀλέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="779">μοῖρα πέλει. πῶς γάρ κεν ἐμοὺς λελάθοιμι τοκῆας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="780">φάρμακα μησαμένη; ποῖον δʼ ἐπὶ μῦθον ἐνίψω;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="781">τίς δὲ δόλος, τίς μῆτις ἐπίκλοπος ἔσσετʼ ἀρωγῆς;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="782">ἦ μιν ἄνευθʼ ἑτάρων προσπτύξομαι οἶον ἰδοῦσα;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="783">δύσμορος· οὐ μὲν ἔολπα καταφθιμένοιό περ ἔμπης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="784">λωφήσειν ἀχέων· τότε δʼ ἂν κακὸν ἄμμι πέλοιτο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="785">κεῖνος ὅτε ζωῆς ἀπαμείρεται. ἐρρέτω αἰδώς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="786">ἐρρέτω ἀγλαΐη· ὁ δʼ ἐμῇ ἰότητι σαωθεὶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="787">ἀσκηθής, ἵνα οἱ θυμῷ φίλον, ἔνθα νέοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="788">αὐτὰρ ἐγὼν αὐτῆμαρ, ὅτʼ ἐξανύσειεν ἄεθλον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="789">τεθναίην, ἢ λαιμὸν ἀναρτήσασα μελάθρῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="790">ἢ καὶ πασσαμένη ῥαιστήρια φάρμακα θυμοῦ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="791">ἀλλὰ καὶ ὧς φθιμένῃ μοι ἐπιλλίξουσιν ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="792">κερτομίας· τηλοῦ δὲ πόλις περὶ πᾶσα βοήσει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="793">πότμον ἐμόν· καί κέν με διὰ στόματος φορέουσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="794">Κολχίδες ἄλλυδις ἄλλαι ἀεικέα μωμήσονται·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="795">ἥτις κηδομένη τόσον ἀνέρος ἀλλοδαποῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="796">κάτθανεν, ἥτις δῶμα καὶ οὓς ᾔσχυνε τοκῆας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="797">μαργοσύνῃ εἴξασα. τί δʼ οὐκ ἐμὸν ἔσσεται αἶσχος;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="798">ᾤ μοι ἐμῆς ἄτης. ἦ τʼ ἂν πολὺ κέρδιον εἴη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="799">τῇδʼ αὐτῇ ἐν νυκτὶ λιπεῖν βίον ἐν θαλάμοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="800">πότμῳ ἀνωίστῳ, κάκʼ ἐλέγχεα πάντα φυγοῦσαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="801">πρὶν τάδε λωβήεντα καὶ οὐκ ὀνομαστὰ τελέσσαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="771"><q rend="double">δειλὴ ἐγώ, νῦν ἔνθα κακῶν ἢ ἔνθα γένωμαι;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="772"><q rend="double; merge">πάντῃ μοι φρένες εἰσὶν ἀμήχανοι· οὐδέ τις ἀλκὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="773"><q rend="double; merge">πήματος· ἀλλʼ αὔτως φλέγει ἔμπεδον. ὡς ὄφελόν γε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="774"><q rend="double; merge">Ἀρτέμιδος κραιπνοῖσι πάρος βελέεσσι δαμῆναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="775"><q rend="double; merge">πρὶν τόνγʼ εἰσιδέειν, πρὶν Ἀχαιίδα γαῖαν ἱκέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="776"><q rend="double; merge">Χαλκιόπης υἷας. τοὺς μὲν θεὸς ἤ τις Ἐρινὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="777"><q rend="double; merge">ἄμμι πολυκλαύτους δεῦρʼ ἤγαγε κεῖθεν ἀνίας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="778"><q rend="double; merge">φθίσθω ἀεθλεύων, εἴ οἱ κατὰ νειὸν ὀλέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="779"><q rend="double; merge">μοῖρα πέλει. πῶς γάρ κεν ἐμοὺς λελάθοιμι τοκῆας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="780"><q rend="double; merge">φάρμακα μησαμένη; ποῖον δʼ ἐπὶ μῦθον ἐνίψω;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="781"><q rend="double; merge">τίς δὲ δόλος, τίς μῆτις ἐπίκλοπος ἔσσετʼ ἀρωγῆς;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="782"><q rend="double; merge">ἦ μιν ἄνευθʼ ἑτάρων προσπτύξομαι οἶον ἰδοῦσα;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="783"><q rend="double; merge">δύσμορος· οὐ μὲν ἔολπα καταφθιμένοιό περ ἔμπης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="784"><q rend="double; merge">λωφήσειν ἀχέων· τότε δʼ ἂν κακὸν ἄμμι πέλοιτο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="785"><q rend="double; merge">κεῖνος ὅτε ζωῆς ἀπαμείρεται. ἐρρέτω αἰδώς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="786"><q rend="double; merge">ἐρρέτω ἀγλαΐη· ὁ δʼ ἐμῇ ἰότητι σαωθεὶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="787"><q rend="double; merge">ἀσκηθής, ἵνα οἱ θυμῷ φίλον, ἔνθα νέοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="788"><q rend="double; merge">αὐτὰρ ἐγὼν αὐτῆμαρ, ὅτʼ ἐξανύσειεν ἄεθλον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="789"><q rend="double; merge">τεθναίην, ἢ λαιμὸν ἀναρτήσασα μελάθρῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="790"><q rend="double; merge">ἢ καὶ πασσαμένη ῥαιστήρια φάρμακα θυμοῦ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="791"><q rend="double; merge">ἀλλὰ καὶ ὧς φθιμένῃ μοι ἐπιλλίξουσιν ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="792"><q rend="double; merge">κερτομίας· τηλοῦ δὲ πόλις περὶ πᾶσα βοήσει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="793"><q rend="double; merge">πότμον ἐμόν· καί κέν με διὰ στόματος φορέουσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="794"><q rend="double; merge">Κολχίδες ἄλλυδις ἄλλαι ἀεικέα μωμήσονται·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="795"><q rend="double; merge">ἥτις κηδομένη τόσον ἀνέρος ἀλλοδαποῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="796"><q rend="double; merge">κάτθανεν, ἥτις δῶμα καὶ οὓς ᾔσχυνε τοκῆας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="797"><q rend="double; merge">μαργοσύνῃ εἴξασα. τί δʼ οὐκ ἐμὸν ἔσσεται αἶσχος;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="798"><q rend="double; merge">ᾤ μοι ἐμῆς ἄτης. ἦ τʼ ἂν πολὺ κέρδιον εἴη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="799"><q rend="double; merge">τῇδʼ αὐτῇ ἐν νυκτὶ λιπεῖν βίον ἐν θαλάμοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="800"><q rend="double; merge">πότμῳ ἀνωίστῳ, κάκʼ ἐλέγχεα πάντα φυγοῦσαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="801"><q rend="double; merge">πρὶν τάδε λωβήεντα καὶ οὐκ ὀνομαστὰ τελέσσαι.</q></l>
 					          <milestone n="802" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="802">ἦ, καὶ φωριαμὸν μετεκίαθεν, ᾗ ἔνι πολλὰ</l>
@@ -4054,27 +4054,27 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="890">ἱεμένη, καὶ τοῖα μετὰ δμωῇσιν ἔειπεν·</l>
 					          <milestone n="891" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="891">‘ὦ φίλαι, ἦ μέγα δή τι παρήλιτον, οὐδʼ ἐνόησα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="892">μὴ ἴμεν ἀλλοδαποῖσι μετʼ ἀνδράσιν, οἵ τʼ ἐπὶ γαῖαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="893">ἡμετέρην στρωφῶσιν. ἀμηχανίῃ βεβόληται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="894">πᾶσα πόλις· τὸ καὶ οὔτις ἀνήλυθε δεῦρο γυναικῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="895">τάων, αἳ τὸ πάροιθεν ἐπημάτιαι ἀγέρονται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="896">ἀλλʼ ἐπεὶ οὖν ἱκόμεσθα, καὶ οὔ νύ τις ἄλλος ἔπεισιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="897">εἰ δʼ ἄγε μολπῇ θυμὸν ἀφειδείως κορέσωμεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="898">μειλιχίῃ, τὰ δὲ καλὰ τερείνης ἄνθεα ποίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="899">λεξάμεναι τότʼ ἔπειτʼ αὐτὴν ἀπονισσόμεθʼ ὥρην.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="900">καὶ δέ κε σὺν πολέεσσιν ὀνείασιν οἴκαδʼ ἵκοισθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="901">ἤματι τῷ, εἴ μοι συναρέσσετε τήνδε μενοινήν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="902">Ἄργος γάρ μʼ ἐπέεσσι παρατρέπει, ὧς δὲ καὶ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="903">Χαλκιόπη· τὰ δὲ σῖγα νόῳ ἔχετʼ εἰσαΐουσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="904">ἐξ ἐμέθεν, μὴ πατρὸς ἐς οὔατα μῦθος ἵκηται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="905">τὸν ξεῖνόν με κέλονται, ὅτις περὶ βουσὶν ὑπέστη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="906">δῶρʼ ἀποδεξαμένην ὀλοῶν ῥύσασθαι ἀέθλων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="907">αὐτὰρ ἐγὼ τὸν μῦθον ἐπῄνεον, ἠδὲ καὶ αὐτὸν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="908">κέκλομαι εἰς ὠπὴν ἑτάρων ἄπο μοῦνον ἱκέσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="909">ὄφρα τὰ μὲν δασόμεσθα μετὰ σφίσιν, εἴ κεν ὀπάσσῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="910">δῶρα φέρων, τῷ δʼ αὖτε κακώτερον ἄλλο πόρωμεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="911">φάρμακον. ἀλλʼ ἀπονόσφι πέλεσθέ μοι, εὖτʼ ἂν ἵκηται.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="891"><q rend="double">ὦ φίλαι, ἦ μέγα δή τι παρήλιτον, οὐδʼ ἐνόησα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="892"><q rend="double; merge">μὴ ἴμεν ἀλλοδαποῖσι μετʼ ἀνδράσιν, οἵ τʼ ἐπὶ γαῖαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="893"><q rend="double; merge">ἡμετέρην στρωφῶσιν. ἀμηχανίῃ βεβόληται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="894"><q rend="double; merge">πᾶσα πόλις· τὸ καὶ οὔτις ἀνήλυθε δεῦρο γυναικῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="895"><q rend="double; merge">τάων, αἳ τὸ πάροιθεν ἐπημάτιαι ἀγέρονται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="896"><q rend="double; merge">ἀλλʼ ἐπεὶ οὖν ἱκόμεσθα, καὶ οὔ νύ τις ἄλλος ἔπεισιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="897"><q rend="double; merge">εἰ δʼ ἄγε μολπῇ θυμὸν ἀφειδείως κορέσωμεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="898"><q rend="double; merge">μειλιχίῃ, τὰ δὲ καλὰ τερείνης ἄνθεα ποίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="899"><q rend="double; merge">λεξάμεναι τότʼ ἔπειτʼ αὐτὴν ἀπονισσόμεθʼ ὥρην.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="900"><q rend="double; merge">καὶ δέ κε σὺν πολέεσσιν ὀνείασιν οἴκαδʼ ἵκοισθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="901"><q rend="double; merge">ἤματι τῷ, εἴ μοι συναρέσσετε τήνδε μενοινήν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="902"><q rend="double; merge">Ἄργος γάρ μʼ ἐπέεσσι παρατρέπει, ὧς δὲ καὶ αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="903"><q rend="double; merge">Χαλκιόπη· τὰ δὲ σῖγα νόῳ ἔχετʼ εἰσαΐουσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="904"><q rend="double; merge">ἐξ ἐμέθεν, μὴ πατρὸς ἐς οὔατα μῦθος ἵκηται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="905"><q rend="double; merge">τὸν ξεῖνόν με κέλονται, ὅτις περὶ βουσὶν ὑπέστη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="906"><q rend="double; merge">δῶρʼ ἀποδεξαμένην ὀλοῶν ῥύσασθαι ἀέθλων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="907"><q rend="double; merge">αὐτὰρ ἐγὼ τὸν μῦθον ἐπῄνεον, ἠδὲ καὶ αὐτὸν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="908"><q rend="double; merge">κέκλομαι εἰς ὠπὴν ἑτάρων ἄπο μοῦνον ἱκέσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="909"><q rend="double; merge">ὄφρα τὰ μὲν δασόμεσθα μετὰ σφίσιν, εἴ κεν ὀπάσσῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="910"><q rend="double; merge">δῶρα φέρων, τῷ δʼ αὖτε κακώτερον ἄλλο πόρωμεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="911"><q rend="double; merge">φάρμακον. ἀλλʼ ἀπονόσφι πέλεσθέ μοι, εὖτʼ ἂν ἵκηται.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="912">ὧς ηὔδα· πάσῃσι δʼ ἐπίκλοπος ἥνδανε μῆτις.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="913">αὐτίκα δʼ Αἰσονίδην ἑτάρων ἄπο μοῦνον ἐρύσσας</l>
@@ -4100,22 +4100,22 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="930">τάων τις μεσσηγὺς ἀνὰ πτερὰ κινήσασα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="931">ὑψοῦ ἐπʼ ἀκρεμόνων Ἥρης ἠνίπαπε βουλάς·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="932">‘Ἀκλειὴς ὅδε μάντις, ὃς οὐδʼ ὅσα παῖδες ἴσασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="933">οἶδε νόῳ φράσσασθαι, ὁθούνεκεν οὔτε τι λαρὸν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="934">οὔτʼ ἐρατὸν κούρη κεν ἔπος προτιμυθήσαιτο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="935">ἠιθέῳ, εὖτʼ ἄν σφιν ἐπήλυδες ἄλλοι ἕπωνται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="936">ἔρροις, ὦ κακόμαντι, κακοφραδές· οὔτε σε Κύπρις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="937">οὔτʼ ἀγανοὶ φιλέοντες ἐπιπνείουσιν Ἔρωτες.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="932"><q rend="double">Ἀκλειὴς ὅδε μάντις, ὃς οὐδʼ ὅσα παῖδες ἴσασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="933"><q rend="double; merge">οἶδε νόῳ φράσσασθαι, ὁθούνεκεν οὔτε τι λαρὸν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="934"><q rend="double; merge">οὔτʼ ἐρατὸν κούρη κεν ἔπος προτιμυθήσαιτο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="935"><q rend="double; merge">ἠιθέῳ, εὖτʼ ἄν σφιν ἐπήλυδες ἄλλοι ἕπωνται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="936"><q rend="double; merge">ἔρροις, ὦ κακόμαντι, κακοφραδές· οὔτε σε Κύπρις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="937"><q rend="double; merge">οὔτʼ ἀγανοὶ φιλέοντες ἐπιπνείουσιν Ἔρωτες.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="938">Ἴσκεν ἀτεμβομένη· μείδησε δὲ Μόψος ἀκούσας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="939">ὀμφὴν οἰωνοῖο θεήλατον, ὧδέ τʼ ἔειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="940">‘τύνη μὲν νηόνδε θεᾶς ἴθι, τῷ ἔνι κούρην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="941">δήεις, Αἰσονίδη· μάλα δʼ ἠπίῃ ἀντιβολήσεις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="942">Κύπριδος ἐννεσίῃς, ἥ τοι συνέριθος ἀέθλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="943">ἔσσεται, ὡς δὴ καὶ πρὶν Ἀγηνορίδης φάτο Φινεύς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="944">νῶι δʼ, ἐγὼν Ἄργος τε, δεδεγμένοι, εὖτʼ ἂν ἵκηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="945">τῷδʼ αὐτῷ ἐνὶ χώρῳ ἀπεσσόμεθʼ· οἰόθι δʼ αὐτὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="946">λίσσεό μιν πυκινοῖσι παρατροπέων ἐπέεσσιν.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="940"><q rend="double">τύνη μὲν νηόνδε θεᾶς ἴθι, τῷ ἔνι κούρην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="941"><q rend="double; merge">δήεις, Αἰσονίδη· μάλα δʼ ἠπίῃ ἀντιβολήσεις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="942"><q rend="double; merge">Κύπριδος ἐννεσίῃς, ἥ τοι συνέριθος ἀέθλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="943"><q rend="double; merge">ἔσσεται, ὡς δὴ καὶ πρὶν Ἀγηνορίδης φάτο Φινεύς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="944"><q rend="double; merge">νῶι δʼ, ἐγὼν Ἄργος τε, δεδεγμένοι, εὖτʼ ἂν ἵκηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="945"><q rend="double; merge">τῷδʼ αὐτῷ ἐνὶ χώρῳ ἀπεσσόμεθʼ· οἰόθι δʼ αὐτὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="946"><q rend="double; merge">λίσσεό μιν πυκινοῖσι παρατροπέων ἐπέεσσιν.</q></l>
 					          <milestone n="947" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="947">ἦ ῥα περιφραδέως, ἐπὶ δὲ σχεδὸν ᾔνεον ἄμφω.</l>
@@ -4147,40 +4147,40 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="973">γνῶ δέ μιν Αἰσονίδης ἄτῃ ἐνιπεπτηυῖαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="974">θευμορίῃ, καὶ τοῖον ὑποσσαίνων φάτο μῦθον·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="975">‘τίπτε με, παρθενική, τόσον ἅζεαι, οἶον
-						ἐόντα;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="976">οὔ τοι ἐγών, οἷοί τε δυσαυχέες ἄλλοι ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="977">ἀνέρες, οὐδʼ ὅτε περ πάτρῃ ἔνι ναιετάασκον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="978">ἦα πάρος. τῶ μή με λίην ὑπεραίδεο, κούρη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="979">ἤ τι παρεξερέεσθαι, ὅ τοι φίλον, ἠέ τι φάσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="980">ἀλλʼ ἐπεὶ ἀλλήλοισιν ἱκάνομεν εὐμενέοντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="981">χώρῳ ἐν ἠγαθέῳ, ἵνα τʼ οὐ θέμις ἔστʼ ἀλιτέσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="982">ἀμφαδίην ἀγόρευε καὶ εἴρεο· μηδέ με τερπνοῖς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="983">φηλώσῃς ἐπέεσσιν, ἐπεὶ τὸ πρῶτον ὑπέστης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="984">αὐτοκασιγνήτῃ μενοεικέα φάρμακα δώσειν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="985">πρός σʼ αὐτῆς Ἑκάτης μειλίσσομαι ἠδὲ τοκήων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="986">καὶ Διός, ὃς ξείνοις ἱκέτῃσί τε χεῖρʼ ὑπερίσχει·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="987">ἀμφότερον δʼ, ἱκέτης ξεῖνός τέ τοι ἐνθάδʼ ἱκάνω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="988">χρειοῖ ἀναγκαίῃ γουνούμενος. οὐ γὰρ ἄνευθεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="989">ὑμείων στονόεντος ὑπέρτερος ἔσσομʼ ἀέθλου.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="990">σοὶ δʼ ἂν ἐγὼ τίσαιμι χάριν μετόπισθεν ἀρωγῆς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="991">ἣ θέμις, ὡς ἐπέοικε διάνδιχα ναιετάοντας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="992">οὔνομα καὶ καλὸν τεύχων κλέος· ὧς δὲ καὶ ὧλλοι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="993">ἥρωες κλῄσουσιν ἐς Ἑλλάδα νοστήσαντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="994">ἡρώων τʼ ἄλοχοι καὶ μητέρες, αἵ νύ που ἤδη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="995">ἡμέας ἠιόνεσσιν ἐφεζόμεναι γοάουσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="996">τάων ἀργαλέας κεν ἀποσκεδάσειας ἀνίας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="997">δή ποτε καὶ Θησῆα κακῶν ὑπελύσατʼ ἀέθλων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="998">παρθενικὴ Μινωὶς ἐυφρονέουσʼ Ἀριάδνη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="999">ἥν ῥά τε Πασιφάη κούρη τέκεν Ἠελίοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1000">ἀλλʼ ἡ μὲν καὶ νηός, ἐπεὶ χόλον εὔνασε Μίνως,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1001">σὺν τῷ ἐφεζομένη πάτρην λίπε· τὴν δὲ καὶ αὐτοὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1002">ἀθάνατοι φίλαντο, μέσῳ δέ οἱ αἰθέρι τέκμαρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1003">ἀστερόεις στέφανος, τόν τε κλείουσʼ Ἀριάδνης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1004">πάννυχος οὐρανίοισιν ἑλίσσεται εἰδώλοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1005">ὧς καὶ σοὶ θεόθεν χάρις ἔσσεται, εἴ κε σαώσῃς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1006">τόσσον ἀριστήων ἀνδρῶν στόλον. ἦ γὰρ ἔοικας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1007">ἐκ μορφῆς ἀγανῇσιν ἐπητείῃσι κεκάσθαι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="975"><q rend="double">τίπτε με, παρθενική, τόσον ἅζεαι, οἶον
+						ἐόντα;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="976"><q rend="double; merge">οὔ τοι ἐγών, οἷοί τε δυσαυχέες ἄλλοι ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="977"><q rend="double; merge">ἀνέρες, οὐδʼ ὅτε περ πάτρῃ ἔνι ναιετάασκον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="978"><q rend="double; merge">ἦα πάρος. τῶ μή με λίην ὑπεραίδεο, κούρη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="979"><q rend="double; merge">ἤ τι παρεξερέεσθαι, ὅ τοι φίλον, ἠέ τι φάσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="980"><q rend="double; merge">ἀλλʼ ἐπεὶ ἀλλήλοισιν ἱκάνομεν εὐμενέοντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="981"><q rend="double; merge">χώρῳ ἐν ἠγαθέῳ, ἵνα τʼ οὐ θέμις ἔστʼ ἀλιτέσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="982"><q rend="double; merge">ἀμφαδίην ἀγόρευε καὶ εἴρεο· μηδέ με τερπνοῖς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="983"><q rend="double; merge">φηλώσῃς ἐπέεσσιν, ἐπεὶ τὸ πρῶτον ὑπέστης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="984"><q rend="double; merge">αὐτοκασιγνήτῃ μενοεικέα φάρμακα δώσειν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="985"><q rend="double; merge">πρός σʼ αὐτῆς Ἑκάτης μειλίσσομαι ἠδὲ τοκήων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="986"><q rend="double; merge">καὶ Διός, ὃς ξείνοις ἱκέτῃσί τε χεῖρʼ ὑπερίσχει·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="987"><q rend="double; merge">ἀμφότερον δʼ, ἱκέτης ξεῖνός τέ τοι ἐνθάδʼ ἱκάνω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="988"><q rend="double; merge">χρειοῖ ἀναγκαίῃ γουνούμενος. οὐ γὰρ ἄνευθεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="989"><q rend="double; merge">ὑμείων στονόεντος ὑπέρτερος ἔσσομʼ ἀέθλου.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="990"><q rend="double; merge">σοὶ δʼ ἂν ἐγὼ τίσαιμι χάριν μετόπισθεν ἀρωγῆς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="991"><q rend="double; merge">ἣ θέμις, ὡς ἐπέοικε διάνδιχα ναιετάοντας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="992"><q rend="double; merge">οὔνομα καὶ καλὸν τεύχων κλέος· ὧς δὲ καὶ ὧλλοι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="993"><q rend="double; merge">ἥρωες κλῄσουσιν ἐς Ἑλλάδα νοστήσαντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="994"><q rend="double; merge">ἡρώων τʼ ἄλοχοι καὶ μητέρες, αἵ νύ που ἤδη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="995"><q rend="double; merge">ἡμέας ἠιόνεσσιν ἐφεζόμεναι γοάουσιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="996"><q rend="double; merge">τάων ἀργαλέας κεν ἀποσκεδάσειας ἀνίας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="997"><q rend="double; merge">δή ποτε καὶ Θησῆα κακῶν ὑπελύσατʼ ἀέθλων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="998"><q rend="double; merge">παρθενικὴ Μινωὶς ἐυφρονέουσʼ Ἀριάδνη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="999"><q rend="double; merge">ἥν ῥά τε Πασιφάη κούρη τέκεν Ἠελίοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1000"><q rend="double; merge">ἀλλʼ ἡ μὲν καὶ νηός, ἐπεὶ χόλον εὔνασε Μίνως,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1001"><q rend="double; merge">σὺν τῷ ἐφεζομένη πάτρην λίπε· τὴν δὲ καὶ αὐτοὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1002"><q rend="double; merge">ἀθάνατοι φίλαντο, μέσῳ δέ οἱ αἰθέρι τέκμαρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1003"><q rend="double; merge">ἀστερόεις στέφανος, τόν τε κλείουσʼ Ἀριάδνης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1004"><q rend="double; merge">πάννυχος οὐρανίοισιν ἑλίσσεται εἰδώλοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1005"><q rend="double; merge">ὧς καὶ σοὶ θεόθεν χάρις ἔσσεται, εἴ κε σαώσῃς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1006"><q rend="double; merge">τόσσον ἀριστήων ἀνδρῶν στόλον. ἦ γὰρ ἔοικας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1007"><q rend="double; merge">ἐκ μορφῆς ἀγανῇσιν ἐπητείῃσι κεκάσθαι.</q></l>
 					          <milestone n="1008" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1008">ὧς φάτο κυδαίνων· ἡ δʼ ἐγκλιδὸν ὄσσε βαλοῦσα</l>
@@ -4202,43 +4202,43 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1024">ἱμερόεν φαιδρῇσιν ὑπʼ ὀφρύσι μειδιόωντες.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1025">ὀψὲ δὲ δὴ τοίοισι μόλις προσπτύξατο κούρη·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1026">‘φράζεο νῦν, ὥς κέν τοι ἐγὼ μητίσομʼ ἀρωγήν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1027">εὖτʼ ἂν δὴ μετιόντι πατὴρ ἐμὸς ἐγγυαλίξῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1028">ἐξ ὄφιος γενύων ὀλοοὺς σπείρασθαι ὀδόντας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1029">δὴ τότε μέσσην νύκτα διαμμοιρηδὰ φυλάξας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1030">ἀκαμάτοιο ῥοῇσι λοεσσάμενος ποταμοῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1031">οἶος ἄνευθʼ ἄλλων ἐνὶ φάρεσι κυανέοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1032">βόθρον ὀρύξασθαι περιηγέα· τῷ δʼ ἔνι θῆλυν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1033">ἀρνειὸν σφάζειν, καὶ ἀδαίετον ὠμοθετῆσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1034">αὐτῷ πυρκαϊὴν εὖ νηήσας ἐπὶ βόθρῳ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1035">μουνογενῆ δʼ Ἑκάτην Περσηίδα μειλίσσοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1036">λείβων ἐκ δέπαος σιμβλήια ἔργα μελισσέων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1037">ἔνθα δʼ ἐπεί κε θεὰν μεμνημένος ἱλάσσηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1038">ἂψ ἀπὸ πυρκαϊῆς ἀναχάζεο· μηδέ σε δοῦπος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1039">ἠὲ ποδῶν ὄρσῃσι μεταστρεφθῆναι ὀπίσσω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1040">ἠὲ κυνῶν ὑλακή, μή πως τὰ ἕκαστα κολούσας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1041">οὐδʼ αὐτὸς κατὰ κόσμον ἑοῖς ἑτάροισι πελάσσῃς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1042">ἦρι δὲ μυδήνας τόδε φάρμακον, ἠύτʼ ἀλοιφῇ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1043">γυμνωθεὶς φαίδρυνε τεὸν δέμας· ἐν δέ οἱ ἀλκὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1044">ἔσσετʼ ἀπειρεσίη μέγα τε σθένος, οὐδέ κε φαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1045">ἀνδράσιν, ἀλλὰ θεοῖσιν ἰσαζέμεν ἀθανάτοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1046">πρὸς δὲ καὶ αὐτῷ δουρὶ σάκος πεπαλαγμένον ἔστω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1047">καὶ ξίφος. ἔνθʼ οὐκ ἄν σε διατμήξειαν ἀκωκαὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1048">γηγενέων ἀνδρῶν, οὐδʼ ἄσχετος ἀίσσουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1049">φλὸξ ὀλοῶν ταύρων. τοῖός γε μὲν οὐκ ἐπὶ δηρὸν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1050">ἔσσεαι, ἀλλʼ αὐτῆμαρ· ὅμως σύγε μή ποτʼ ἀέθλου</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1051">χάζεο. καὶ δέ τοι ἄλλο παρὲξ ὑποθήσομʼ ὄνειαρ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1052">αὐτίκʼ ἐπὴν κρατεροὺς ζεύξῃς βόας, ὦκα δὲ πᾶσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1053">χερσὶ καὶ ἠνορέῃ στυφελὴν διὰ νειὸν ἀρόσσῃς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1054">οἱ δʼ ἤδη κατὰ ὦλκας ἀνασταχύωσι Γίγαντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1055">σπειρομένων ὄφιος δνοφερὴν ἐπὶ βῶλον ὀδόντων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1056">αἴ κεν ὀρινομένους πολέας νειοῖο δοκεύσῃς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1057">λάθρῃ λᾶαν ἄφες στιβαρώτερον· οἱ δʼ ἂν ἐπʼ αὐτῷ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1058">καρχαλέοι κύνες ὥστε περὶ βρώμης, ὀλέκοιεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1059">ἀλλήλους· καὶ δʼ αὐτὸς ἐπείγεο δηιοτῆτος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1060">ἰθῦσαι. τὸ δὲ κῶας ἐς Ἑλλάδα τοῖό γʼ ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1061">οἴσεαι ἐξ Αἴης τηλοῦ ποθί· νίσσεο δʼ ἔμπης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1062">ᾗ φίλον, ἤ τοι ἕαδεν ἀφορμηθέντι νέεσθαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1026"><q rend="double">φράζεο νῦν, ὥς κέν τοι ἐγὼ μητίσομʼ ἀρωγήν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1027"><q rend="double; merge">εὖτʼ ἂν δὴ μετιόντι πατὴρ ἐμὸς ἐγγυαλίξῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1028"><q rend="double; merge">ἐξ ὄφιος γενύων ὀλοοὺς σπείρασθαι ὀδόντας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1029"><q rend="double; merge">δὴ τότε μέσσην νύκτα διαμμοιρηδὰ φυλάξας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1030"><q rend="double; merge">ἀκαμάτοιο ῥοῇσι λοεσσάμενος ποταμοῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1031"><q rend="double; merge">οἶος ἄνευθʼ ἄλλων ἐνὶ φάρεσι κυανέοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1032"><q rend="double; merge">βόθρον ὀρύξασθαι περιηγέα· τῷ δʼ ἔνι θῆλυν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1033"><q rend="double; merge">ἀρνειὸν σφάζειν, καὶ ἀδαίετον ὠμοθετῆσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1034"><q rend="double; merge">αὐτῷ πυρκαϊὴν εὖ νηήσας ἐπὶ βόθρῳ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1035"><q rend="double; merge">μουνογενῆ δʼ Ἑκάτην Περσηίδα μειλίσσοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1036"><q rend="double; merge">λείβων ἐκ δέπαος σιμβλήια ἔργα μελισσέων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1037"><q rend="double; merge">ἔνθα δʼ ἐπεί κε θεὰν μεμνημένος ἱλάσσηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1038"><q rend="double; merge">ἂψ ἀπὸ πυρκαϊῆς ἀναχάζεο· μηδέ σε δοῦπος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1039"><q rend="double; merge">ἠὲ ποδῶν ὄρσῃσι μεταστρεφθῆναι ὀπίσσω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1040"><q rend="double; merge">ἠὲ κυνῶν ὑλακή, μή πως τὰ ἕκαστα κολούσας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1041"><q rend="double; merge">οὐδʼ αὐτὸς κατὰ κόσμον ἑοῖς ἑτάροισι πελάσσῃς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1042"><q rend="double; merge">ἦρι δὲ μυδήνας τόδε φάρμακον, ἠύτʼ ἀλοιφῇ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1043"><q rend="double; merge">γυμνωθεὶς φαίδρυνε τεὸν δέμας· ἐν δέ οἱ ἀλκὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1044"><q rend="double; merge">ἔσσετʼ ἀπειρεσίη μέγα τε σθένος, οὐδέ κε φαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1045"><q rend="double; merge">ἀνδράσιν, ἀλλὰ θεοῖσιν ἰσαζέμεν ἀθανάτοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1046"><q rend="double; merge">πρὸς δὲ καὶ αὐτῷ δουρὶ σάκος πεπαλαγμένον ἔστω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1047"><q rend="double; merge">καὶ ξίφος. ἔνθʼ οὐκ ἄν σε διατμήξειαν ἀκωκαὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1048"><q rend="double; merge">γηγενέων ἀνδρῶν, οὐδʼ ἄσχετος ἀίσσουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1049"><q rend="double; merge">φλὸξ ὀλοῶν ταύρων. τοῖός γε μὲν οὐκ ἐπὶ δηρὸν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1050"><q rend="double; merge">ἔσσεαι, ἀλλʼ αὐτῆμαρ· ὅμως σύγε μή ποτʼ ἀέθλου</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1051"><q rend="double; merge">χάζεο. καὶ δέ τοι ἄλλο παρὲξ ὑποθήσομʼ ὄνειαρ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1052"><q rend="double; merge">αὐτίκʼ ἐπὴν κρατεροὺς ζεύξῃς βόας, ὦκα δὲ πᾶσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1053"><q rend="double; merge">χερσὶ καὶ ἠνορέῃ στυφελὴν διὰ νειὸν ἀρόσσῃς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1054"><q rend="double; merge">οἱ δʼ ἤδη κατὰ ὦλκας ἀνασταχύωσι Γίγαντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1055"><q rend="double; merge">σπειρομένων ὄφιος δνοφερὴν ἐπὶ βῶλον ὀδόντων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1056"><q rend="double; merge">αἴ κεν ὀρινομένους πολέας νειοῖο δοκεύσῃς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1057"><q rend="double; merge">λάθρῃ λᾶαν ἄφες στιβαρώτερον· οἱ δʼ ἂν ἐπʼ αὐτῷ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1058"><q rend="double; merge">καρχαλέοι κύνες ὥστε περὶ βρώμης, ὀλέκοιεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1059"><q rend="double; merge">ἀλλήλους· καὶ δʼ αὐτὸς ἐπείγεο δηιοτῆτος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1060"><q rend="double; merge">ἰθῦσαι. τὸ δὲ κῶας ἐς Ἑλλάδα τοῖό γʼ ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1061"><q rend="double; merge">οἴσεαι ἐξ Αἴης τηλοῦ ποθί· νίσσεο δʼ ἔμπης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1062"><q rend="double; merge">ᾗ φίλον, ἤ τοι ἕαδεν ἀφορμηθέντι νέεσθαι.</q></l>
 					          <milestone n="1063" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1063">ὧς ἄρʼ ἔφη, καὶ σῖγα ποδῶν πάρος ὄσσε βαλοῦσα</l>
@@ -4248,75 +4248,75 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1067">ἐξαῦτις μύθῳ προσεφώνεεν, εἷλέ τε χειρὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1068">δεξιτερῆς· δὴ γάρ οἱ ἀπʼ ὀφθαλμοὺς λίπεν αἰδώς·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1069">‘μνώεο δʼ, ἢν ἄρα δή ποθʼ ὑπότροπος οἴκαδʼ
-						ἵκηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1070">οὔνομα Μηδείης· ὧς δʼ αὖτʼ ἐγὼ ἀμφὶς ἐόντος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1071">μνήσομαι. εἰπὲ δέ μοι πρόφρων τόδε, πῇ τοι ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1072">δώματα, πῇ νῦν ἔνθεν ὑπεὶρ ἅλα νηὶ περήσεις·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1073">ἤ νύ που ἀφνειοῦ σχεδὸν ἵξεαι Ὀρχομενοῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1074">ἦε καὶ Αἰαίης νήσου πέλας; εἰπὲ δὲ κούρην,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1075">ἥντινα τήνδʼ ὀνόμηνας ἀριγνώτην γεγαυῖαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1076">Πασιφάης, ἣ πατρὸς ὁμόγνιός ἐστιν ἐμεῖο.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1069"><q rend="double">μνώεο δʼ, ἢν ἄρα δή ποθʼ ὑπότροπος οἴκαδʼ
+						ἵκηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1070"><q rend="double; merge">οὔνομα Μηδείης· ὧς δʼ αὖτʼ ἐγὼ ἀμφὶς ἐόντος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1071"><q rend="double; merge">μνήσομαι. εἰπὲ δέ μοι πρόφρων τόδε, πῇ τοι ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1072"><q rend="double; merge">δώματα, πῇ νῦν ἔνθεν ὑπεὶρ ἅλα νηὶ περήσεις·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1073"><q rend="double; merge">ἤ νύ που ἀφνειοῦ σχεδὸν ἵξεαι Ὀρχομενοῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1074"><q rend="double; merge">ἦε καὶ Αἰαίης νήσου πέλας; εἰπὲ δὲ κούρην,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1075"><q rend="double; merge">ἥντινα τήνδʼ ὀνόμηνας ἀριγνώτην γεγαυῖαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1076"><q rend="double; merge">Πασιφάης, ἣ πατρὸς ὁμόγνιός ἐστιν ἐμεῖο.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1077">ὧς φάτο· τὸν δὲ καὶ αὐτὸν ὑπήιε δάκρυσι κούρης</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1078">οὖλος Ἔρως, τοῖον δὲ παραβλήδην ἔπος ηὔδα·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1079">‘καὶ λίην οὐ νύκτας ὀίομαι, οὐδέ ποτʼ ἦμαρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1080">σεῦ ἐπιλήσεσθαι, προφυγὼν μόρον, εἰ ἐτεόν γε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1081">φεύξομαι ἀσκηθὴς ἐς Ἀχαιίδα, μηδέ τινʼ ἄλλον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1082">Αἰήτης προβάλῃσι κακώτερον ἄμμιν ἄεθλον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1083">εἰ δέ τοι ἡμετέρην ἐξίδμεναι εὔαδε πάτρην,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1084">ἐξερέω· μάλα γάρ με καὶ αὐτὸν θυμὸς ἀνώγει.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1085">ἔστι τις αἰπεινοῖσι περίδρομος οὔρεσι γαῖα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1086">πάμπαν ἐύρρηνός τε καὶ εὔβοτος, ἔνθα Προμηθεὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1087">Ἰαπετιονίδης ἀγαθὸν τέκε Δευκαλίωνα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1088">ὃς πρῶτος ποίησε πόλεις καὶ ἐδείματο νηοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1089">ἀθανάτοις, πρῶτος δὲ καὶ ἀνθρώπων βασίλευσεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1090">Αἱμονίην δὴ τήνγε περικτίονες καλέουσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1091">ἐν δʼ αὐτῇ Ἰαωλκός, ἐμὴ πόλις, ἐν δὲ καὶ ἄλλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1092">πολλαὶ ναιετάουσιν, ἵνʼ οὐδέ περ οὔνομʼ ἀκοῦσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1093">Αἰαίης νήσου· Μινύην γε μὲν ὁρμηθέντα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1094">Αἰολίδην Μινύην ἔνθεν φάτις Ὀρχομενοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1095">δή ποτε Καδμείοισιν ὁμούριον ἄστυ πολίσσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1096">ἀλλὰ τίη τάδε τοι μεταμώνια πάντʼ ἀγορεύω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1097">ἡμετέρους τε δόμους τηλεκλείτην τʼ Ἀριάδνην,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1098">κούρην Μίνωος, τόπερ ἀγλαὸν οὔνομα κείνην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1099">παρθενικὴν καλέεσκον ἐπήρατον, ἥν μʼ ἐρεείνεις;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1100">αἴθε γάρ, ὡς Θησῆι τότε ξυναρέσσατο Μίνως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1101">ἀμφʼ αὐτῆς, ὧς ἄμμι πατὴρ τεὸς ἄρθμιος εἴη.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1079"><q rend="double">καὶ λίην οὐ νύκτας ὀίομαι, οὐδέ ποτʼ ἦμαρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1080"><q rend="double; merge">σεῦ ἐπιλήσεσθαι, προφυγὼν μόρον, εἰ ἐτεόν γε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1081"><q rend="double; merge">φεύξομαι ἀσκηθὴς ἐς Ἀχαιίδα, μηδέ τινʼ ἄλλον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1082"><q rend="double; merge">Αἰήτης προβάλῃσι κακώτερον ἄμμιν ἄεθλον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1083"><q rend="double; merge">εἰ δέ τοι ἡμετέρην ἐξίδμεναι εὔαδε πάτρην,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1084"><q rend="double; merge">ἐξερέω· μάλα γάρ με καὶ αὐτὸν θυμὸς ἀνώγει.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1085"><q rend="double; merge">ἔστι τις αἰπεινοῖσι περίδρομος οὔρεσι γαῖα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1086"><q rend="double; merge">πάμπαν ἐύρρηνός τε καὶ εὔβοτος, ἔνθα Προμηθεὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1087"><q rend="double; merge">Ἰαπετιονίδης ἀγαθὸν τέκε Δευκαλίωνα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1088"><q rend="double; merge">ὃς πρῶτος ποίησε πόλεις καὶ ἐδείματο νηοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1089"><q rend="double; merge">ἀθανάτοις, πρῶτος δὲ καὶ ἀνθρώπων βασίλευσεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1090"><q rend="double; merge">Αἱμονίην δὴ τήνγε περικτίονες καλέουσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1091"><q rend="double; merge">ἐν δʼ αὐτῇ Ἰαωλκός, ἐμὴ πόλις, ἐν δὲ καὶ ἄλλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1092"><q rend="double; merge">πολλαὶ ναιετάουσιν, ἵνʼ οὐδέ περ οὔνομʼ ἀκοῦσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1093"><q rend="double; merge">Αἰαίης νήσου· Μινύην γε μὲν ὁρμηθέντα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1094"><q rend="double; merge">Αἰολίδην Μινύην ἔνθεν φάτις Ὀρχομενοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1095"><q rend="double; merge">δή ποτε Καδμείοισιν ὁμούριον ἄστυ πολίσσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1096"><q rend="double; merge">ἀλλὰ τίη τάδε τοι μεταμώνια πάντʼ ἀγορεύω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1097"><q rend="double; merge">ἡμετέρους τε δόμους τηλεκλείτην τʼ Ἀριάδνην,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1098"><q rend="double; merge">κούρην Μίνωος, τόπερ ἀγλαὸν οὔνομα κείνην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1099"><q rend="double; merge">παρθενικὴν καλέεσκον ἐπήρατον, ἥν μʼ ἐρεείνεις;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1100"><q rend="double; merge">αἴθε γάρ, ὡς Θησῆι τότε ξυναρέσσατο Μίνως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1101"><q rend="double; merge">ἀμφʼ αὐτῆς, ὧς ἄμμι πατὴρ τεὸς ἄρθμιος εἴη.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1102">ὧς φάτο, μειλιχίοισι καταψήχων ὀάροισιν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1103">τῆς δʼ ἀλεγεινόταται κραδίην ἐρέθεσκον ἀνῖαι,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1104">καί μιν ἀκηχεμένη ἀδινῷ προσπτύξατο μύθῳ·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1105">‘Ἑλλάδι που τάδε καλά, συνημοσύνας
-						ἀλεγύνειν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1106">Αἰήτης δʼ οὐ τοῖος ἐν ἀνδράσιν, οἷον ἔειπας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1107">Μίνω Πασιφάης πόσιν ἔμμεναι· οὐδʼ Ἀριάδνῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1108">ἰσοῦμαι· τῶ μήτι φιλοξενίην ἀγόρευε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1109">ἀλλʼ οἶον τύνη μὲν ἐμεῦ, ὅτʼ Ἰωλκὸν ἵκηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1110">μνώεο· σεῖο δʼ ἐγὼ καὶ ἐμῶν ἀέκητι τοκήων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1111">μνήσομαι. ἔλθοι δʼ ἧμιν ἀπόπροθεν ἠέ τις ὄσσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1112">ἠέ τις ἄγγελος ὄρνις, ὅτʼ ἐκλελάθοιο ἐμεῖο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1113">ἢ αὐτήν με ταχεῖαι ὑπὲρ πόντοιο φέροιεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1114">ἐνθένδʼ εἰς Ἰαωλκὸν ἀναρπάξασαι ἄελλαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1115">ὄφρα σʼ, ἐν ὀφθαλμοῖσιν ἐλεγχείας προφέρουσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1116">μνήσω ἐμῇ ἰότητι πεφυγμένον. αἴθε γὰρ εἴην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1117">ἀπροφάτως τότε σοῖσιν ἐφέστιος ἐν μεγάροισιν.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1105"><q rend="double">Ἑλλάδι που τάδε καλά, συνημοσύνας
+						ἀλεγύνειν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1106"><q rend="double; merge">Αἰήτης δʼ οὐ τοῖος ἐν ἀνδράσιν, οἷον ἔειπας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1107"><q rend="double; merge">Μίνω Πασιφάης πόσιν ἔμμεναι· οὐδʼ Ἀριάδνῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1108"><q rend="double; merge">ἰσοῦμαι· τῶ μήτι φιλοξενίην ἀγόρευε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1109"><q rend="double; merge">ἀλλʼ οἶον τύνη μὲν ἐμεῦ, ὅτʼ Ἰωλκὸν ἵκηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1110"><q rend="double; merge">μνώεο· σεῖο δʼ ἐγὼ καὶ ἐμῶν ἀέκητι τοκήων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1111"><q rend="double; merge">μνήσομαι. ἔλθοι δʼ ἧμιν ἀπόπροθεν ἠέ τις ὄσσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1112"><q rend="double; merge">ἠέ τις ἄγγελος ὄρνις, ὅτʼ ἐκλελάθοιο ἐμεῖο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1113"><q rend="double; merge">ἢ αὐτήν με ταχεῖαι ὑπὲρ πόντοιο φέροιεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1114"><q rend="double; merge">ἐνθένδʼ εἰς Ἰαωλκὸν ἀναρπάξασαι ἄελλαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1115"><q rend="double; merge">ὄφρα σʼ, ἐν ὀφθαλμοῖσιν ἐλεγχείας προφέρουσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1116"><q rend="double; merge">μνήσω ἐμῇ ἰότητι πεφυγμένον. αἴθε γὰρ εἴην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1117"><q rend="double; merge">ἀπροφάτως τότε σοῖσιν ἐφέστιος ἐν μεγάροισιν.</q></l>
 					          <milestone n="1118" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1118">ὧς ἄρʼ ἔφη, ἐλεεινὰ καταπροχέουσα παρειῶν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1119">δάκρυα· τὴν δʼ ὅγε δῆθεν ὑποβλήδην προσέειπεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1120">‘δαιμονίη, κενεὰς μὲν ἔα πλάζεσθαι ἀέλλας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1121">ὧς δὲ καὶ ἄγγελον ὄρνιν, ἐπεὶ μεταμώνια βάζεις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1122">εἰ δέ κεν ἤθεα κεῖνα καὶ Ἑλλάδα γαῖαν ἵκηαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1123">τιμήεσσα γυναιξὶ καὶ ἀνδράσιν αἰδοίη τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1124">ἔσσεαι· οἱ δέ σε πάγχυ θεὸν ὣς πορσανέουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1125">οὕνεκα τῶν μὲν παῖδες ὑπότροποι οἴκαδʼ ἵκοντο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1126">σῇ βουλῇ, τῶν δʼ αὖτε κασίγνητοί τε ἔται τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1127">καὶ θαλεροὶ κακότητος ἄδην ἐσάωθεν ἀκοῖται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1128">ἡμέτερον δὲ λέχος θαλάμοις ἔνι κουριδίοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1129">πορσυνέεις· οὐδʼ ἄμμε διακρινέει φιλότητος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1130">ἄλλο, πάρος θάνατόν γε μεμορμένον ἀμφικαλύψαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1120"><q rend="double">δαιμονίη, κενεὰς μὲν ἔα πλάζεσθαι ἀέλλας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1121"><q rend="double; merge">ὧς δὲ καὶ ἄγγελον ὄρνιν, ἐπεὶ μεταμώνια βάζεις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1122"><q rend="double; merge">εἰ δέ κεν ἤθεα κεῖνα καὶ Ἑλλάδα γαῖαν ἵκηαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1123"><q rend="double; merge">τιμήεσσα γυναιξὶ καὶ ἀνδράσιν αἰδοίη τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1124"><q rend="double; merge">ἔσσεαι· οἱ δέ σε πάγχυ θεὸν ὣς πορσανέουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1125"><q rend="double; merge">οὕνεκα τῶν μὲν παῖδες ὑπότροποι οἴκαδʼ ἵκοντο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1126"><q rend="double; merge">σῇ βουλῇ, τῶν δʼ αὖτε κασίγνητοί τε ἔται τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1127"><q rend="double; merge">καὶ θαλεροὶ κακότητος ἄδην ἐσάωθεν ἀκοῖται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1128"><q rend="double; merge">ἡμέτερον δὲ λέχος θαλάμοις ἔνι κουριδίοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1129"><q rend="double; merge">πορσυνέεις· οὐδʼ ἄμμε διακρινέει φιλότητος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1130"><q rend="double; merge">ἄλλο, πάρος θάνατόν γε μεμορμένον ἀμφικαλύψαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1131">ὧς φάτο· τῇ δʼ ἔντοσθε κατείβετο θυμὸς ἀκουῇ,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1132">ἔμπης δʼ ἔργʼ ἀίδηλα κατερρίγησεν ἰδέσθαι.</l>
@@ -4331,9 +4331,9 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1140">ἡ δʼ οὔπω κομιδῆς μιμνήσκετο, τέρπετο γάρ οἱ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1141">θυμὸς ὁμῶς μορφῇ τε καὶ αἱμυλίοισι λόγοισιν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1142">εἰ μὴ ἄρʼ Αἰσονίδης πεφυλαγμένος ὀψέ περ ηὔδα·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1143">‘ὥρη ἀποβλώσκειν, μὴ πρὶν φάος ἠελίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1144">δύῃ ὑποφθάμενον, καί τις τὰ ἕκαστα νοήσῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1145">ὀθνείων· αὖτις δʼ ἀβολήσομεν ἐνθάδʼ ἰόντες.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1143"><q rend="double">ὥρη ἀποβλώσκειν, μὴ πρὶν φάος ἠελίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1144"><q rend="double; merge">δύῃ ὑποφθάμενον, καί τις τὰ ἕκαστα νοήσῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1145"><q rend="double; merge">ὀθνείων· αὖτις δʼ ἀβολήσομεν ἐνθάδʼ ἰόντες.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1146">ὧς τώγʼ ἀλλήλων ἀγανοῖς ἐπὶ τόσσον ἔπεσσιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1147">πείρηθεν· μετὰ δʼ αὖτε διέτμαγεν. ἤτοι Ἰήσων</l>
@@ -4640,11 +4640,11 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="28">ῥηξαμένη πλόκαμον, θαλάμῳ μνημήια μητρὶ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="29">κάλλιπε παρθενίης, ἀδινῇ δʼ ὀλοφύρατο φωνῇ·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="30">‘τόνδε τοι ἀντʼ ἐμέθεν ταναὸν πλόκον εἶμι
-						λιποῦσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="31">μῆτερ ἐμή· χαίροις δὲ καὶ ἄνδιχα πολλὸν ἰούσῃ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="32">χαίροις Χαλκιόπη, καὶ πᾶς δόμος. αἴθε σε πόντος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="33">ξεῖνε, διέρραισεν, πρὶν Κολχίδα γαῖαν ἱκέσθαι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="30"><q rend="double">τόνδε τοι ἀντʼ ἐμέθεν ταναὸν πλόκον εἶμι
+						λιποῦσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="31"><q rend="double; merge">μῆτερ ἐμή· χαίροις δὲ καὶ ἄνδιχα πολλὸν ἰούσῃ·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="32"><q rend="double; merge">χαίροις Χαλκιόπη, καὶ πᾶς δόμος. αἴθε σε πόντος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="33"><q rend="double; merge">ξεῖνε, διέρραισεν, πρὶν Κολχίδα γαῖαν ἱκέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="34">ὧς ἄρʼ ἔφη· βλεφάρων δὲ κατʼ ἀθρόα δάκρυα
 						χεῦεν.</l>
@@ -4672,15 +4672,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="56">ἁρπαλέως, καὶ τοῖα μετὰ φρεσὶν ᾗσιν ἔειπεν·</l>
 					          <milestone n="57" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="57">‘οὐκ ἄρʼ ἐγὼ μούνη μετὰ Λάτμιον ἄντρον ἀλύσκω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="58">οὐδʼ οἴη καλῷ περιδαίομαι Ἐνδυμίωνι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="59">ἦ θαμὰ δὴ καὶ σεῖο κίον δολίῃσιν ἀοιδαῖς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="60">μνησαμένη φιλότητος, ἵνα σκοτίῃ ἐνὶ νυκτὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="61">φαρμάσσῃς εὔκηλος, ἅ τοι φίλα ἔργα τέτυκται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="62">νῦν δὲ καὶ αὐτὴ δῆθεν ὁμοίης ἔμμορες ἄτης·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="63">δῶκε δʼ ἀνιηρόν τοι Ἰήσονα πῆμα γενέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="64">δαίμων ἀλγινόεις. ἀλλʼ ἔρχεο, τέτλαθι δʼ ἔμπης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="65">καὶ πινυτή περ ἐοῦσα, πολύστονον ἄλγος ἀείρειν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="57"><q rend="double">οὐκ ἄρʼ ἐγὼ μούνη μετὰ Λάτμιον ἄντρον ἀλύσκω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="58"><q rend="double; merge">οὐδʼ οἴη καλῷ περιδαίομαι Ἐνδυμίωνι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="59"><q rend="double; merge">ἦ θαμὰ δὴ καὶ σεῖο κίον δολίῃσιν ἀοιδαῖς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="60"><q rend="double; merge">μνησαμένη φιλότητος, ἵνα σκοτίῃ ἐνὶ νυκτὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="61"><q rend="double; merge">φαρμάσσῃς εὔκηλος, ἅ τοι φίλα ἔργα τέτυκται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="62"><q rend="double; merge">νῦν δὲ καὶ αὐτὴ δῆθεν ὁμοίης ἔμμορες ἄτης·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="63"><q rend="double; merge">δῶκε δʼ ἀνιηρόν τοι Ἰήσονα πῆμα γενέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="64"><q rend="double; merge">δαίμων ἀλγινόεις. ἀλλʼ ἔρχεο, τέτλαθι δʼ ἔμπης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="65"><q rend="double; merge">καὶ πινυτή περ ἐοῦσα, πολύστονον ἄλγος ἀείρειν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="66">ὦς ἄρʼ ἔφη· τὴν δʼ αἶψα πόδες φέρον
 						ἐγκονέουσαν.</l>
@@ -4701,24 +4701,24 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="81">υἷε δύω Φρίξου, χαμάδις θόρον· ἡ δʼ ἄρα τούσγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="82">γούνων ἀμφοτέρῃσι περισχομένη προσέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="83">‘ἔκ με, φίλοι, ῥύσασθε δυσάμμορον, ὧς δὲ καὶ
-						αὐτοὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="84">ὑμέας Αἰήταο, πρὸ γάρ τʼ ἀναφανδὰ τέτυκται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="85">πάντα μάλʼ, οὐδέ τι μῆχος ἱκάνεται. ἀλλʼ ἐπὶ νηὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="86">φεύγωμεν, πρὶν τόνδε θοῶν ἐπιβήμεναι ἵππων.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="87">δώσω δὲ χρύσειον ἐγὼ δέρος, εὐνήσασα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="88">φρουρὸν ὄφιν· τύνη δὲ θεοὺς ἐνὶ σοῖσιν ἑταίροις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="89">ξεῖνε, τεῶν μύθων ἐπιίστορας, οὕς μοι ὑπέστης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="90">ποίησαι· μηδʼ ἔνθεν ἑκαστέρω ὁρμηθεῖσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="91">χήτει κηδεμόνων ὀνοτὴν καὶ ἀεικέα θείης.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="83"><q rend="double">ἔκ με, φίλοι, ῥύσασθε δυσάμμορον, ὧς δὲ καὶ
+						αὐτοὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="84"><q rend="double; merge">ὑμέας Αἰήταο, πρὸ γάρ τʼ ἀναφανδὰ τέτυκται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="85"><q rend="double; merge">πάντα μάλʼ, οὐδέ τι μῆχος ἱκάνεται. ἀλλʼ ἐπὶ νηὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="86"><q rend="double; merge">φεύγωμεν, πρὶν τόνδε θοῶν ἐπιβήμεναι ἵππων.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="87"><q rend="double; merge">δώσω δὲ χρύσειον ἐγὼ δέρος, εὐνήσασα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="88"><q rend="double; merge">φρουρὸν ὄφιν· τύνη δὲ θεοὺς ἐνὶ σοῖσιν ἑταίροις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="89"><q rend="double; merge">ξεῖνε, τεῶν μύθων ἐπιίστορας, οὕς μοι ὑπέστης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="90"><q rend="double; merge">ποίησαι· μηδʼ ἔνθεν ἑκαστέρω ὁρμηθεῖσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="91"><q rend="double; merge">χήτει κηδεμόνων ὀνοτὴν καὶ ἀεικέα θείης.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="92">Ἴσκεν ἀκηχεμένη· μέγα δὲ φρένες Αἰσονίδαο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="93">γήθεον· αἶψα δέ μιν περὶ γούνασι πεπτηυῖαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="94">ἦκʼ ἀναειρόμενος προσπτύξατο, θάρσυνέν τε·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="95">‘δαιμονίη, Ζεὺς αὐτὸς Ὀλύμπιος ὅρκιος ἔστω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="96">Ἥρη τε Ζυγίη, Διὸς εὐνέτις, ἦ μὲν ἐμοῖσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="97">κουριδίην σε δόμοισιν ἐνιστήσεσθαι ἄκοιτιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="98">εὖτʼ ἂν ἐς Ἑλλάδα γαῖαν ἱκώμεθα νοστήσαντες.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="95"><q rend="double">δαιμονίη, Ζεὺς αὐτὸς Ὀλύμπιος ὅρκιος ἔστω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="96"><q rend="double; merge">Ἥρη τε Ζυγίη, Διὸς εὐνέτις, ἦ μὲν ἐμοῖσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="97"><q rend="double; merge">κουριδίην σε δόμοισιν ἐνιστήσεσθαι ἄκοιτιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="98"><q rend="double; merge">εὖτʼ ἂν ἐς Ἑλλάδα γαῖαν ἱκώμεθα νοστήσαντες.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="99">ὧς ηὔδα, καὶ χεῖρα παρασχεδὸν ἤραρε χειρὶ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="100">δεξιτερήν· ἡ δέ σφιν ἐς ἱερὸν ἄλσος ἀνώγει</l>
@@ -4817,23 +4817,23 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="188">κάββαλε νηγάτεον· πρύμνῃ δʼ ἐνεείσατο κούρην</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="189">ἀνθέμενος, καὶ τοῖον ἔπος μετὰ πᾶσιν ἔειπεν·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="190">‘μηκέτι νῦν χάζεσθε, φίλοι, πάτρηνδε
-						νέεσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="191">ἤδη γὰρ χρειώ, τῆς εἵνεκα τήνδʼ ἀλεγεινὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="192">ναυτιλίην ἔτλημεν ὀιζύι μοχθίζοντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="193">εὐπαλέως κούρης ὑπὸ δήνεσι κεκράανται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="194">τὴν μὲν ἐγὼν ἐθέλουσαν ἀνάξομαι οἴκαδʼ ἄκοιτιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="195">κουριδίην· ἀτὰρ ὔμμες Ἀχαιίδος οἷά τε πάσης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="196">αὐτῶν θʼ ὑμείων ἐσθλὴν ἐπαρωγὸν ἐοῦσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="197">σώετε. δὴ γάρ που, μάλʼ ὀίομαι, εἶσιν ἐρύξων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="198">Αἰήτης ὁμάδῳ πόντονδʼ ἴμεν ἐκ ποταμοῖο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="199">ἀλλʼ οἱ μὲν διὰ νηός, ἀμοιβαδὶς ἀνέρος ἀνὴρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="200">ἑζόμενος, πηδοῖσιν ἐρέσσετε· τοὶ δὲ βοείας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="201">ἀσπίδας ἡμίσεες, δῄων θοὸν ἔχμα βολάων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="202">προσχόμενοι νόστῳ ἐπαμύνετε. νῦν δʼ ἐνὶ χερσὶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="203">παῖδας ἑοὺς πάτρην τε φίλην, γεραρούς τε τοκῆας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="204">ἴσχομεν· ἡμετέρῃ δʼ ἐπερείδεται Ἑλλὰς ἐφορμῇ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="205">ἠὲ κατηφείην, ἢ καὶ μέγα κῦδος ἀρέσθαι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="190"><q rend="double">μηκέτι νῦν χάζεσθε, φίλοι, πάτρηνδε
+						νέεσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="191"><q rend="double; merge">ἤδη γὰρ χρειώ, τῆς εἵνεκα τήνδʼ ἀλεγεινὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="192"><q rend="double; merge">ναυτιλίην ἔτλημεν ὀιζύι μοχθίζοντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="193"><q rend="double; merge">εὐπαλέως κούρης ὑπὸ δήνεσι κεκράανται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="194"><q rend="double; merge">τὴν μὲν ἐγὼν ἐθέλουσαν ἀνάξομαι οἴκαδʼ ἄκοιτιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="195"><q rend="double; merge">κουριδίην· ἀτὰρ ὔμμες Ἀχαιίδος οἷά τε πάσης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="196"><q rend="double; merge">αὐτῶν θʼ ὑμείων ἐσθλὴν ἐπαρωγὸν ἐοῦσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="197"><q rend="double; merge">σώετε. δὴ γάρ που, μάλʼ ὀίομαι, εἶσιν ἐρύξων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="198"><q rend="double; merge">Αἰήτης ὁμάδῳ πόντονδʼ ἴμεν ἐκ ποταμοῖο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="199"><q rend="double; merge">ἀλλʼ οἱ μὲν διὰ νηός, ἀμοιβαδὶς ἀνέρος ἀνὴρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="200"><q rend="double; merge">ἑζόμενος, πηδοῖσιν ἐρέσσετε· τοὶ δὲ βοείας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="201"><q rend="double; merge">ἀσπίδας ἡμίσεες, δῄων θοὸν ἔχμα βολάων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="202"><q rend="double; merge">προσχόμενοι νόστῳ ἐπαμύνετε. νῦν δʼ ἐνὶ χερσὶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="203"><q rend="double; merge">παῖδας ἑοὺς πάτρην τε φίλην, γεραρούς τε τοκῆας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="204"><q rend="double; merge">ἴσχομεν· ἡμετέρῃ δʼ ἐπερείδεται Ἑλλὰς ἐφορμῇ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="205"><q rend="double; merge">ἠὲ κατηφείην, ἢ καὶ μέγα κῦδος ἀρέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="206">ὧς φάτο, δῦνε δὲ τεύχεʼ ἀρήια· τοὶ δʼ ἰάχησαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="207">θεσπέσιον μεμαῶτες. ὁ δὲ ξίφος ἐκ κολεοῖο</l>
@@ -4892,43 +4892,43 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="255">ἐξ Αἴης ἔσσεσθαι· ἀνώιστος δʼ ἐτέτυκτο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="256">πᾶσιν ὁμῶς. Ἄργος δὲ λιλαιομένοις ἀγόρευσεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="257">‘Νισσόμεθʼ Ὀρχομενὸν τὴν ἔχραεν ὔμμι περῆσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="258">νημερτὴς ὅδε μάντις, ὅτῳ ξυνέβητε πάροιθεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="259">ἔστιν γὰρ πλόος ἄλλος, ὃν ἀθανάτων ἱερῆες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="260">πέφραδον, οἳ Θήβης Τριτωνίδος ἐκγεγάασιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="261">οὔπω τείρεα πάντα, τά τʼ οὐρανῷ εἱλίσσονται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="262">οὐδέ τί πω Δαναῶν ἱερὸν γένος ἦεν ἀκοῦσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="263">πευθομένοις· οἶοι δʼ ἔσαν Ἀρκάδες Ἀπιδανῆες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="264">Ἀρκάδες, οἳ καὶ πρόσθε σεληναίης ὑδέονται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="265">ζώειν, φηγὸν ἔδοντες ἐν οὔρεσιν. οὐδὲ Πελασγὶς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="266">χθὼν τότε κυδαλίμοισιν ἀνάσσετο Δευκαλίδῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="267">ἦμος ὅτʼ Ἠερίη πολυλήιος ἐκλήιστο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="268">μήτηρ Αἴγυπτος προτερηγενέων αἰζηῶν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="269">καὶ ποταμὸς Τρίτων ἠύρροος, ᾧ ὕπο πᾶσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="270">ἄρδεται Ἠερίη· Διόθεν δέ μιν οὔποτε δεύει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="271">ὄμβρος· ἅλις προχοῇσι δʼ ἀνασταχύουσιν ἄρουραι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="272">ἔνθεν δή τινά φασι πέριξ διὰ πᾶσαν ὁδεῦσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="273">Εὐρώπην Ἀσίην τε βίῃ καὶ κάρτεϊ λαῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="274">σφωιτέρων θάρσει τε πεποιθότα· μυρία δʼ ἄστη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="275">νάσσατʼ ἐποιχόμενος, τὰ μὲν ἤ ποθι ναιετάουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="276">ἠὲ καὶ οὔ· πουλὺς γὰρ ἄδην ἐπενήνοθεν αἰών.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="277">αἶά γε μὴν ἔτι νῦν μένει ἔμπεδον υἱωνοί τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="278">τῶνδʼ ἀνδρῶν, οὓς ὅσγε καθίσσατο ναιέμεν Αἶαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="279">οἳ δή τοι γραπτῦς πατέρων ἕθεν εἰρύονται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="280">κύρβιας, οἷς ἔνι πᾶσαι ὁδοὶ καὶ πείρατʼ ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="281">ὑγρῆς τε τραφερῆς τε πέριξ ἐπινισσομένοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="282">ἔστι δέ τις ποταμός, ὕπατον κέρας Ὠκεανοῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="283">εὐρύς τε προβαθής τε καὶ ὁλκάδι νηὶ περῆσαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="284">Ἴστρον μιν καλέοντες ἑκὰς διετεκμήραντο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="285">ὅς δή τοι τείως μὲν ἀπείρονα τέμνετʼ ἄρουραν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="286">εἷς οἶος· πηγαὶ γὰρ ὑπὲρ πνοιῆς βορέαο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="287">Ῥιπαίοις ἐν ὄρεσσιν ἀπόπροθι μορμύρουσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="288">ἀλλʼ ὁπόταν Θρῃκῶν Σκυθέων τʼ ἐπιβήσεται οὔρους,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="289">ἔνθα διχῆ τὸ μὲν ἔνθα μετʼ ἠῴην ἅλα βάλλει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="290">τῇδʼ ὕδωρ, τὸ δʼ ὄπισθε βαθὺν διὰ κόλπον ἵησιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="291">σχιζόμενος πόντου Τρινακρίου εἰσανέχοντα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="292">γαίῃ ὃς ὑμετέρῃ παρακέκλιται, εἰ ἐτεὸν δὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="293">ὑμετέρης γαίης Ἀχελώιος ἐξανίησιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="257"><q rend="double">Νισσόμεθʼ Ὀρχομενὸν τὴν ἔχραεν ὔμμι περῆσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="258"><q rend="double; merge">νημερτὴς ὅδε μάντις, ὅτῳ ξυνέβητε πάροιθεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="259"><q rend="double; merge">ἔστιν γὰρ πλόος ἄλλος, ὃν ἀθανάτων ἱερῆες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="260"><q rend="double; merge">πέφραδον, οἳ Θήβης Τριτωνίδος ἐκγεγάασιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="261"><q rend="double; merge">οὔπω τείρεα πάντα, τά τʼ οὐρανῷ εἱλίσσονται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="262"><q rend="double; merge">οὐδέ τί πω Δαναῶν ἱερὸν γένος ἦεν ἀκοῦσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="263"><q rend="double; merge">πευθομένοις· οἶοι δʼ ἔσαν Ἀρκάδες Ἀπιδανῆες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="264"><q rend="double; merge">Ἀρκάδες, οἳ καὶ πρόσθε σεληναίης ὑδέονται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="265"><q rend="double; merge">ζώειν, φηγὸν ἔδοντες ἐν οὔρεσιν. οὐδὲ Πελασγὶς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="266"><q rend="double; merge">χθὼν τότε κυδαλίμοισιν ἀνάσσετο Δευκαλίδῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="267"><q rend="double; merge">ἦμος ὅτʼ Ἠερίη πολυλήιος ἐκλήιστο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="268"><q rend="double; merge">μήτηρ Αἴγυπτος προτερηγενέων αἰζηῶν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="269"><q rend="double; merge">καὶ ποταμὸς Τρίτων ἠύρροος, ᾧ ὕπο πᾶσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="270"><q rend="double; merge">ἄρδεται Ἠερίη· Διόθεν δέ μιν οὔποτε δεύει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="271"><q rend="double; merge">ὄμβρος· ἅλις προχοῇσι δʼ ἀνασταχύουσιν ἄρουραι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="272"><q rend="double; merge">ἔνθεν δή τινά φασι πέριξ διὰ πᾶσαν ὁδεῦσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="273"><q rend="double; merge">Εὐρώπην Ἀσίην τε βίῃ καὶ κάρτεϊ λαῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="274"><q rend="double; merge">σφωιτέρων θάρσει τε πεποιθότα· μυρία δʼ ἄστη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="275"><q rend="double; merge">νάσσατʼ ἐποιχόμενος, τὰ μὲν ἤ ποθι ναιετάουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="276"><q rend="double; merge">ἠὲ καὶ οὔ· πουλὺς γὰρ ἄδην ἐπενήνοθεν αἰών.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="277"><q rend="double; merge">αἶά γε μὴν ἔτι νῦν μένει ἔμπεδον υἱωνοί τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="278"><q rend="double; merge">τῶνδʼ ἀνδρῶν, οὓς ὅσγε καθίσσατο ναιέμεν Αἶαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="279"><q rend="double; merge">οἳ δή τοι γραπτῦς πατέρων ἕθεν εἰρύονται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="280"><q rend="double; merge">κύρβιας, οἷς ἔνι πᾶσαι ὁδοὶ καὶ πείρατʼ ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="281"><q rend="double; merge">ὑγρῆς τε τραφερῆς τε πέριξ ἐπινισσομένοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="282"><q rend="double; merge">ἔστι δέ τις ποταμός, ὕπατον κέρας Ὠκεανοῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="283"><q rend="double; merge">εὐρύς τε προβαθής τε καὶ ὁλκάδι νηὶ περῆσαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="284"><q rend="double; merge">Ἴστρον μιν καλέοντες ἑκὰς διετεκμήραντο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="285"><q rend="double; merge">ὅς δή τοι τείως μὲν ἀπείρονα τέμνετʼ ἄρουραν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="286"><q rend="double; merge">εἷς οἶος· πηγαὶ γὰρ ὑπὲρ πνοιῆς βορέαο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="287"><q rend="double; merge">Ῥιπαίοις ἐν ὄρεσσιν ἀπόπροθι μορμύρουσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="288"><q rend="double; merge">ἀλλʼ ὁπόταν Θρῃκῶν Σκυθέων τʼ ἐπιβήσεται οὔρους,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="289"><q rend="double; merge">ἔνθα διχῆ τὸ μὲν ἔνθα μετʼ ἠῴην ἅλα βάλλει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="290"><q rend="double; merge">τῇδʼ ὕδωρ, τὸ δʼ ὄπισθε βαθὺν διὰ κόλπον ἵησιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="291"><q rend="double; merge">σχιζόμενος πόντου Τρινακρίου εἰσανέχοντα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="292"><q rend="double; merge">γαίῃ ὃς ὑμετέρῃ παρακέκλιται, εἰ ἐτεὸν δὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="293"><q rend="double; merge">ὑμετέρης γαίης Ἀχελώιος ἐξανίησιν.</q></l>
 					          <milestone n="294" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="294">ὧς ἄρʼ ἔφη· τοῖσιν δὲ θεὰ τέρας ἐγγυάλιξεν</l>
@@ -4997,79 +4997,79 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="352">νωλεμές· αἶψα δὲ νόσφιν Ἰήσονα μοῦνον ἑταίρων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="353">ἐκπροκαλεσσαμένη ἄγεν ἄλλυδις, ὄφρʼ ἐλίασθεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="354">πολλὸν ἑκάς, στονόεντα δʼ ἐνωπαδὶς ἔκφατο μῦθον·</l>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="355">‘Αἰσονίδη, τίνα τήνδε συναρτύνασθε
-						μενοινὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="356">ἀμφʼ ἐμοί; ἦέ σε πάγχυ λαθιφροσύναις ἐνέηκαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="357">ἀγλαΐαι, τῶν δʼ οὔτι μετατρέπῃ, ὅσσʼ ἀγόρευες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="358">χρειοῖ ἐνισχόμενος; ποῦ τοι Διὸς Ἱκεσίοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="359">ὅρκια, ποῦ δὲ μελιχραὶ ὑποσχεσίαι βεβάασιν;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="360">ᾗς ἐγὼ οὐ κατὰ κόσμον ἀναιδήτῳ ἰότητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="361">πάτρην τε κλέα τε μεγάρων αὐτούς τε τοκῆας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="362">νοσφισάμην, τά μοι ἦεν ὑπέρτατα· τηλόθι δʼ οἴη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="363">λυγρῇσιν κατὰ πόντον ἅμʼ ἀλκυόνεσσι φορεῦμαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="364">σῶν ἕνεκεν καμάτων, ἵνα μοι σόος ἀμφί τε βουσὶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="365">ἀμφί τε γηγενέεσσιν ἀναπλήσειας ἀέθλους.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="366">ὕστατον αὖ καὶ κῶας, ἐπεί τʼ ἐπαϊστὸν ἐτύχθη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="367">εἷλες ἐμῇ ματίῃ· κατὰ δʼ οὐλοὸν αἶσχος ἔχευα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="368">θηλυτέραις. τῶ φημὶ τεὴ κούρη τε δάμαρ τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="369">αὐτοκασιγνήτη τε μεθʼ Ἑλλάδα γαῖαν ἕπεσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="370">πάντῃ νυν πρόφρων ὑπερίστασο, μηδέ με μούνην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="371">σεῖο λίπῃς ἀπάνευθεν, ἐποιχόμενος βασιλῆας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="372">ἀλλʼ αὔτως εἴρυσο· δίκη δέ τοι ἔμπεδος ἔστω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="373">καὶ θέμις, ἣν ἄμφω συναρέσσαμεν· ἢ σύγʼ ἔπειτα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="374">φασγάνῳ αὐτίκα τόνδε μέσον διὰ λαιμὸν ἀμῆσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="375">ὄφρʼ ἐπίηρα φέρωμαι ἐοικότα μαργοσύνῃσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="376">σχετλίη, εἴ κεν δή με κασιγνήτοιο δικάσσῃ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="377">ἔμμεναι οὗτος ἄναξ, τῷ ἐπίσχετε τάσδʼ ἀλεγεινὰς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="378">ἄμφω συνθεσίας. πῶς ἵξομαι ὄμματα πατρός;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="379">ἦ μάλʼ ἐυκλειής; τίνα δʼ οὐ τίσιν, ἠὲ βαρεῖαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="380">ἄτην οὐ σμυγερῶς δεινῶν ὕπερ, οἷα ἔοργα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="381">ὀτλήσω; σὺ δέ κεν θυμηδέα νόστον ἕλοιο;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="382">μὴ τόγε παμβασίλεια Διὸς τελέσειεν ἄκοιτις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="383">ᾗ ἐπικυδιάεις. μνήσαιο δέ καί ποτʼ ἐμεῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="384">στρευγόμενος καμάτοισι· δέρος δέ τοι ἶσον ὀνείροις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="385">οἴχοιτʼ εἰς ἔρεβος μεταμώνιον. ἐκ δέ σε πάτρης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="386">αὐτίκʼ ἐμαί σʼ ἐλάσειαν Ἐρινύες· οἷα καὶ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="387">σῇ πάθον ἀτροπίῃ. τὰ μὲν οὐ θέμις ἀκράαντα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="388">ἐν γαίῃ πεσέειν. μάλα γὰρ μέγαν ἤλιτες ὅρκον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="389">νηλεές· ἀλλʼ οὔ θήν μοι ἐπιλλίζοντες ὀπίσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="390">δὴν ἔσσεσθʼ εὔκηλοι ἕκητί γε συνθεσιάων.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="355"><q rend="double">Αἰσονίδη, τίνα τήνδε συναρτύνασθε
+						μενοινὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="356"><q rend="double; merge">ἀμφʼ ἐμοί; ἦέ σε πάγχυ λαθιφροσύναις ἐνέηκαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="357"><q rend="double; merge">ἀγλαΐαι, τῶν δʼ οὔτι μετατρέπῃ, ὅσσʼ ἀγόρευες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="358"><q rend="double; merge">χρειοῖ ἐνισχόμενος; ποῦ τοι Διὸς Ἱκεσίοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="359"><q rend="double; merge">ὅρκια, ποῦ δὲ μελιχραὶ ὑποσχεσίαι βεβάασιν;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="360"><q rend="double; merge">ᾗς ἐγὼ οὐ κατὰ κόσμον ἀναιδήτῳ ἰότητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="361"><q rend="double; merge">πάτρην τε κλέα τε μεγάρων αὐτούς τε τοκῆας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="362"><q rend="double; merge">νοσφισάμην, τά μοι ἦεν ὑπέρτατα· τηλόθι δʼ οἴη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="363"><q rend="double; merge">λυγρῇσιν κατὰ πόντον ἅμʼ ἀλκυόνεσσι φορεῦμαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="364"><q rend="double; merge">σῶν ἕνεκεν καμάτων, ἵνα μοι σόος ἀμφί τε βουσὶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="365"><q rend="double; merge">ἀμφί τε γηγενέεσσιν ἀναπλήσειας ἀέθλους.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="366"><q rend="double; merge">ὕστατον αὖ καὶ κῶας, ἐπεί τʼ ἐπαϊστὸν ἐτύχθη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="367"><q rend="double; merge">εἷλες ἐμῇ ματίῃ· κατὰ δʼ οὐλοὸν αἶσχος ἔχευα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="368"><q rend="double; merge">θηλυτέραις. τῶ φημὶ τεὴ κούρη τε δάμαρ τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="369"><q rend="double; merge">αὐτοκασιγνήτη τε μεθʼ Ἑλλάδα γαῖαν ἕπεσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="370"><q rend="double; merge">πάντῃ νυν πρόφρων ὑπερίστασο, μηδέ με μούνην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="371"><q rend="double; merge">σεῖο λίπῃς ἀπάνευθεν, ἐποιχόμενος βασιλῆας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="372"><q rend="double; merge">ἀλλʼ αὔτως εἴρυσο· δίκη δέ τοι ἔμπεδος ἔστω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="373"><q rend="double; merge">καὶ θέμις, ἣν ἄμφω συναρέσσαμεν· ἢ σύγʼ ἔπειτα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="374"><q rend="double; merge">φασγάνῳ αὐτίκα τόνδε μέσον διὰ λαιμὸν ἀμῆσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="375"><q rend="double; merge">ὄφρʼ ἐπίηρα φέρωμαι ἐοικότα μαργοσύνῃσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="376"><q rend="double; merge">σχετλίη, εἴ κεν δή με κασιγνήτοιο δικάσσῃ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="377"><q rend="double; merge">ἔμμεναι οὗτος ἄναξ, τῷ ἐπίσχετε τάσδʼ ἀλεγεινὰς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="378"><q rend="double; merge">ἄμφω συνθεσίας. πῶς ἵξομαι ὄμματα πατρός;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="379"><q rend="double; merge">ἦ μάλʼ ἐυκλειής; τίνα δʼ οὐ τίσιν, ἠὲ βαρεῖαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="380"><q rend="double; merge">ἄτην οὐ σμυγερῶς δεινῶν ὕπερ, οἷα ἔοργα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="381"><q rend="double; merge">ὀτλήσω; σὺ δέ κεν θυμηδέα νόστον ἕλοιο;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="382"><q rend="double; merge">μὴ τόγε παμβασίλεια Διὸς τελέσειεν ἄκοιτις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="383"><q rend="double; merge">ᾗ ἐπικυδιάεις. μνήσαιο δέ καί ποτʼ ἐμεῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="384"><q rend="double; merge">στρευγόμενος καμάτοισι· δέρος δέ τοι ἶσον ὀνείροις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="385"><q rend="double; merge">οἴχοιτʼ εἰς ἔρεβος μεταμώνιον. ἐκ δέ σε πάτρης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="386"><q rend="double; merge">αὐτίκʼ ἐμαί σʼ ἐλάσειαν Ἐρινύες· οἷα καὶ αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="387"><q rend="double; merge">σῇ πάθον ἀτροπίῃ. τὰ μὲν οὐ θέμις ἀκράαντα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="388"><q rend="double; merge">ἐν γαίῃ πεσέειν. μάλα γὰρ μέγαν ἤλιτες ὅρκον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="389"><q rend="double; merge">νηλεές· ἀλλʼ οὔ θήν μοι ἐπιλλίζοντες ὀπίσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="390"><q rend="double; merge">δὴν ἔσσεσθʼ εὔκηλοι ἕκητί γε συνθεσιάων.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="391">ὧς φάτʼ ἀναζείουσα βαρὺν χόλον· ἵετο δʼ ἥγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="392">νῆα καταφλέξαι, διά τʼ ἔμπεδα πάντα κεάσσαι,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="393">ἐν δὲ πεσεῖν αὐτὴ μαλερῷ πυρί. τοῖα δʼ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="394">μειλιχίοις ἐπέεσσιν ὑποδδείσας προσέειπεν·</l>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="395">‘ἴσχεο, δαιμονίη· τὰ μὲν ἁνδάνει οὐδʼ ἐμοὶ
-						αὐτῷ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="396">ἀλλά τινʼ ἀμβολίην διζήμεθα δηιοτῆτος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="397">ὅσσον δυσμενέων ἀνδρῶν νέφος ἀμφιδέδηεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="398">εἵνεκα σεῦ. πάντες γάρ, ὅσοι χθόνα τήνδε νέμονται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="399">Ἀψύρτῳ μεμάασιν ἀμυνέμεν, ὄφρα σε πατρί,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="400">οἷά τε ληισθεῖσαν, ὑπότροπον οἴκαδʼ ἄγοιντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="401">αὐτοὶ δὲ στυγερῷ κεν ὀλοίμεθα πάντες ὀλέθρῳ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="402">μίξαντες δαῒ χεῖρας· ὅ τοι καὶ ῥίγιον ἄλγος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="403">ἔσσεται, εἴ σε θανόντες ἕλωρ κείνοισι λίποιμεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="404">ἥδε δὲ συνθεσίη κρανέει δόλον, ᾧ μιν ἐς ἄτην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="405">βήσομεν. οὐδʼ ἂν ὁμῶς περιναιέται ἀντιόωσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="406">Κόλχοις ἦρα φέροντες ὑπὲρ σέο νόσφιν ἄνακτος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="407">ὅς τοι ἀοσσητήρ τε κασίγνητός τε τέτυκται·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="408">οὐδʼ ἂν ἐγὼ Κόλχοισιν ὑπείξω μὴ πολεμίζειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="409">ἀντιβίην, ὅτε μή με διὲξ εἰῶσι νέεσθαι.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="395"><q rend="double">ἴσχεο, δαιμονίη· τὰ μὲν ἁνδάνει οὐδʼ ἐμοὶ
+						αὐτῷ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="396"><q rend="double; merge">ἀλλά τινʼ ἀμβολίην διζήμεθα δηιοτῆτος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="397"><q rend="double; merge">ὅσσον δυσμενέων ἀνδρῶν νέφος ἀμφιδέδηεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="398"><q rend="double; merge">εἵνεκα σεῦ. πάντες γάρ, ὅσοι χθόνα τήνδε νέμονται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="399"><q rend="double; merge">Ἀψύρτῳ μεμάασιν ἀμυνέμεν, ὄφρα σε πατρί,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="400"><q rend="double; merge">οἷά τε ληισθεῖσαν, ὑπότροπον οἴκαδʼ ἄγοιντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="401"><q rend="double; merge">αὐτοὶ δὲ στυγερῷ κεν ὀλοίμεθα πάντες ὀλέθρῳ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="402"><q rend="double; merge">μίξαντες δαῒ χεῖρας· ὅ τοι καὶ ῥίγιον ἄλγος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="403"><q rend="double; merge">ἔσσεται, εἴ σε θανόντες ἕλωρ κείνοισι λίποιμεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="404"><q rend="double; merge">ἥδε δὲ συνθεσίη κρανέει δόλον, ᾧ μιν ἐς ἄτην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="405"><q rend="double; merge">βήσομεν. οὐδʼ ἂν ὁμῶς περιναιέται ἀντιόωσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="406"><q rend="double; merge">Κόλχοις ἦρα φέροντες ὑπὲρ σέο νόσφιν ἄνακτος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="407"><q rend="double; merge">ὅς τοι ἀοσσητήρ τε κασίγνητός τε τέτυκται·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="408"><q rend="double; merge">οὐδʼ ἂν ἐγὼ Κόλχοισιν ὑπείξω μὴ πολεμίζειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="409"><q rend="double; merge">ἀντιβίην, ὅτε μή με διὲξ εἰῶσι νέεσθαι.</q></l>
 					          <milestone n="410" unit="card"/>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="410">Ἴσκεν ὑποσσαίνων· ἡ δʼ οὐλοὸν ἔκφατο
 						μῦθον·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="411">‘φράζεο νῦν. χρειὼ γὰρ ἀεικελίοισιν ἐπʼ ἔργοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="412">καὶ τόδε μητίσασθαι, ἐπεὶ τὸ πρῶτον ἀάσθην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="413">ἀμπλακίῃ, θεόθεν δὲ κακὰς ἤνυσσα μενοινάς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="414">τύνη μὲν κατὰ μῶλον ἀλέξεο δούρατα Κόλχων·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="415">αὐτὰρ ἐγὼ κεῖνόν γε τεὰς ἐς χεῖρας ἱκέσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="416">μειλίξω· σὺ δέ μιν φαιδροῖς ἀγαπάζεο δώροις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="417">εἴ κέν πως κήρυκας ἀπερχομένους πεπίθοιμι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="418">οἰόθεν οἶον ἐμοῖσι συναρθμῆσαι ἐπέεσσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="419">ἔνθʼ εἴ τοι τόδε ἔργον ἐφανδάνει, οὔτι μεγαίρω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="420">κτεῖνέ τε, καὶ Κόλχοισιν ἀείρεο δηιοτῆτα.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="411"><q rend="double">φράζεο νῦν. χρειὼ γὰρ ἀεικελίοισιν ἐπʼ ἔργοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="412"><q rend="double; merge">καὶ τόδε μητίσασθαι, ἐπεὶ τὸ πρῶτον ἀάσθην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="413"><q rend="double; merge">ἀμπλακίῃ, θεόθεν δὲ κακὰς ἤνυσσα μενοινάς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="414"><q rend="double; merge">τύνη μὲν κατὰ μῶλον ἀλέξεο δούρατα Κόλχων·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="415"><q rend="double; merge">αὐτὰρ ἐγὼ κεῖνόν γε τεὰς ἐς χεῖρας ἱκέσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="416"><q rend="double; merge">μειλίξω· σὺ δέ μιν φαιδροῖς ἀγαπάζεο δώροις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="417"><q rend="double; merge">εἴ κέν πως κήρυκας ἀπερχομένους πεπίθοιμι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="418"><q rend="double; merge">οἰόθεν οἶον ἐμοῖσι συναρθμῆσαι ἐπέεσσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="419"><q rend="double; merge">ἔνθʼ εἴ τοι τόδε ἔργον ἐφανδάνει, οὔτι μεγαίρω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="420"><q rend="double; merge">κτεῖνέ τε, καὶ Κόλχοισιν ἀείρεο δηιοτῆτα.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="421">ὧς τώγε ξυμβάντε μέγαν δόλον ἠρτύνοντο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="422">Ἀψύρτῳ, καὶ πολλὰ πόρον ξεινήια δῶρα,</l>
@@ -5151,15 +5151,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="492">ἔνθα δὲ ναυτιλίης πυκινὴν περὶ μητιάασκον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="493">ἑζόμενοι βουλήν· ἐπὶ δέ σφισιν ἤλυθε κούρη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="494">φραζομένοις· Πηλεὺς δὲ παροίτατος ἔκφατο μῦθον·</l>
-					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="495">‘ἤδη νῦν κέλομαι νύκτωρ ἔτι νῆʼ
-						ἐπιβάντας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="496">εἰρεσίῃ περάαν πλόον ἀντίον, ᾧ ἐπέχουσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="497">δήιοι· ἠῶθεν γὰρ ἐπαθρήσαντας ἕκαστα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="498">ἔλπομαι οὐχ ἕνα μῦθον, ὅτις προτέρωσε δίεσθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="499">ἡμέας ὀτρυνέει, τοὺς πεισέμεν· οἷα δʼ ἄνακτος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="500">εὔνιδες, ἀργαλέῃσι διχοστασίῃς κεδόωνται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="501">ῥηιδίη δέ κεν ἄμμι, κεδασθέντων δίχα λαῶν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="502">ἤ τʼ εἴη μετέπειτα κατερχομένοισι κέλευθος.’</l>
+					          <milestone unit="para"/><l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="495"><q rend="double">ἤδη νῦν κέλομαι νύκτωρ ἔτι νῆʼ
+						ἐπιβάντας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="496"><q rend="double; merge">εἰρεσίῃ περάαν πλόον ἀντίον, ᾧ ἐπέχουσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="497"><q rend="double; merge">δήιοι· ἠῶθεν γὰρ ἐπαθρήσαντας ἕκαστα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="498"><q rend="double; merge">ἔλπομαι οὐχ ἕνα μῦθον, ὅτις προτέρωσε δίεσθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="499"><q rend="double; merge">ἡμέας ὀτρυνέει, τοὺς πεισέμεν· οἷα δʼ ἄνακτος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="500"><q rend="double; merge">εὔνιδες, ἀργαλέῃσι διχοστασίῃς κεδόωνται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="501"><q rend="double; merge">ῥηιδίη δέ κεν ἄμμι, κεδασθέντων δίχα λαῶν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="502"><q rend="double; merge">ἤ τʼ εἴη μετέπειτα κατερχομένοισι κέλευθος.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="503">ὧς ἔφατʼ· ᾔνησαν δὲ νέοι ἔπος Λἰακίδαο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="504">ῥίμφα δὲ νῆʼ ἐπιβάντες ἐπερρώοντʼ ἐλάτῃσιν</l>
@@ -5411,16 +5411,16 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="738">μυρομένην ἐλέαιρεν, ἔπος δʼ ἐπὶ τοῖον ἔειπεν·</l>
 					          <milestone n="739" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="739">‘σχετλίη, ἦ ῥα κακὸν καὶ ἀεικέα μήσαο νόστον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="740">ἔλπομαι οὐκ ἐπὶ δήν σε βαρὺν χόλον Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="741">ἐκφυγέειν· τάχα δʼ εἶσι καὶ Ἑλλάδος ἤθεα γαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="742">τισόμενος φόνον υἷος, ὅτʼ ἄσχετα ἔργʼ ἐτέλεσσας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="743">ἀλλʼ ἐπεὶ οὖν ἱκέτις καὶ ὁμόγνιος ἔπλευ ἐμεῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="744">ἄλλο μὲν οὔτι κακὸν μητίσομαι ἐνθάδʼ ἰούσῃ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="745">ἔρχεο δʼ ἐκ μεγάρων ξείνῳ συνοπηδὸς ἐοῦσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="746">ὅντινα τοῦτον ἄιστον ἀείραο πατρὸς ἄνευθεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="747">μηδέ με γουνάσσηαι ἐφέστιος, οὐ γὰρ ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="748">αἰνήσω βουλάς τε σέθεν καὶ ἀεικέα φύξιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="739"><q rend="double">σχετλίη, ἦ ῥα κακὸν καὶ ἀεικέα μήσαο νόστον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="740"><q rend="double; merge">ἔλπομαι οὐκ ἐπὶ δήν σε βαρὺν χόλον Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="741"><q rend="double; merge">ἐκφυγέειν· τάχα δʼ εἶσι καὶ Ἑλλάδος ἤθεα γαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="742"><q rend="double; merge">τισόμενος φόνον υἷος, ὅτʼ ἄσχετα ἔργʼ ἐτέλεσσας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="743"><q rend="double; merge">ἀλλʼ ἐπεὶ οὖν ἱκέτις καὶ ὁμόγνιος ἔπλευ ἐμεῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="744"><q rend="double; merge">ἄλλο μὲν οὔτι κακὸν μητίσομαι ἐνθάδʼ ἰούσῃ·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="745"><q rend="double; merge">ἔρχεο δʼ ἐκ μεγάρων ξείνῳ συνοπηδὸς ἐοῦσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="746"><q rend="double; merge">ὅντινα τοῦτον ἄιστον ἀείραο πατρὸς ἄνευθεν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="747"><q rend="double; merge">μηδέ με γουνάσσηαι ἐφέστιος, οὐ γὰρ ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="748"><q rend="double; merge">αἰνήσω βουλάς τε σέθεν καὶ ἀεικέα φύξιν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="749">ὧς φάτο· τὴν δʼ ἀμέγαρτον ἄχος λάβεν· ἀμφὶ δὲ
 						πέπλον</l>
@@ -5433,20 +5433,20 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="755">αὐτὴ γάρ μιν ἄνωγε δοκευέμεν, ὁππότε νῆα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="756">στείχοιεν· τὸ καὶ αὖτις ἐποτρύνουσʼ ἀγόρευεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="757">‘Ἶρι φίλη, νῦν, εἴ ποτʼ ἐμὰς ἐτέλεσσας
-						ἐφετμάς,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="758">εἰ δʼ ἄγε λαιψηρῇσι μετοιχομένη πτερύγεσσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="759">δεῦρο Θέτιν μοι ἄνωχθι μολεῖν ἁλὸς ἐξανιοῦσαν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="760">κείνης γὰρ χρειώ με κιχάνεται. αὐτὰρ ἔπειτα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="761">ἐλθεῖν εἰς ἀκτάς, ὅθι τʼ ἄκμονες Ἡφαίστοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="762">χάλκειοι στιβαρῇσιν ἀράσσονται τυπίδεσσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="763">εἰπὲ δὲ κοιμῆσαι φύσας πυρός, εἰσόκεν Ἀργὼ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="764">τάσγε παρεξελάσῃσιν. ἀτὰρ καὶ ἐς Αἴολον ἐλθεῖν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="765">Αἴολον, ὅς τʼ ἀνέμοις αἰθρηγενέεσσιν ἀνάσσει·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="766">καὶ δὲ τῷ εἰπέμεναι τὸν ἐμὸν νόον, ὥς κεν ἀήτας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="767">πάντας ἀπολλήξειεν ὑπʼ ἠέρι, μηδέ τις αὔρη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="768">τρηχύνοι πέλαγος· Ζεφύρου γε μὲν οὖρος ἀήτω,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="769">ὄφρʼ οἵγʼ Ἀλκινόου Φαιηκίδα νῆσον ἵκωνται.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="757"><q rend="double">Ἶρι φίλη, νῦν, εἴ ποτʼ ἐμὰς ἐτέλεσσας
+						ἐφετμάς,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="758"><q rend="double; merge">εἰ δʼ ἄγε λαιψηρῇσι μετοιχομένη πτερύγεσσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="759"><q rend="double; merge">δεῦρο Θέτιν μοι ἄνωχθι μολεῖν ἁλὸς ἐξανιοῦσαν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="760"><q rend="double; merge">κείνης γὰρ χρειώ με κιχάνεται. αὐτὰρ ἔπειτα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="761"><q rend="double; merge">ἐλθεῖν εἰς ἀκτάς, ὅθι τʼ ἄκμονες Ἡφαίστοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="762"><q rend="double; merge">χάλκειοι στιβαρῇσιν ἀράσσονται τυπίδεσσιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="763"><q rend="double; merge">εἰπὲ δὲ κοιμῆσαι φύσας πυρός, εἰσόκεν Ἀργὼ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="764"><q rend="double; merge">τάσγε παρεξελάσῃσιν. ἀτὰρ καὶ ἐς Αἴολον ἐλθεῖν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="765"><q rend="double; merge">Αἴολον, ὅς τʼ ἀνέμοις αἰθρηγενέεσσιν ἀνάσσει·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="766"><q rend="double; merge">καὶ δὲ τῷ εἰπέμεναι τὸν ἐμὸν νόον, ὥς κεν ἀήτας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="767"><q rend="double; merge">πάντας ἀπολλήξειεν ὑπʼ ἠέρι, μηδέ τις αὔρη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="768"><q rend="double; merge">τρηχύνοι πέλαγος· Ζεφύρου γε μὲν οὖρος ἀήτω,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="769"><q rend="double; merge">ὄφρʼ οἵγʼ Ἀλκινόου Φαιηκίδα νῆσον ἵκωνται.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="770">ὧς ἔφατʼ· αὐτίκα δʼ Ἶρις ἀπʼ Οὐλύμποιο
 						θοροῦσα</l>
@@ -5463,68 +5463,68 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="781">ἐξ ἁλὸς Οὔλυμπόνδε θεὰν μετεκίαθεν Ἥρην·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="782">ἡ δέ μιν ἆσσον ἑοῖο παρεῖσέ τε, φαῖνέ τε μῦθον·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="783">‘κέκλυθι νῦν, Θέτι δῖα, τά τοι ἐπιέλδομʼ
-						ἐνισπεῖν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="784">οἶσθα μέν, ὅσσον ἐμῇσιν ἐνὶ φρεσὶ τίεται ἥρως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="785">Αἰσονίδης, οἱ δʼ ἄλλοι ἀοσσητῆρες ἀέθλου,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="786">οἵως τέ σφʼ ἐσάωσα διὰ πλαγκτὰς περόωντας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="787">πέτρας, ἔνθα πάρος δειναὶ βρομέουσι θύελλαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="788">κύματά τε σκληρῇσι περιβλύει σπιλάδεσσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="789">νῦν δὲ παρὰ Σκύλλης σκόπελον μέγαν ἠδὲ Χάρυβδιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="790">δεινὸν ἐρευγομένην δέχεται ὁδός. ἀλλά σε γὰρ δὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="791">ἐξέτι νηπυτίης αὐτὴ τρέφον ἠδʼ ἀγάπησα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="792">ἔξοχον ἀλλάων, αἵ τʼ εἰν ἁλὶ ναιετάουσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="793">οὕνεκεν οὐκ ἔτλης εὐνῇ Διὸς ἱεμένοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="794">λέξασθαι. κείνῳ γὰρ ἀεὶ τάδε ἔργα μέμηλεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="795">ἠὲ σὺν ἀθανάταις ἠὲ θνητῇσιν ἰαύειν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="796">ἀλλʼ ἐμὲ αἰδομένη καὶ ἐνὶ φρεσὶ δειμαίνουσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="797">ἠλεύω· ὁ δʼ ἔπειτα πελώριον ὅρκον ὄμοσσεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="798">μήποτέ σʼ ἀθανάτοιο θεοῦ καλέεσθαι ἄκοιτιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="799">ἔμπης δʼ οὐ μεθίεσκεν ὀπιπεύων ἀέκουσαν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="800">εἰσότε οἱ πρέσβειρα Θέμις κατέλεξεν ἅπαντα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="801">ὡς δή τοι πέπρωται ἀμείνονα πατρὸς ἑοῖο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="802">παῖδα τεκεῖν· τῶ καί σε λιλαιόμενος μεθέηκεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="803">δείματι, μή τις ἑοῦ ἀντάξιος ἄλλος ἀνάσσοι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="804">ἀθανάτων, ἀλλʼ αἰὲν ἑὸν κράτος εἰρύοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="805">αὐτὰρ ἐγὼ τὸν ἄριστον ἐπιχθονίων πόσιν εἶναι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="806">δῶκά τοι, ὄφρα γάμου θυμηδέος ἀντιάσειας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="807">τέκνα τε φιτύσαιο· θεοὺς δʼ ἐς δαῖτʼ ἐκάλεσσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="808">πάντας ὁμῶς· αὐτὴ δὲ σέλας χείρεσσιν ἀνέσχον</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="809">νυμφίδιον, κείνης ἀγανόφρονος εἵνεκα τιμῆς.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="810">ἀλλʼ ἄγε καί τινά τοι νημερτέα μῦθον ἐνίψω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="811">εὖτʼ ἂν ἐς Ἠλύσιον πεδίον τεὸς υἱὸς ἵκηται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="812">ὃν δὴ νῦν Χείρωνος ἐν ἤθεσι Κενταύροιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="813">νηιάδες κομέουσι τεοῦ λίπτοντα γάλακτος,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="814">χρειώ μιν κούρης πόσιν ἔμμεναι Αἰήταο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="815">Μηδείης· σὺ δʼ ἄρηγε νυῷ ἑκυρή περ ἐοῦσα,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="816">ἠδʼ αὐτῷ Πηλῆι. τί τοι χόλος ἐστήρικται;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="817">ἀάσθη. καὶ γάρ τε θεοὺς ἐπινίσσεται ἄτη.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="818">ναὶ μὲν ἐφημοσύνῃσιν ἐμαῖς Ἥφαιστον ὀίω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="819">λωφήσειν πρήσοντα πυρὸς μένος, Ἱπποτάδην δὲ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="820">Αἴολον ὠκείας ἀνέμων ἄικας ἐρύξειν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="821">νόσφιν ἐυσταθέος ζεφύρου, τείως κεν ἵκωνται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="822">Φαιήκων λιμένας· σὺ δʼ ἀκηδέα μήδεο νόστον.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="823">δεῖμα δέ τοι πέτραι καὶ ὑπέρβια κύματʼ ἔασιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="824">μοῦνον, ἅ κεν τρέψαιο κασιγνήτῃσι σὺν ἄλλαις.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="825">μηδὲ σύγʼ ἠὲ Χάρυβδιν ἀμηχανέοντας ἐάσῃς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="826">ἐσβαλέειν, μὴ πάντας ἀναβρόξασα φέρῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="827">ἠὲ παρὰ Σκύλλης στυγερὸν κευθμῶνα νέεσθαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="828">Σκύλλης Αὐσονίης ὀλοόφρονος, ἣν τέκε Φόρκυι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="829">νυκτιπόλος Ἑκάτη, τήν τε κλείουσι Κράταιιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="830">μή πως σμερδαλέῃσιν ἐπαΐξασα γένυσσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="831">λεκτοὺς ἡρώων δηλήσεται. ἀλλʼ ἔχε νῆα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="832">κεῖσʼ, ὅθι περ τυτθή γε παραίβασις ἔσσετʼ ὀλέθρου.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="783"><q rend="double">κέκλυθι νῦν, Θέτι δῖα, τά τοι ἐπιέλδομʼ
+						ἐνισπεῖν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="784"><q rend="double; merge">οἶσθα μέν, ὅσσον ἐμῇσιν ἐνὶ φρεσὶ τίεται ἥρως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="785"><q rend="double; merge">Αἰσονίδης, οἱ δʼ ἄλλοι ἀοσσητῆρες ἀέθλου,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="786"><q rend="double; merge">οἵως τέ σφʼ ἐσάωσα διὰ πλαγκτὰς περόωντας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="787"><q rend="double; merge">πέτρας, ἔνθα πάρος δειναὶ βρομέουσι θύελλαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="788"><q rend="double; merge">κύματά τε σκληρῇσι περιβλύει σπιλάδεσσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="789"><q rend="double; merge">νῦν δὲ παρὰ Σκύλλης σκόπελον μέγαν ἠδὲ Χάρυβδιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="790"><q rend="double; merge">δεινὸν ἐρευγομένην δέχεται ὁδός. ἀλλά σε γὰρ δὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="791"><q rend="double; merge">ἐξέτι νηπυτίης αὐτὴ τρέφον ἠδʼ ἀγάπησα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="792"><q rend="double; merge">ἔξοχον ἀλλάων, αἵ τʼ εἰν ἁλὶ ναιετάουσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="793"><q rend="double; merge">οὕνεκεν οὐκ ἔτλης εὐνῇ Διὸς ἱεμένοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="794"><q rend="double; merge">λέξασθαι. κείνῳ γὰρ ἀεὶ τάδε ἔργα μέμηλεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="795"><q rend="double; merge">ἠὲ σὺν ἀθανάταις ἠὲ θνητῇσιν ἰαύειν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="796"><q rend="double; merge">ἀλλʼ ἐμὲ αἰδομένη καὶ ἐνὶ φρεσὶ δειμαίνουσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="797"><q rend="double; merge">ἠλεύω· ὁ δʼ ἔπειτα πελώριον ὅρκον ὄμοσσεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="798"><q rend="double; merge">μήποτέ σʼ ἀθανάτοιο θεοῦ καλέεσθαι ἄκοιτιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="799"><q rend="double; merge">ἔμπης δʼ οὐ μεθίεσκεν ὀπιπεύων ἀέκουσαν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="800"><q rend="double; merge">εἰσότε οἱ πρέσβειρα Θέμις κατέλεξεν ἅπαντα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="801"><q rend="double; merge">ὡς δή τοι πέπρωται ἀμείνονα πατρὸς ἑοῖο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="802"><q rend="double; merge">παῖδα τεκεῖν· τῶ καί σε λιλαιόμενος μεθέηκεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="803"><q rend="double; merge">δείματι, μή τις ἑοῦ ἀντάξιος ἄλλος ἀνάσσοι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="804"><q rend="double; merge">ἀθανάτων, ἀλλʼ αἰὲν ἑὸν κράτος εἰρύοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="805"><q rend="double; merge">αὐτὰρ ἐγὼ τὸν ἄριστον ἐπιχθονίων πόσιν εἶναι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="806"><q rend="double; merge">δῶκά τοι, ὄφρα γάμου θυμηδέος ἀντιάσειας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="807"><q rend="double; merge">τέκνα τε φιτύσαιο· θεοὺς δʼ ἐς δαῖτʼ ἐκάλεσσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="808"><q rend="double; merge">πάντας ὁμῶς· αὐτὴ δὲ σέλας χείρεσσιν ἀνέσχον</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="809"><q rend="double; merge">νυμφίδιον, κείνης ἀγανόφρονος εἵνεκα τιμῆς.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="810"><q rend="double; merge">ἀλλʼ ἄγε καί τινά τοι νημερτέα μῦθον ἐνίψω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="811"><q rend="double; merge">εὖτʼ ἂν ἐς Ἠλύσιον πεδίον τεὸς υἱὸς ἵκηται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="812"><q rend="double; merge">ὃν δὴ νῦν Χείρωνος ἐν ἤθεσι Κενταύροιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="813"><q rend="double; merge">νηιάδες κομέουσι τεοῦ λίπτοντα γάλακτος,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="814"><q rend="double; merge">χρειώ μιν κούρης πόσιν ἔμμεναι Αἰήταο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="815"><q rend="double; merge">Μηδείης· σὺ δʼ ἄρηγε νυῷ ἑκυρή περ ἐοῦσα,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="816"><q rend="double; merge">ἠδʼ αὐτῷ Πηλῆι. τί τοι χόλος ἐστήρικται;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="817"><q rend="double; merge">ἀάσθη. καὶ γάρ τε θεοὺς ἐπινίσσεται ἄτη.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="818"><q rend="double; merge">ναὶ μὲν ἐφημοσύνῃσιν ἐμαῖς Ἥφαιστον ὀίω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="819"><q rend="double; merge">λωφήσειν πρήσοντα πυρὸς μένος, Ἱπποτάδην δὲ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="820"><q rend="double; merge">Αἴολον ὠκείας ἀνέμων ἄικας ἐρύξειν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="821"><q rend="double; merge">νόσφιν ἐυσταθέος ζεφύρου, τείως κεν ἵκωνται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="822"><q rend="double; merge">Φαιήκων λιμένας· σὺ δʼ ἀκηδέα μήδεο νόστον.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="823"><q rend="double; merge">δεῖμα δέ τοι πέτραι καὶ ὑπέρβια κύματʼ ἔασιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="824"><q rend="double; merge">μοῦνον, ἅ κεν τρέψαιο κασιγνήτῃσι σὺν ἄλλαις.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="825"><q rend="double; merge">μηδὲ σύγʼ ἠὲ Χάρυβδιν ἀμηχανέοντας ἐάσῃς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="826"><q rend="double; merge">ἐσβαλέειν, μὴ πάντας ἀναβρόξασα φέρῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="827"><q rend="double; merge">ἠὲ παρὰ Σκύλλης στυγερὸν κευθμῶνα νέεσθαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="828"><q rend="double; merge">Σκύλλης Αὐσονίης ὀλοόφρονος, ἣν τέκε Φόρκυι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="829"><q rend="double; merge">νυκτιπόλος Ἑκάτη, τήν τε κλείουσι Κράταιιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="830"><q rend="double; merge">μή πως σμερδαλέῃσιν ἐπαΐξασα γένυσσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="831"><q rend="double; merge">λεκτοὺς ἡρώων δηλήσεται. ἀλλʼ ἔχε νῆα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="832"><q rend="double; merge">κεῖσʼ, ὅθι περ τυτθή γε παραίβασις ἔσσετʼ ὀλέθρου.</q></l>
 					          <milestone n="833" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="833">ὧς φάτο· τὴν δὲ Θέτις τοίῳ προσελέξατο μύθῳ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="834">‘εἰ μὲν δὴ μαλεροῖο πυρὸς μένος ἠδὲ θύελλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="835">ζαχρηεῖς λήξουσιν ἐτήτυμον, ἦ τʼ ἂν ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="836">θαρσαλέη φαίην, καὶ κύματος ἀντιόωντος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="837">νῆα σαωσέμεναι, ζεφύρου λίγα κινυμένοιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="838">ἀλλʼ ὥρη δολιχήν τε καὶ ἄσπετον οἶμον ὁδεύειν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="839">ὄφρα κασιγνήτας μετελεύσομαι, αἵ μοι ἀρωγοὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="840">ἔσσονται, καὶ νηὸς ὅθι πρυμνήσιʼ ἀνῆπται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="841">ὥς κεν ὑπηῷοι μνησαίατο νόστον ἑλέσθαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="834"><q rend="double">εἰ μὲν δὴ μαλεροῖο πυρὸς μένος ἠδὲ θύελλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="835"><q rend="double; merge">ζαχρηεῖς λήξουσιν ἐτήτυμον, ἦ τʼ ἂν ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="836"><q rend="double; merge">θαρσαλέη φαίην, καὶ κύματος ἀντιόωντος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="837"><q rend="double; merge">νῆα σαωσέμεναι, ζεφύρου λίγα κινυμένοιο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="838"><q rend="double; merge">ἀλλʼ ὥρη δολιχήν τε καὶ ἄσπετον οἶμον ὁδεύειν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="839"><q rend="double; merge">ὄφρα κασιγνήτας μετελεύσομαι, αἵ μοι ἀρωγοὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="840"><q rend="double; merge">ἔσσονται, καὶ νηὸς ὅθι πρυμνήσιʼ ἀνῆπται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="841"><q rend="double; merge">ὥς κεν ὑπηῷοι μνησαίατο νόστον ἑλέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="842">ἦ, καὶ ἀναΐξασα κατʼ αἰθέρος ἔμπεσε δίναις</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="843">κυανέου πόντοιο· κάλει δʼ ἐπαμυνέμεν ἄλλας</l>
@@ -5541,15 +5541,15 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="854">οὐδέ τις εἰσιδέειν δύνατʼ ἔμπεδον, ἀλλʼ ἄρα τῷγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="855">οἴῳ ἐν ὀφθαλμοῖσιν ἐείσατο, φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="856">‘μηκέτι νῦν ἀκταῖς Τυρσηνίσιν ἧσθε μένοντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="857">ἠῶθεν δὲ θοῆς πρυμνήσια λύετε νηός,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="858">Ἥρῃ πειθόμενοι ἐπαρηγόνι. τῆς γὰρ ἐφετμῇς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="859">πασσυδίῃ κοῦραι Νηρηίδες ἀντιόωσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="860">νῆα διὲκ πέτρας, αἵ τε Πλαγκταὶ καλέονται,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="861">ῥυσόμεναι. κείνη γὰρ ἐναίσιμος ὔμμι κέλευθος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="862">ἀλλὰ σὺ μή τῳ ἐμὸν δείξῃς δέμας, εὖτʼ ἂν ἴδηαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="863">ἀντομένην σὺν τῇσι· νόῳ δʼ ἔχε, μή με χολώσῃς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="864">πλεῖον ἔτʼ, ἢ τὸ πάροιθεν ἀπηλεγέως ἐχόλωσας.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="856"><q rend="double">μηκέτι νῦν ἀκταῖς Τυρσηνίσιν ἧσθε μένοντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="857"><q rend="double; merge">ἠῶθεν δὲ θοῆς πρυμνήσια λύετε νηός,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="858"><q rend="double; merge">Ἥρῃ πειθόμενοι ἐπαρηγόνι. τῆς γὰρ ἐφετμῇς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="859"><q rend="double; merge">πασσυδίῃ κοῦραι Νηρηίδες ἀντιόωσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="860"><q rend="double; merge">νῆα διὲκ πέτρας, αἵ τε Πλαγκταὶ καλέονται,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="861"><q rend="double; merge">ῥυσόμεναι. κείνη γὰρ ἐναίσιμος ὔμμι κέλευθος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="862"><q rend="double; merge">ἀλλὰ σὺ μή τῳ ἐμὸν δείξῃς δέμας, εὖτʼ ἂν ἴδηαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="863"><q rend="double; merge">ἀντομένην σὺν τῇσι· νόῳ δʼ ἔχε, μή με χολώσῃς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="864"><q rend="double; merge">πλεῖον ἔτʼ, ἢ τὸ πάροιθεν ἀπηλεγέως ἐχόλωσας.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="865">ἦ, καὶ ἔπειτʼ ἀίδηλος ἐδύσατο βένθεα
 						πόντου·</l>
@@ -5707,49 +5707,49 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1012">Αἰσονίδεω ἑτάρους μειλίσσετο, πολλὰ δὲ χερσὶν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1013">Ἀρήτης γούνων ἀλόχου θίγεν Ἀλκινόοιο·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1014">‘γουνοῦμαι, βασίλεια· σὺ δʼ ἵλαθι, μηδέ με
-						Κόλχοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1015">ἐκδώῃς ᾧ πατρὶ κομιζέμεν, εἴ νυ καὶ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1016">ἀνθρώπων γενεῆς μία φέρβεαι, οἷσιν ἐς ἄτην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1017">ὠκύτατος κούφῃσι θέει νόος ἀμπλακίῃσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1018">ὡς ἐμοὶ ἐκ πυκιναὶ ἔπεσον φρένες, οὐ μὲν ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1019">μαργοσύνης. ἴστω δʼ ἱερὸν φάος Ἠελίοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1020">ἴστω νυκτιπόλου Περσηίδος ὄργια κούρης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1021">μὴ μὲν ἐγὼν ἐθέλουσα σὺν ἀνδράσιν ἀλλοδαποῖσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1022">κεῖθεν ἀφωρμήθην· στυγερὸν δέ με τάρβος ἔπεισεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1023">τῆσγε φυγῆς μνήσασθαι, ὅτʼ ἤλιτον· οὐδέ τις ἄλλη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1024">μῆτις ἔην. ἔτι μοι μίτρη μένει, ὡς ἐνὶ πατρὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1025">δώμασιν, ἄχραντος καὶ ἀκήρατος. ἀλλʼ ἐλέαιρε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1026">πότνα, τεόν τε πόσιν μειλίσσεο· σοὶ δʼ ὀπάσειαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1027">ἀθάνατοι βίοτόν τε τελεσφόρον ἀγλαΐην τε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1028">καὶ παῖδας καὶ κῦδος ἀπορθήτοιο πόληος.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1014"><q rend="double">γουνοῦμαι, βασίλεια· σὺ δʼ ἵλαθι, μηδέ με
+						Κόλχοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1015"><q rend="double; merge">ἐκδώῃς ᾧ πατρὶ κομιζέμεν, εἴ νυ καὶ αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1016"><q rend="double; merge">ἀνθρώπων γενεῆς μία φέρβεαι, οἷσιν ἐς ἄτην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1017"><q rend="double; merge">ὠκύτατος κούφῃσι θέει νόος ἀμπλακίῃσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1018"><q rend="double; merge">ὡς ἐμοὶ ἐκ πυκιναὶ ἔπεσον φρένες, οὐ μὲν ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1019"><q rend="double; merge">μαργοσύνης. ἴστω δʼ ἱερὸν φάος Ἠελίοιο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1020"><q rend="double; merge">ἴστω νυκτιπόλου Περσηίδος ὄργια κούρης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1021"><q rend="double; merge">μὴ μὲν ἐγὼν ἐθέλουσα σὺν ἀνδράσιν ἀλλοδαποῖσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1022"><q rend="double; merge">κεῖθεν ἀφωρμήθην· στυγερὸν δέ με τάρβος ἔπεισεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1023"><q rend="double; merge">τῆσγε φυγῆς μνήσασθαι, ὅτʼ ἤλιτον· οὐδέ τις ἄλλη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1024"><q rend="double; merge">μῆτις ἔην. ἔτι μοι μίτρη μένει, ὡς ἐνὶ πατρὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1025"><q rend="double; merge">δώμασιν, ἄχραντος καὶ ἀκήρατος. ἀλλʼ ἐλέαιρε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1026"><q rend="double; merge">πότνα, τεόν τε πόσιν μειλίσσεο· σοὶ δʼ ὀπάσειαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1027"><q rend="double; merge">ἀθάνατοι βίοτόν τε τελεσφόρον ἀγλαΐην τε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1028"><q rend="double; merge">καὶ παῖδας καὶ κῦδος ἀπορθήτοιο πόληος.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1029">τοῖα μὲν Ἀρήτην γουνάζετο δάκρυ χέουσα·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1030">τοῖα δʼ ἀριστήων ἐπαμοιβαδὶς ἄνδρα ἕκαστον·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1031">‘ὑμέων, ὦ πέρι δὴ μέγα φέρτατοι, ἀμφί τʼ
-						ἀέθλοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1032">ὧν κάμον ὑμετέροισιν, ἀτύζομαι· ἧς ἰότητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1033">ταύρους τʼ ἐζεύξασθε, καὶ ἐκ θέρος οὐλοὸν ἀνδρῶν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1034">κείρατε γηγενέων· ἧς εἵνεκεν Αἱμονίηνδε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1035">χρύσεον αὐτίκα κῶας ἀνάξετε νοστήσαντες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1036">ἥδʼ ἐγώ, ἣ πάτρην τε καὶ οὓς ὤλεσσα τοκῆας,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1037">ἣ δόμον, ἣ σύμπασαν ἐυφροσύνην βιότοιο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1038">ὔμμι δὲ καὶ πάτρην καὶ δώματα ναιέμεν αὖτις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1039">ἤνυσα· καὶ γλυκεροῖσιν ἔτʼ εἰσόψεσθε τοκῆας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1040">ὄμμασιν· αὐτὰρ ἐμοὶ ἀπὸ δὴ βαρὺς εἵλετο δαίμων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1041">ἀγλαΐας· στυγερὴ δὲ σὺν ὀθνείοις ἀλάλημαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1042">δείσατε συνθεσίας τε καὶ ὅρκια, δείσατʼ Ἐρινὺν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1043">Ἱκεσίην, νέμεσίν τε θεῶν, ἐς χεῖρας ἰοῦσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1044">Αἰήτεω λώβῃ πολυπήμονι δῃωθῆναι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1045">οὐ νηούς, οὐ πύργον ἐπίρροθον, οὐκ ἀλεωρὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1046">ἄλλην, οἰόθι δὲ προτιβάλλομαι ὑμέας αὐτους.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1047">σχέτλιοι ἀτροπίης καὶ ἀνηλέες· οὐδʼ ἐνὶ θυμῷ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1048">αἰδεῖσθε ξείνης μʼ ἐπὶ γούνατα χεῖρας ἀνάσσης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1049">δερκόμενοι τείνουσαν ἀμήχανον· ἀλλά κε πᾶσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1050">κῶας ἑλεῖν μεμαῶτες, ἐμίξατε δούρατα Κόλχοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1051">αὐτῷ τʼ Αἰήτῃ ὑπερήνορι· νῦν δʼ ἐλάθεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1052">ἠνορέης, ὅτε μοῦνοι ἀποτμηγέντες ἔασιν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1031"><q rend="double">ὑμέων, ὦ πέρι δὴ μέγα φέρτατοι, ἀμφί τʼ
+						ἀέθλοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1032"><q rend="double; merge">ὧν κάμον ὑμετέροισιν, ἀτύζομαι· ἧς ἰότητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1033"><q rend="double; merge">ταύρους τʼ ἐζεύξασθε, καὶ ἐκ θέρος οὐλοὸν ἀνδρῶν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1034"><q rend="double; merge">κείρατε γηγενέων· ἧς εἵνεκεν Αἱμονίηνδε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1035"><q rend="double; merge">χρύσεον αὐτίκα κῶας ἀνάξετε νοστήσαντες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1036"><q rend="double; merge">ἥδʼ ἐγώ, ἣ πάτρην τε καὶ οὓς ὤλεσσα τοκῆας,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1037"><q rend="double; merge">ἣ δόμον, ἣ σύμπασαν ἐυφροσύνην βιότοιο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1038"><q rend="double; merge">ὔμμι δὲ καὶ πάτρην καὶ δώματα ναιέμεν αὖτις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1039"><q rend="double; merge">ἤνυσα· καὶ γλυκεροῖσιν ἔτʼ εἰσόψεσθε τοκῆας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1040"><q rend="double; merge">ὄμμασιν· αὐτὰρ ἐμοὶ ἀπὸ δὴ βαρὺς εἵλετο δαίμων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1041"><q rend="double; merge">ἀγλαΐας· στυγερὴ δὲ σὺν ὀθνείοις ἀλάλημαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1042"><q rend="double; merge">δείσατε συνθεσίας τε καὶ ὅρκια, δείσατʼ Ἐρινὺν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1043"><q rend="double; merge">Ἱκεσίην, νέμεσίν τε θεῶν, ἐς χεῖρας ἰοῦσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1044"><q rend="double; merge">Αἰήτεω λώβῃ πολυπήμονι δῃωθῆναι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1045"><q rend="double; merge">οὐ νηούς, οὐ πύργον ἐπίρροθον, οὐκ ἀλεωρὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1046"><q rend="double; merge">ἄλλην, οἰόθι δὲ προτιβάλλομαι ὑμέας αὐτους.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1047"><q rend="double; merge">σχέτλιοι ἀτροπίης καὶ ἀνηλέες· οὐδʼ ἐνὶ θυμῷ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1048"><q rend="double; merge">αἰδεῖσθε ξείνης μʼ ἐπὶ γούνατα χεῖρας ἀνάσσης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1049"><q rend="double; merge">δερκόμενοι τείνουσαν ἀμήχανον· ἀλλά κε πᾶσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1050"><q rend="double; merge">κῶας ἑλεῖν μεμαῶτες, ἐμίξατε δούρατα Κόλχοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1051"><q rend="double; merge">αὐτῷ τʼ Αἰήτῃ ὑπερήνορι· νῦν δʼ ἐλάθεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1052"><q rend="double; merge">ἠνορέης, ὅτε μοῦνοι ἀποτμηγέντες ἔασιν.</q></l>
 					          <milestone n="1053" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1053">ὧς φάτο λισσομένη· τῶν δʼ ὅντινα γουνάζοιτο,</l>
@@ -5775,46 +5775,46 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1071">οἷσιν ἐνὶ λεχέεσσι διὰ κνέφας· οἷα δʼ ἀκοίτην</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1072">κουρίδιον θαλεροῖσι δάμαρ προσπτύσσετο μύθοις·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1073">‘ναὶ φίλος, εἰ δʼ ἄγε μοι πολυκηδέα ῥύεο
-						Κόλχων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1074">παρθενικήν, Μινύῃσι φέρων χάριν. ἐγγύθι δʼ Ἄργος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1075">ἡμετέρης νήσοιο καὶ ἀνέρες Αἱμονιῆες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1076">Αἰήτης δʼ οὔτʼ ἂρ ναίει σχεδόν, οὐδέ τι ἴδμεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1077">Αἰήτην, ἀλλʼ οἶον ἀκούομεν· ἥδε δὲ κούρη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1078">αἰνοπαθὴς κατά μοι νόον ἔκλασεν ἀντιόωσα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1079">μή μιν, ἄναξ, Κόλχοισι πόροις ἐς πατρὸς ἄγεσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1080">ἀάσθη, ὅτε πρῶτα βοῶν θελκτήρια δῶκεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1081">φάρμακά οἱ· σχεδόθεν δὲ κακῷ κακόν, οἷά τε πολλὰ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1082">ῥέζομεν ἀμπλακίῃσιν, ἀκειομένη ὑπάλυξεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1083">πατρὸς ὑπερφιάλοιο βαρὺν χόλον. αὐτὰρ Ἰήσων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1084">ὡς ἀίω, μεγάλοισιν ἐνίσχεται ἐξ ἕθεν ὅρκοις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1085">κουριδίην θήσεσθαι ἐνὶ μεγάροισιν ἄκοιτιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1086">τῶ, φίλε, μήτʼ οὖν αὐτὸν ἑκὼν ἐπίορκον ὀμόσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1087">θείης Αἰσονίδην, μήτʼ ἄσχετα σεῖο ἕκητι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1088">παῖδα πατὴρ θυμῷ κεκοτηότι δηλήσαιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1089">λίην γὰρ δύσζηλοι ἑαῖς ἐπὶ παισὶ τοκῆες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1090">οἷα μὲν Ἀντιόπην εὐώπιδα μήσατο Νυκτεύς·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1091">οἷα δὲ καὶ Δανάη πόντῳ ἔνι πήματʼ ἀνέτλη,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1092">πατρὸς ἀτασθαλίῃσι· νέον γε μέν, οὐδʼ ἀποτηλοῦ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1093">ὑβριστὴς Ἔχετος γλήναις ἔνι χάλκεα κέντρα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1094">πῆξε θυγατρὸς ἑῆς· στονόεντι δὲ κάρφεται οἴτῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1095">ὀρφναίῃ ἐνὶ χαλκὸν ἀλετρεύουσα καλιῇ.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1073"><q rend="double">ναὶ φίλος, εἰ δʼ ἄγε μοι πολυκηδέα ῥύεο
+						Κόλχων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1074"><q rend="double; merge">παρθενικήν, Μινύῃσι φέρων χάριν. ἐγγύθι δʼ Ἄργος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1075"><q rend="double; merge">ἡμετέρης νήσοιο καὶ ἀνέρες Αἱμονιῆες·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1076"><q rend="double; merge">Αἰήτης δʼ οὔτʼ ἂρ ναίει σχεδόν, οὐδέ τι ἴδμεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1077"><q rend="double; merge">Αἰήτην, ἀλλʼ οἶον ἀκούομεν· ἥδε δὲ κούρη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1078"><q rend="double; merge">αἰνοπαθὴς κατά μοι νόον ἔκλασεν ἀντιόωσα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1079"><q rend="double; merge">μή μιν, ἄναξ, Κόλχοισι πόροις ἐς πατρὸς ἄγεσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1080"><q rend="double; merge">ἀάσθη, ὅτε πρῶτα βοῶν θελκτήρια δῶκεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1081"><q rend="double; merge">φάρμακά οἱ· σχεδόθεν δὲ κακῷ κακόν, οἷά τε πολλὰ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1082"><q rend="double; merge">ῥέζομεν ἀμπλακίῃσιν, ἀκειομένη ὑπάλυξεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1083"><q rend="double; merge">πατρὸς ὑπερφιάλοιο βαρὺν χόλον. αὐτὰρ Ἰήσων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1084"><q rend="double; merge">ὡς ἀίω, μεγάλοισιν ἐνίσχεται ἐξ ἕθεν ὅρκοις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1085"><q rend="double; merge">κουριδίην θήσεσθαι ἐνὶ μεγάροισιν ἄκοιτιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1086"><q rend="double; merge">τῶ, φίλε, μήτʼ οὖν αὐτὸν ἑκὼν ἐπίορκον ὀμόσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1087"><q rend="double; merge">θείης Αἰσονίδην, μήτʼ ἄσχετα σεῖο ἕκητι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1088"><q rend="double; merge">παῖδα πατὴρ θυμῷ κεκοτηότι δηλήσαιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1089"><q rend="double; merge">λίην γὰρ δύσζηλοι ἑαῖς ἐπὶ παισὶ τοκῆες·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1090"><q rend="double; merge">οἷα μὲν Ἀντιόπην εὐώπιδα μήσατο Νυκτεύς·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1091"><q rend="double; merge">οἷα δὲ καὶ Δανάη πόντῳ ἔνι πήματʼ ἀνέτλη,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1092"><q rend="double; merge">πατρὸς ἀτασθαλίῃσι· νέον γε μέν, οὐδʼ ἀποτηλοῦ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1093"><q rend="double; merge">ὑβριστὴς Ἔχετος γλήναις ἔνι χάλκεα κέντρα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1094"><q rend="double; merge">πῆξε θυγατρὸς ἑῆς· στονόεντι δὲ κάρφεται οἴτῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1095"><q rend="double; merge">ὀρφναίῃ ἐνὶ χαλκὸν ἀλετρεύουσα καλιῇ.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1096">ὧς ἔφατʼ ἀντομένη· τοῦ δὲ φρένες ἰαίνοντυ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1097">ἧς ἀλόχου μύθοισιν, ἔπος δʼ ἐπὶ τοῖον ἔειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1098">‘Ἀρήτη, καί κεν σὺν τεύχεσιν ἐξελάσαιμι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1099">Κόλχους, ἡρώεσσι φέρων χάριν, εἵνεκα κούρης.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1100">ἀλλὰ Διὸς δείδοικα δίκην ἰθεῖαν ἀτίσσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1101">οὐδὲ μὲν Αἰήτην ἀθεριζέμεν, ὡς ἀγορεύεις,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1102">λώιον· οὐ γάρ τις βασιλεύτερος Αἰήταο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1103">καί κʼ ἐθέλων, ἕκαθέν περ, ἐφʼ Ἑλλάδι νεῖκος ἄγοιτο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1104">τῶ μʼ ἐπέοικε δίκην, ἥτις μετὰ πᾶσιν ἀρίστη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1105">ἔσσεται ἀνθρώποισι, δικαζέμεν· οὐδέ σε κεύσω.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1106">παρθενικὴν μὲν ἐοῦσαν ἑῷ ἀπὸ πατρὶ κομίσσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1107">ἰθύνω· λέκτρον δὲ σὺν ἀνέρι πορσαίνουσαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1108">οὔ μιν ἑοῦ πόσιος νοσφίσσομαι· οὐδέ, γενέθλην</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1109">εἴ τινʼ ὑπὸ σπλάγχνοισι φέρει, δῄοισιν ὀπάσσω.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1098"><q rend="double">Ἀρήτη, καί κεν σὺν τεύχεσιν ἐξελάσαιμι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1099"><q rend="double; merge">Κόλχους, ἡρώεσσι φέρων χάριν, εἵνεκα κούρης.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1100"><q rend="double; merge">ἀλλὰ Διὸς δείδοικα δίκην ἰθεῖαν ἀτίσσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1101"><q rend="double; merge">οὐδὲ μὲν Αἰήτην ἀθεριζέμεν, ὡς ἀγορεύεις,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1102"><q rend="double; merge">λώιον· οὐ γάρ τις βασιλεύτερος Αἰήταο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1103"><q rend="double; merge">καί κʼ ἐθέλων, ἕκαθέν περ, ἐφʼ Ἑλλάδι νεῖκος ἄγοιτο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1104"><q rend="double; merge">τῶ μʼ ἐπέοικε δίκην, ἥτις μετὰ πᾶσιν ἀρίστη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1105"><q rend="double; merge">ἔσσεται ἀνθρώποισι, δικαζέμεν· οὐδέ σε κεύσω.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1106"><q rend="double; merge">παρθενικὴν μὲν ἐοῦσαν ἑῷ ἀπὸ πατρὶ κομίσσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1107"><q rend="double; merge">ἰθύνω· λέκτρον δὲ σὺν ἀνέρι πορσαίνουσαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1108"><q rend="double; merge">οὔ μιν ἑοῦ πόσιος νοσφίσσομαι· οὐδέ, γενέθλην</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1109"><q rend="double; merge">εἴ τινʼ ὑπὸ σπλάγχνοισι φέρει, δῄοισιν ὀπάσσω.</q></l>
 					          <milestone n="1110" unit="card"/>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1110">ὧς ἄρʼ ἔφη· καὶ τὸν μέν ἐπισχεδὸν εὔνασεν
@@ -5969,33 +5969,33 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1249">αὔλιον, εὐκήλῳ δὲ κατείχετο πάντα γαλήνῃ.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1250">ἄλλος δʼ αὖτʼ ἄλλον τετιημένος ἐξερέεινεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1251">‘τίς χθὼν εὔχεται ἥδε; πόθι ξυνέωσαν ἄελλαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1252">ἡμέας; αἴθʼ ἔτλημεν, ἀφειδέες οὐλομένοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1253">δείματος, αὐτὰ κέλευθα διαμπερὲς ὁρμηθῆναι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1254">πετράων. ἦ τʼ ἂν καὶ ὑπὲρ Διὸς αἶσαν ἰοῦσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1255">βέλτερον ἦν μέγα δή τι μενοινώοντας ὀλέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1256">νῦν δὲ τί κεν ῥέξαιμεν, ἐρυκόμενοι ἀνέμοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1257">αὖθι μένειν τυτθόν περ ἐπὶ χρόνον; οἷον ἐρήμη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1258">πέζα διωλυγίης ἀναπέπταται ἠπείροιο.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1251"><q rend="double">τίς χθὼν εὔχεται ἥδε; πόθι ξυνέωσαν ἄελλαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1252"><q rend="double; merge">ἡμέας; αἴθʼ ἔτλημεν, ἀφειδέες οὐλομένοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1253"><q rend="double; merge">δείματος, αὐτὰ κέλευθα διαμπερὲς ὁρμηθῆναι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1254"><q rend="double; merge">πετράων. ἦ τʼ ἂν καὶ ὑπὲρ Διὸς αἶσαν ἰοῦσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1255"><q rend="double; merge">βέλτερον ἦν μέγα δή τι μενοινώοντας ὀλέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1256"><q rend="double; merge">νῦν δὲ τί κεν ῥέξαιμεν, ἐρυκόμενοι ἀνέμοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1257"><q rend="double; merge">αὖθι μένειν τυτθόν περ ἐπὶ χρόνον; οἷον ἐρήμη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1258"><q rend="double; merge">πέζα διωλυγίης ἀναπέπταται ἠπείροιο.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1259">ὧς ἄρʼ ἔφη· μετὰ δʼ αὐτὸς ἀμηχανίῃ κακότητος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1260">ἰθυντὴρ Ἀγκαῖος ἀκηχέμενος ἀγόρευσεν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1261">‘Ὠλόμεθʼ αἰνότατον δῆθεν μόρον, οὐδʼ ὑπάλυξις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1262">ἔστʼ ἄτης· πάρα δʼ ἄμμι τὰ κύντατα πημανθῆναι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1263">τῇδʼ ἐπʼ ἐρημαίῃ πεπτηότας, εἰ καὶ ἀῆται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1264">χερσόθεν ἀμπνεύσειαν· ἐπεὶ τεναγώδεα λεύσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1265">τῆλε περισκοπέων ἅλα πάντοθεν· ἤλιθα δʼ ὕδωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1266">ξαινόμενον πολιῇσιν ἐπιτροχάει ψαμάθοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1267">καί κεν ἐπισμυγερῶς διὰ δὴ πάλαι ἥδʼ ἐκεάσθη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1268">νηῦς ἱερὴ χέρσου πολλὸν πρόσω· ἀλλά μιν αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1269">πλημμυρὶς ἐκ πόντοιο μεταχθονίην ἐκόμισσεν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1270">νῦν δʼ ἡ μὲν πέλαγόσδε μετέσσυται, οἰόθι δʼ ἅλμη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1271">ἄπλοος εἰλεῖται, γαίης ὕπερ ὅσσον ἔχουσα.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1272">τούνεκʼ ἐγὼ πᾶσαν μὲν ἀπʼ ἐλπίδα φημὶ κεκόφθαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1273">ναυτιλίης νόστου τε. δαημοσύνην δέ τις ἄλλος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1274">φαίνοι ἑήν· πάρα γάρ οἱ ἐπʼ οἰήκεσσι θαάσσειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1275">μαιομένῳ κομιδῆς. ἀλλʼ οὐ μάλα νόστιμον ἦμαρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1276">Ζεὺς ἐθέλει καμάτοισιν ἐφʼ ἡμετέροισι τελέσσαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1261"><q rend="double">Ὠλόμεθʼ αἰνότατον δῆθεν μόρον, οὐδʼ ὑπάλυξις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1262"><q rend="double; merge">ἔστʼ ἄτης· πάρα δʼ ἄμμι τὰ κύντατα πημανθῆναι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1263"><q rend="double; merge">τῇδʼ ἐπʼ ἐρημαίῃ πεπτηότας, εἰ καὶ ἀῆται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1264"><q rend="double; merge">χερσόθεν ἀμπνεύσειαν· ἐπεὶ τεναγώδεα λεύσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1265"><q rend="double; merge">τῆλε περισκοπέων ἅλα πάντοθεν· ἤλιθα δʼ ὕδωρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1266"><q rend="double; merge">ξαινόμενον πολιῇσιν ἐπιτροχάει ψαμάθοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1267"><q rend="double; merge">καί κεν ἐπισμυγερῶς διὰ δὴ πάλαι ἥδʼ ἐκεάσθη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1268"><q rend="double; merge">νηῦς ἱερὴ χέρσου πολλὸν πρόσω· ἀλλά μιν αὐτὴ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1269"><q rend="double; merge">πλημμυρὶς ἐκ πόντοιο μεταχθονίην ἐκόμισσεν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1270"><q rend="double; merge">νῦν δʼ ἡ μὲν πέλαγόσδε μετέσσυται, οἰόθι δʼ ἅλμη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1271"><q rend="double; merge">ἄπλοος εἰλεῖται, γαίης ὕπερ ὅσσον ἔχουσα.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1272"><q rend="double; merge">τούνεκʼ ἐγὼ πᾶσαν μὲν ἀπʼ ἐλπίδα φημὶ κεκόφθαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1273"><q rend="double; merge">ναυτιλίης νόστου τε. δαημοσύνην δέ τις ἄλλος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1274"><q rend="double; merge">φαίνοι ἑήν· πάρα γάρ οἱ ἐπʼ οἰήκεσσι θαάσσειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1275"><q rend="double; merge">μαιομένῳ κομιδῆς. ἀλλʼ οὐ μάλα νόστιμον ἦμαρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1276"><q rend="double; merge">Ζεὺς ἐθέλει καμάτοισιν ἐφʼ ἡμετέροισι τελέσσαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1277">ὧς φάτο δακρυόεις· σὺν δʼ ἔννεπον ἀσχαλόωντι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1278">ὅσσοι ἔσαν νηῶν δεδαημένοι· ἐν δʼ ἄρα πᾶσιν</l>
@@ -6040,28 +6040,28 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1317">μειλιχίοις ἐπέεσσιν ἀτυζόμενον προσέειπον·</l>
 					          <milestone n="1318" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1318">‘κάμμορε, τίπτʼ ἐπὶ τόσσον ἀμηχανίῃ βεβόλησαι;</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1319">ἴδμεν ἐποιχομένους χρύσεον δέρος· ἴδμεν ἕκαστα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1320">ὑμετέρων καμάτων, ὅσʼ ἐπὶ χθονός, ὅσσα τʼ ἐφʼ ὑγρὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1321">πλαζόμενοι κατὰ πόντον ὑπέρβια ἔργʼ ἐκάμεσθε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1322">οἰοπόλοι δʼ εἰμὲν χθόνιαι θεαὶ αὐδήεσσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1323">ἡρῷσσαι, Λιβύης τιμήοροι ἠδὲ θύγατρες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1324">ἀλλʼ ἄνα· μηδʼ ἔτι τοῖον ὀιζύων ἀκάχησο·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1325">ἄνστησον δʼ ἑτάρους. εὖτʼ ἂν δέ τοι Ἀμφιτρίτη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1326">ἅρμα Ποσειδάωνος ἐύτροχον αὐτίκα λύσῃ,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1327">δή ῥα τότε σφετέρῃ ἀπὸ μητέρι τίνετʼ ἀμοιβὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1328">ὧν ἔκαμεν δηρὸν κατὰ νηδύος ὔμμε φέρουσα·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1329">καί κεν ἔτʼ ἠγαθέην ἐς Ἀχαιίδα νοστήσαιτε.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1318"><q rend="double">κάμμορε, τίπτʼ ἐπὶ τόσσον ἀμηχανίῃ βεβόλησαι;</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1319"><q rend="double; merge">ἴδμεν ἐποιχομένους χρύσεον δέρος· ἴδμεν ἕκαστα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1320"><q rend="double; merge">ὑμετέρων καμάτων, ὅσʼ ἐπὶ χθονός, ὅσσα τʼ ἐφʼ ὑγρὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1321"><q rend="double; merge">πλαζόμενοι κατὰ πόντον ὑπέρβια ἔργʼ ἐκάμεσθε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1322"><q rend="double; merge">οἰοπόλοι δʼ εἰμὲν χθόνιαι θεαὶ αὐδήεσσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1323"><q rend="double; merge">ἡρῷσσαι, Λιβύης τιμήοροι ἠδὲ θύγατρες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1324"><q rend="double; merge">ἀλλʼ ἄνα· μηδʼ ἔτι τοῖον ὀιζύων ἀκάχησο·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1325"><q rend="double; merge">ἄνστησον δʼ ἑτάρους. εὖτʼ ἂν δέ τοι Ἀμφιτρίτη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1326"><q rend="double; merge">ἅρμα Ποσειδάωνος ἐύτροχον αὐτίκα λύσῃ,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1327"><q rend="double; merge">δή ῥα τότε σφετέρῃ ἀπὸ μητέρι τίνετʼ ἀμοιβὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1328"><q rend="double; merge">ὧν ἔκαμεν δηρὸν κατὰ νηδύος ὔμμε φέρουσα·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1329"><q rend="double; merge">καί κεν ἔτʼ ἠγαθέην ἐς Ἀχαιίδα νοστήσαιτε.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1330">ὧς ἄρʼ ἔφαν, καὶ ἄφαντοι ἵνʼ ἔσταθεν, ἔνθʼ ἄρα
 						ταίγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1331">φθογγῇ ὁμοῦ ἐγένοντο παρασχεδόν. αὐτὰρ Ἰήσων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1332">παπτήνας ἀνʼ ἄρʼ ἕζετʼ ἐπὶ χθονός, ὧδέ τʼ ἔειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1333">‘Ἵλατʼ ἐρημονόμοι κυδραὶ θεαί· ἀμφὶ δὲ νόστῳ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1334">οὔτι μαλʼ ἀντικρὺ νοέω φάτιν. ἦ μὲν ἑταίρους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1335">εἰς ἓν ἀγειράμενος μυθήσομαι, εἴ νύ τι τέκμωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1336">δήωμεν κομιδῆς· πολέων δέ τε μῆτις ἀρείων.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1333"><q rend="double">Ἵλατʼ ἐρημονόμοι κυδραὶ θεαί· ἀμφὶ δὲ νόστῳ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1334"><q rend="double; merge">οὔτι μαλʼ ἀντικρὺ νοέω φάτιν. ἦ μὲν ἑταίρους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1335"><q rend="double; merge">εἰς ἓν ἀγειράμενος μυθήσομαι, εἴ νύ τι τέκμωρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1336"><q rend="double; merge">δήωμεν κομιδῆς· πολέων δέ τε μῆτις ἀρείων.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1337">ἦ, καὶ ἀναΐξας ἑτάρους ἐπὶ μακρὸν ἀύτει,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1338">αὐσταλέος κονίῃσι, λέων ὥς, ὅς ῥά τʼ ἀνʼ ὕλην</l>
@@ -6074,22 +6074,22 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1345">ἀχνυμένους ὅρμοιο πέλας μίγα θηλυτέρῃσιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1346">ἱδρύσας, μυθεῖτο πιφαυσκόμενος τὰ ἕκαστα·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1347">‘κλῦτε, φίλοι· τρεῖς γάρ μοι ἀνιάζοντι θεάων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1348">στέρφεσιν αἰγείοις ἐζωσμέναι ἐξ ὑπάτοιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1349">αὐχένος ἀμφί τε νῶτα καὶ ἰξύας, ἠύτε κοῦραι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1350">ἔσταν ὑπὲρ κεφαλῆς μάλʼ ἐπισχεδόν· ἂν δʼ ἐκάλυψαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1351">πέπλον ἐρυσσάμεναι κούφῃ χερί, καὶ μʼ ἐκέλοντο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1352">αὐτόν τʼ ἔγρεσθαι, ἀνά θʼ ὑμέας ὄρσαι ἰόντα·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1353">μητέρι δὲ σφετέρῃ μενοεικέα τῖσαι ἀμοιβὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1354">ὧν ἔκαμεν δηρὸν κατὰ νηδύος ἄμμε φέρουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1355">ὁππότε κεν λύσῃσιν ἐύτροχον Ἀμφιτρίτη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1356">ἅρμα Ποσειδάωνος. ἐγὼ δʼ οὐ πάγχυ νοῆσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1357">τῆσδε θεοπροπίης ἴσχω πέρι. φάν γε μὲν εἶναι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1358">ἡρῷσσαι, Λιβύης τιμήοροι ᾐδὲ θύγατρες·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1359">καὶ δʼ ὁπόσʼ αὐτοὶ πρόσθεν ἐπὶ χθονὸς ἠδʼ ὅσʼ ἐφʼ ὑγρὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1360">ἔτλημεν, τὰ ἕκαστα διίδμεναι εὐχετόωντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1361">οὐδʼ ἔτι τάσδʼ ἀνὰ χῶρον ἐσέδρακον, ἀλλά τις ἀχλὺς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1362">ἠὲ νέφος μεσσηγὺ φαεινομένας ἐκάλυψεν.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1347"><q rend="double">κλῦτε, φίλοι· τρεῖς γάρ μοι ἀνιάζοντι θεάων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1348"><q rend="double; merge">στέρφεσιν αἰγείοις ἐζωσμέναι ἐξ ὑπάτοιο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1349"><q rend="double; merge">αὐχένος ἀμφί τε νῶτα καὶ ἰξύας, ἠύτε κοῦραι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1350"><q rend="double; merge">ἔσταν ὑπὲρ κεφαλῆς μάλʼ ἐπισχεδόν· ἂν δʼ ἐκάλυψαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1351"><q rend="double; merge">πέπλον ἐρυσσάμεναι κούφῃ χερί, καὶ μʼ ἐκέλοντο</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1352"><q rend="double; merge">αὐτόν τʼ ἔγρεσθαι, ἀνά θʼ ὑμέας ὄρσαι ἰόντα·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1353"><q rend="double; merge">μητέρι δὲ σφετέρῃ μενοεικέα τῖσαι ἀμοιβὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1354"><q rend="double; merge">ὧν ἔκαμεν δηρὸν κατὰ νηδύος ἄμμε φέρουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1355"><q rend="double; merge">ὁππότε κεν λύσῃσιν ἐύτροχον Ἀμφιτρίτη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1356"><q rend="double; merge">ἅρμα Ποσειδάωνος. ἐγὼ δʼ οὐ πάγχυ νοῆσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1357"><q rend="double; merge">τῆσδε θεοπροπίης ἴσχω πέρι. φάν γε μὲν εἶναι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1358"><q rend="double; merge">ἡρῷσσαι, Λιβύης τιμήοροι ᾐδὲ θύγατρες·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1359"><q rend="double; merge">καὶ δʼ ὁπόσʼ αὐτοὶ πρόσθεν ἐπὶ χθονὸς ἠδʼ ὅσʼ ἐφʼ ὑγρὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1360"><q rend="double; merge">ἔτλημεν, τὰ ἕκαστα διίδμεναι εὐχετόωντο.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1361"><q rend="double; merge">οὐδʼ ἔτι τάσδʼ ἀνὰ χῶρον ἐσέδρακον, ἀλλά τις ἀχλὺς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1362"><q rend="double; merge">ἠὲ νέφος μεσσηγὺ φαεινομένας ἐκάλυψεν.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1363">ὧς ἔφαθʼ· οἱ δʼ ἄρα πάντες ἐθάμβεον
 						εἰσαΐοντες.</l>
@@ -6101,16 +6101,16 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1369">γηθήσας ἑτάροισιν ὁμηγερέεσσι μετηύδα· </l>
                               <milestone n="1370" unit="card"/>
 					          <milestone unit="para"/>
-				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1370">‘ἅρματα μὲν δή φημι Ποσειδάωνος ἔγωγε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1371">ἤδη νῦν ἀλόχοιο φίλης ὑπὸ χερσὶ λελύσθαι·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1372">μητέρα δʼ οὐκ ἄλλην προτιόσσομαι, ἠέ περ αὐτὴν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1373">νῆα πέλειν· ἦ γὰρ κατὰ νηδύος ἄμμε φέρουσα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1374">νωλεμὲς ἀργαλέοισιν ὀιζύει καμάτοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1375">ἀλλά μιν ἀστεμφεῖ τε βίῃ καὶ ἀτειρέσιν ὤμοις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1376">ὑψόθεν ἀνθέμενοι ψαμαθώδεος ἔνδοθι γαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1377">οἴσομεν, ᾗ προτέρωσε ταχὺς πόδας ἤλασεν ἵππος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1378">οὐ γὰρ ὅγε ξηρὴν ὑποδύσεται· ἴχνια δʼ ἡμῖν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1379">σημανέειν τινʼ ἔολπα μυχὸν καθύπερθε θαλάσσης.’</l>
+				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1370"><q rend="double">ἅρματα μὲν δή φημι Ποσειδάωνος ἔγωγε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1371"><q rend="double; merge">ἤδη νῦν ἀλόχοιο φίλης ὑπὸ χερσὶ λελύσθαι·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1372"><q rend="double; merge">μητέρα δʼ οὐκ ἄλλην προτιόσσομαι, ἠέ περ αὐτὴν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1373"><q rend="double; merge">νῆα πέλειν· ἦ γὰρ κατὰ νηδύος ἄμμε φέρουσα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1374"><q rend="double; merge">νωλεμὲς ἀργαλέοισιν ὀιζύει καμάτοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1375"><q rend="double; merge">ἀλλά μιν ἀστεμφεῖ τε βίῃ καὶ ἀτειρέσιν ὤμοις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1376"><q rend="double; merge">ὑψόθεν ἀνθέμενοι ψαμαθώδεος ἔνδοθι γαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1377"><q rend="double; merge">οἴσομεν, ᾗ προτέρωσε ταχὺς πόδας ἤλασεν ἵππος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1378"><q rend="double; merge">οὐ γὰρ ὅγε ξηρὴν ὑποδύσεται· ἴχνια δʼ ἡμῖν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1379"><q rend="double; merge">σημανέειν τινʼ ἔολπα μυχὸν καθύπερθε θαλάσσης.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1380">ὧς ηὔδα· πάντεσσι δʼ ἐπήβολος ἥνδανε
 						μῆτις·</l>
@@ -6145,17 +6145,17 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1408">ἄφνω ὁμοῦ· ταὶ δʼ αἶψα κόνις καὶ γαῖα, κιόντων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1409">ἐσσυμένως, ἐγένοντο καταυτόθι. νώσατο δʼ Ὀρφεὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1410">θεῖα τέρα, τὰς δέ σφι παρηγορέεσκε λιτῇσιν·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1411">‘δαίμονες ὦ καλαὶ καὶ ἐύφρονες, ἵλατʼ, ἄνασσαι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1412">εἴτʼ οὖν οὐρανίαις ἐναρίθμιοί ἐστε θεῇσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1413">εἴτε καταχθονίαις, εἴτʼ οἰοπόλοι καλέεσθε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1414">νύμφαι· ἴτʼ ὦ νύμφαι, ἱερὸν γένος Ὠκεανοῖο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1415">δείξατʼ ἐελδομένοισιν ἐνωπαδὶς ἄμμι φανεῖσαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1416">ἤ τινα πετραίην χύσιν ὕδατος, ἤ τινα γαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1417">ἱερὸν ἐκβλύοντα, θεαί, ῥόον, ᾧ ἀπὸ δίψαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1418">αἰθομένην ἄμοτον λωφήσομεν. εἰ δέ κεν αὖτις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1419">δή ποτʼ Ἀχαιίδα γαῖαν ἱκώμεθα ναυτιλίῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1420">δὴ τότε μυρία δῶρα μετὰ πρώτῃσι θεάων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1421">λοιβάς τʼ εἰλαπίνας τε παρέξομεν εὐμενέοντες.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1411"><q rend="double">δαίμονες ὦ καλαὶ καὶ ἐύφρονες, ἵλατʼ, ἄνασσαι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1412"><q rend="double; merge">εἴτʼ οὖν οὐρανίαις ἐναρίθμιοί ἐστε θεῇσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1413"><q rend="double; merge">εἴτε καταχθονίαις, εἴτʼ οἰοπόλοι καλέεσθε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1414"><q rend="double; merge">νύμφαι· ἴτʼ ὦ νύμφαι, ἱερὸν γένος Ὠκεανοῖο,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1415"><q rend="double; merge">δείξατʼ ἐελδομένοισιν ἐνωπαδὶς ἄμμι φανεῖσαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1416"><q rend="double; merge">ἤ τινα πετραίην χύσιν ὕδατος, ἤ τινα γαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1417"><q rend="double; merge">ἱερὸν ἐκβλύοντα, θεαί, ῥόον, ᾧ ἀπὸ δίψαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1418"><q rend="double; merge">αἰθομένην ἄμοτον λωφήσομεν. εἰ δέ κεν αὖτις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1419"><q rend="double; merge">δή ποτʼ Ἀχαιίδα γαῖαν ἱκώμεθα ναυτιλίῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1420"><q rend="double; merge">δὴ τότε μυρία δῶρα μετὰ πρώτῃσι θεάων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1421"><q rend="double; merge">λοιβάς τʼ εἰλαπίνας τε παρέξομεν εὐμενέοντες.</q></l>
 					          <milestone n="1422" unit="card"/>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1422">ὧς φάτο λισσόμενος ἀδινῇ ὀπί· ταὶ δʼ ἐλέαιρον</l>
@@ -6169,24 +6169,24 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1430">ἐξέφανεν, θάμβος περιώσιον, ἔκφατο δʼ Λἴγλη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1431">μειλιχίοις ἐπέεσσιν ἀμειβομένη χατέοντας·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1432">‘ἦ ἄρα δὴ μέγα πάμπαν ἐφʼ ὑμετέροισιν ὄνειαρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1433">δεῦρʼ ἔμολεν καμάτοισιν ὁ κύντατος, ὅστις ἀπούρας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1434">φρουρὸν ὄφιν ζωῆς παγχρύσεα μῆλα θεάων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1435">οἴχετʼ ἀειράμενος· στυγερὸν δʼ ἄχος ἄμμι λέλειπται.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1436">ἤλυθε γὰρ χθιζός τις ἀνὴρ ὀλοώτατος ὕβριν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1437">καὶ δέμας· ὄσσε δέ οἱ βλοσυρῷ ὑπέλαμπε μετώπῳ·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1438">νηλής· ἀμφὶ δὲ δέρμα πελωρίου ἕστο λέοντος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1439">ὠμόν, ἀδέψητον· στιβαρὸν δʼ ἔχεν ὄζον ἐλαίης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1440">τόξα τε, τοῖσι πέλωρ τόδʼ ἀπέφθισεν ἰοβολήσας.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1441">ἤλυθε δʼ οὖν κἀκεῖνος, ἅ τε χθόνα πεζὸς ὁδεύων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1442">δίψῃ καρχαλέος· παίφασσε δὲ τόνδʼ ἀνὰ χῶρον,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1443">ὕδωρ ἐξερέων, τὸ μὲν οὔ ποθι μέλλεν ἰδέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1444">ἥδε δέ τις πέτρη Τριτωνίδος ἐγγύθι λίμνης·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1445">τὴν ὅγʼ ἐπιφρασθείς, ἢ καὶ θεοῦ ἐννεσίῃσιν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1446">λὰξ ποδὶ τύψεν ἔνερθε· τὸ δʼ ἀθρόον ἔβλυσεν ὕδωρ.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1447">αὐτὰρ ὅγʼ ἄμφω χεῖρε πέδῳ καὶ στέρνον ἐρείσας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1448">ῥωγάδος ἐκ πέτρης πίεν ἄσπετον, ὄφρα βαθεῖαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1449">νηδύν, φορβάδι ἶσος ἐπιπροπεσών, ἐκορέσθη.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1432"><q rend="double">ἦ ἄρα δὴ μέγα πάμπαν ἐφʼ ὑμετέροισιν ὄνειαρ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1433"><q rend="double; merge">δεῦρʼ ἔμολεν καμάτοισιν ὁ κύντατος, ὅστις ἀπούρας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1434"><q rend="double; merge">φρουρὸν ὄφιν ζωῆς παγχρύσεα μῆλα θεάων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1435"><q rend="double; merge">οἴχετʼ ἀειράμενος· στυγερὸν δʼ ἄχος ἄμμι λέλειπται.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1436"><q rend="double; merge">ἤλυθε γὰρ χθιζός τις ἀνὴρ ὀλοώτατος ὕβριν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1437"><q rend="double; merge">καὶ δέμας· ὄσσε δέ οἱ βλοσυρῷ ὑπέλαμπε μετώπῳ·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1438"><q rend="double; merge">νηλής· ἀμφὶ δὲ δέρμα πελωρίου ἕστο λέοντος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1439"><q rend="double; merge">ὠμόν, ἀδέψητον· στιβαρὸν δʼ ἔχεν ὄζον ἐλαίης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1440"><q rend="double; merge">τόξα τε, τοῖσι πέλωρ τόδʼ ἀπέφθισεν ἰοβολήσας.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1441"><q rend="double; merge">ἤλυθε δʼ οὖν κἀκεῖνος, ἅ τε χθόνα πεζὸς ὁδεύων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1442"><q rend="double; merge">δίψῃ καρχαλέος· παίφασσε δὲ τόνδʼ ἀνὰ χῶρον,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1443"><q rend="double; merge">ὕδωρ ἐξερέων, τὸ μὲν οὔ ποθι μέλλεν ἰδέσθαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1444"><q rend="double; merge">ἥδε δέ τις πέτρη Τριτωνίδος ἐγγύθι λίμνης·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1445"><q rend="double; merge">τὴν ὅγʼ ἐπιφρασθείς, ἢ καὶ θεοῦ ἐννεσίῃσιν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1446"><q rend="double; merge">λὰξ ποδὶ τύψεν ἔνερθε· τὸ δʼ ἀθρόον ἔβλυσεν ὕδωρ.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1447"><q rend="double; merge">αὐτὰρ ὅγʼ ἄμφω χεῖρε πέδῳ καὶ στέρνον ἐρείσας</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1448"><q rend="double; merge">ῥωγάδος ἐκ πέτρης πίεν ἄσπετον, ὄφρα βαθεῖαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1449"><q rend="double; merge">νηδύν, φορβάδι ἶσος ἐπιπροπεσών, ἐκορέσθη.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1450">ὧς φάτο· τοὶ δʼ ἀσπαστὸν ἵνα σφίσι πέφραδεν
 						Αἴγλη</l>
@@ -6198,9 +6198,9 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1456">πετραίῃ Μινύαι περὶ πίδακι δινεύεσκον.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1457">καί πού τις διεροῖς ἐπὶ χείλεσιν εἶπεν ἰανθείς·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1458">‘ὦ πόποι, ἦ καὶ νόσφιν ἐὼν ἐσάωσεν ἑταίρους</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1459">Ἡρακλέης δίψῃ κεκμηότας. ἀλλά μιν εἴ πως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1460">δήοιμεν στείχοντα διʼ ἠπείροιο κιόντες.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1458"><q rend="double">ὦ πόποι, ἦ καὶ νόσφιν ἐὼν ἐσάωσεν ἑταίρους</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1459"><q rend="double; merge">Ἡρακλέης δίψῃ κεκμηότας. ἀλλά μιν εἴ πως</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1460"><q rend="double; merge">δήοιμεν στείχοντα διʼ ἠπείροιο κιόντες.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1461">ἦ, καὶ ἀμειβομένων, οἵ τʼ ἄρμενοι ἐς τόδε
 						ἔργον,</l>
@@ -6303,42 +6303,42 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1552">τρίτων εὐρυβίης, γαίης δʼ ἀνὰ βῶλον ἀείρας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1553">ξείνιʼ ἀριστήεσσι προΐσχετο, φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1554">‘Δέχθε, φίλοι· ἐπεὶ οὐ περιώσιον ἐγγυαλίξαι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1555">ἐνθάδε νῦν πάρʼ ἐμοὶ ξεινήιον ἀντομένοισιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1556">εἰ δέ τι τῆσδε πόρους μαίεσθʼ ἁλός, οἷά τε πολλὰ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1557">ἄνθρωποι χατέουσιν ἐπʼ ἀλλοδαπῇ περόωντες,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1558">ἐξερέω. δὴ γάρ με πατὴρ ἐπιίστορα πόντου</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1559">θῆκε Ποσειδάων τοῦδʼ ἔμμεναι. αὐτὰρ ἀνάσσω</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1560">παρραλίης, εἰ δή τινʼ ἀκούετε νόσφιν ἐόντες</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1561">Εὐρύπυλον Λιβύῃ θηροτρόφῳ ἐγγεγαῶτα.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1554"><q rend="double">Δέχθε, φίλοι· ἐπεὶ οὐ περιώσιον ἐγγυαλίξαι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1555"><q rend="double; merge">ἐνθάδε νῦν πάρʼ ἐμοὶ ξεινήιον ἀντομένοισιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1556"><q rend="double; merge">εἰ δέ τι τῆσδε πόρους μαίεσθʼ ἁλός, οἷά τε πολλὰ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1557"><q rend="double; merge">ἄνθρωποι χατέουσιν ἐπʼ ἀλλοδαπῇ περόωντες,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1558"><q rend="double; merge">ἐξερέω. δὴ γάρ με πατὴρ ἐπιίστορα πόντου</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1559"><q rend="double; merge">θῆκε Ποσειδάων τοῦδʼ ἔμμεναι. αὐτὰρ ἀνάσσω</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1560"><q rend="double; merge">παρραλίης, εἰ δή τινʼ ἀκούετε νόσφιν ἐόντες</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1561"><q rend="double; merge">Εὐρύπυλον Λιβύῃ θηροτρόφῳ ἐγγεγαῶτα.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1562">ὧς ηὔδα· πρόφρων δʼ ὑπερέσχεθε βώλακι χεῖρας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1563">Εὔφημος, καὶ τοῖα παραβλήδην προσέειπεν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1564">‘Ἀπίδα καὶ πέλαγος Μινώιον εἴ νύ που, ἥρως,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1565">ἐξεδάης, νημερτὲς ἀνειρομένοισιν ἔνισπε.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1566">δεῦρο γὰρ οὐκ ἐθέλοντες ἱκάνομεν, ἀλλὰ βαρείαις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1567">χρίμψαντες γαίης ἐπὶ πείρασι τῆσδε θυέλλαις</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1568">νῆα μεταχρονίην ἐκομίσσαμεν ἐς τόδε λίμνης</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1569">χεῦμα διʼ ἠπείρου βεβαρημένοι· οὐδέ τι ἴδμεν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1570">πῇ πλόος ἐξανέχει Πελοπηίδα γαῖαν ἱκέσθαι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1564"><q rend="double">Ἀπίδα καὶ πέλαγος Μινώιον εἴ νύ που, ἥρως,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1565"><q rend="double; merge">ἐξεδάης, νημερτὲς ἀνειρομένοισιν ἔνισπε.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1566"><q rend="double; merge">δεῦρο γὰρ οὐκ ἐθέλοντες ἱκάνομεν, ἀλλὰ βαρείαις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1567"><q rend="double; merge">χρίμψαντες γαίης ἐπὶ πείρασι τῆσδε θυέλλαις</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1568"><q rend="double; merge">νῆα μεταχρονίην ἐκομίσσαμεν ἐς τόδε λίμνης</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1569"><q rend="double; merge">χεῦμα διʼ ἠπείρου βεβαρημένοι· οὐδέ τι ἴδμεν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1570"><q rend="double; merge">πῇ πλόος ἐξανέχει Πελοπηίδα γαῖαν ἱκέσθαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1571">ὧς ἄρʼ ἔφη· ὁ δὲ χεῖρα τανύσσατο, δεῖξε δʼ
 						ἄπωθεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1572">φωνήσας πόντον τε καὶ ἀγχιβαθὲς στόμα λίμνης·</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1573">‘κείνη μὲν πόντοιο διήλυσις, ἔνθα μάλιστα</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1574">βένθος ἀκίνητον μελανεῖ· ἑκάτερθε δὲ λευκαὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1575">ῥηγμῖνες φρίσσουσι διαυγέες· ἡ δὲ μεσηγὺ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1576">ῥηγμίνων στεινὴ τελέθει ὁδὸς ἐκτὸς ἐλάσσαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1577">κεῖνο δʼ ὑπηέριον θείην Πελοπηίδα γαῖαν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1578">εἰσανέχει πέλαγος Κρήτης ὕπερ· ἀλλʼ ἐπὶ χειρὸς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1579">δεξιτερῆς, λίμνηθεν ὅτʼ εἰς ἁλὸς οἶδμα βάλητε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1580">τόφρʼ αὐτὴν παρὰ χέρσον ἐεργμένοι ἰθύνεσθε,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1581">ἔστʼ ἂν ἄνω τείνῃσι· περιρρήδην δʼ ἑτέρωσε</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1582">κλινομένης χέρσοιο, τότε πλόος ὔμμιν ἀπήμων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1583">ἀγκῶνος τέτατʼ ἰθὺς ἀπὸ προύχοντος ἰοῦσιν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1584">ἀλλʼ ἴτε γηθόσυνοι, καμάτοιο δὲ μήτις ἀνίη</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1585">γιγνέσθω, νεότητι κεκασμένα γυῖα μογῆσαι.’</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1573"><q rend="double">κείνη μὲν πόντοιο διήλυσις, ἔνθα μάλιστα</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1574"><q rend="double; merge">βένθος ἀκίνητον μελανεῖ· ἑκάτερθε δὲ λευκαὶ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1575"><q rend="double; merge">ῥηγμῖνες φρίσσουσι διαυγέες· ἡ δὲ μεσηγὺ</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1576"><q rend="double; merge">ῥηγμίνων στεινὴ τελέθει ὁδὸς ἐκτὸς ἐλάσσαι.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1577"><q rend="double; merge">κεῖνο δʼ ὑπηέριον θείην Πελοπηίδα γαῖαν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1578"><q rend="double; merge">εἰσανέχει πέλαγος Κρήτης ὕπερ· ἀλλʼ ἐπὶ χειρὸς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1579"><q rend="double; merge">δεξιτερῆς, λίμνηθεν ὅτʼ εἰς ἁλὸς οἶδμα βάλητε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1580"><q rend="double; merge">τόφρʼ αὐτὴν παρὰ χέρσον ἐεργμένοι ἰθύνεσθε,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1581"><q rend="double; merge">ἔστʼ ἂν ἄνω τείνῃσι· περιρρήδην δʼ ἑτέρωσε</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1582"><q rend="double; merge">κλινομένης χέρσοιο, τότε πλόος ὔμμιν ἀπήμων</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1583"><q rend="double; merge">ἀγκῶνος τέτατʼ ἰθὺς ἀπὸ προύχοντος ἰοῦσιν.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1584"><q rend="double; merge">ἀλλʼ ἴτε γηθόσυνοι, καμάτοιο δὲ μήτις ἀνίη</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1585"><q rend="double; merge">γιγνέσθω, νεότητι κεκασμένα γυῖα μογῆσαι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1586">Ἴσκεν ἐυφρονέων· οἱ δʼ αἶψʼ ἐπὶ νηὸς ἔβησαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1587">λίμνης ἐκπρομολεῖν λελιημένοι εἰρεσίῃσιν.</l>
@@ -6353,11 +6353,11 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1596">σφάξε κατὰ πρύμνης, ἐπὶ δʼ ἔννεπεν εὐχωλῇσιν·</l>
 					          <milestone n="1597" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1597">‘δαῖμον, ὅτις λίμνης ἐπὶ πείρασι τῆσδʼ
-						ἐφαάνθης,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1598">εἴτε σέγε Τρίτωνʼ, ἅλιον τέρας, εἴτε σε Φόρκυν,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1599">ἢ Νηρῆα θύγατρες ἐπικλείουσʼ ἁλοσύδναι,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1600">ἵλαθι, καὶ νόστοιο τέλος θυμηδὲς ὄπαζε.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1597"><q rend="double">δαῖμον, ὅτις λίμνης ἐπὶ πείρασι τῆσδʼ
+						ἐφαάνθης,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1598"><q rend="double; merge">εἴτε σέγε Τρίτωνʼ, ἅλιον τέρας, εἴτε σε Φόρκυν,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1599"><q rend="double; merge">ἢ Νηρῆα θύγατρες ἐπικλείουσʼ ἁλοσύδναι,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1600"><q rend="double; merge">ἵλαθι, καὶ νόστοιο τέλος θυμηδὲς ὄπαζε.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1601">ἦ ῥʼ, ἅμα δʼ εὐχωλῇσιν ἐς ὕδατα λαιμοτομήσας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1602">ἧκε κατὰ πρύμνης· ὁ δὲ βένθεος ἐξεφαάνθη</l>
@@ -6415,11 +6415,11 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1653">εἰ μή σφιν Μήδεια λιαζομένοις ἀγόρευσεν· </l>
                               <milestone n="1654" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1654">‘κέκλυτέ μευ. μούνη γὰρ ὀίομαι ὔμμι δαμάσσειν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1655">ἄνδρα τόν, ὅστις ὅδʼ ἐστί, καὶ εἰ παγχάλκεον ἴσχει</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1656">ὃν δέμας, ὁππότε μή οἱ ἐπʼ ἀκάματος πέλοι αἰών.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1657">ἀλλʼ ἔχετʼ αὐτοῦ νῆα θελήμονες ἐκτὸς ἐρωῆς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1658">πετράων, εἵως κεν ἐμοὶ εἴξειε δαμῆναι.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1654"><q rend="double">κέκλυτέ μευ. μούνη γὰρ ὀίομαι ὔμμι δαμάσσειν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1655"><q rend="double; merge">ἄνδρα τόν, ὅστις ὅδʼ ἐστί, καὶ εἰ παγχάλκεον ἴσχει</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1656"><q rend="double; merge">ὃν δέμας, ὁππότε μή οἱ ἐπʼ ἀκάματος πέλοι αἰών.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1657"><q rend="double; merge">ἀλλʼ ἔχετʼ αὐτοῦ νῆα θελήμονες ἐκτὸς ἐρωῆς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1658"><q rend="double; merge">πετράων, εἵως κεν ἐμοὶ εἴξειε δαμῆναι.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1659">ὧς ἄρʼ ἔφη· καὶ τοὶ μὲν ὑπὲκ βελέων ἐρύσαντο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1660">νῆʼ ἐπʼ ἐρετμοῖσιν, δεδοκημένοι ἥντινα ῥέξει</l>
@@ -6509,25 +6509,25 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1739">ζευξάμενος, τήν τʼ αὐτὸς ἑῷ ἀτίταλλε γάλακτι·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1740">ἡ δέ ἑ μειλιχίοισι παρηγορέεσκʼ ἐπέεσσιν·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1741">‘Τρίτωνος γένος εἰμί, τεῶν τροφός, ὦ φίλε,
-						παίδων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1742">οὐ κούρη· τρίτων γὰρ ἐμοὶ Λιβύη τε τοκῆες.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1743">ἀλλά με Νηρῆος παρακάτθεο παρθενικῇσιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1744">ἂμ πέλαγος ναίειν Ἀνάφης σχεδόν· εἶμι δʼ ἐς αὐγὰς</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1745">ἠελίου μετόπισθε, τεοῖς νεπόδεσσιν ἑτοίμη.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1741"><q rend="double">Τρίτωνος γένος εἰμί, τεῶν τροφός, ὦ φίλε,
+						παίδων,</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1742"><q rend="double; merge">οὐ κούρη· τρίτων γὰρ ἐμοὶ Λιβύη τε τοκῆες.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1743"><q rend="double; merge">ἀλλά με Νηρῆος παρακάτθεο παρθενικῇσιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1744"><q rend="double; merge">ἂμ πέλαγος ναίειν Ἀνάφης σχεδόν· εἶμι δʼ ἐς αὐγὰς</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1745"><q rend="double; merge">ἠελίου μετόπισθε, τεοῖς νεπόδεσσιν ἑτοίμη.</q></l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1746">τῷ δʼ ἄρʼ ἐπὶ μνῆστιν κραδίη βάλεν, ἔκ τʼ
 						ὀνόμηνεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1747">Αἰσονίδῃ· ὁ δʼ ἔπειτα θεοπροπίας Ἑκάτοιο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1748">θυμῷ πεμπάζων ἀνενείκατο φώνησέν τε·</l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1749">‘ὦ πέπον, ἦ μέγα δή δε καὶ ἀγλαὸν ἔμμορε
-						κῦδος.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1750">βώλακα γὰρ τεύξουσι θεοὶ πόντονδε βαλόντι</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1751">νῆσον, ἵνʼ ὁπλότεροι παίδων δέθεν ἐννάσσονται</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1752">παῖδες· ἐπεὶ Τρίτων ξεινήιον ἐγγυάλιξεν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1753">τήνδε τοι ἠπείροιο Λιβυστίδος. οὔ νύ τις ἄλλος</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1754">ἀθανάτων, ἢ κεῖνος, ὅ μιν πόρεν ἀντιβολήσας.’</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1749"><q rend="double">ὦ πέπον, ἦ μέγα δή δε καὶ ἀγλαὸν ἔμμορε
+						κῦδος.</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1750"><q rend="double; merge">βώλακα γὰρ τεύξουσι θεοὶ πόντονδε βαλόντι</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1751"><q rend="double; merge">νῆσον, ἵνʼ ὁπλότεροι παίδων δέθεν ἐννάσσονται</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1752"><q rend="double; merge">παῖδες· ἐπεὶ Τρίτων ξεινήιον ἐγγυάλιξεν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1753"><q rend="double; merge">τήνδε τοι ἠπείροιο Λιβυστίδος. οὔ νύ τις ἄλλος</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1754"><q rend="double; merge">ἀθανάτων, ἢ κεῖνος, ὅ μιν πόρεν ἀντιβολήσας.</q></l>
 					          <milestone unit="para"/>
 				        	  <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1755">ὧς ἔφατʼ· οὐδʼ ἁλίωσεν ὑπόκρισιν
 						Αἰσονίδαο</l>


### PR DESCRIPTION
Fix #1793.