### PR TITLE
(tlg2045.tlg001) put letter inside quote at 15.301

### DIFF
--- a/data/tlg2045/tlg001/tlg2045.tlg001.perseus-grc2.xml
+++ b/data/tlg2045/tlg001/tlg2045.tlg001.perseus-grc2.xml
@@ -7328,7 +7328,7 @@
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="298"><q>Πρὸς Παφίης, φθέγξασθε πάλιν, δρύες, ὡς ἐπὶ Πύρρης,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="299"><q rend="merge">ὡς ἐπὶ Δευκαλίωνος, ἐλέγξατε λυσσάδα κούρην.</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="300"><q rend="merge">δάφνη καὶ σὺ φίλη, δενδρώδεα ῥῆξον ἰωήν·</q> </l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="301"><q rend="merge">αἴθε καλὴ Νίκαια πάρος πέλε, καί κεν Ἀπόλλω</q>ν</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="301"><q rend="merge">αἴθε καλὴ Νίκαια πάρος πέλε, καί κεν Ἀπόλλων</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="302"><q rend="merge">ἁβροτέρην ἐδίωκε, καὶ οὐ φυτὸν ἔπλετο Δάφνη.</q></l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="303">ὣς φάτο· καὶ σύριγγι σαόφρονος ἐγγύθι κούρης</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:15" n="304">μάρτυν ἑῆς ὀδύνης, γαμίην ἐμελίζετο μολπήν.</l>


### PR DESCRIPTION
The last letter of the `q` quotation in this line is cut off: `Ἀπόλλω</q>ν`.

I found this by processing the file with a check to make sure there is no intervening text between `q` elements that are indicated to be merged with `rend="merge"`. The program sees `<q rend="merge">` at 15.302, scans backward for another `<q></q>` to merge it with, sees that what comes before is `...Ἀπόλλω</q>ν`, and then raises an error because it would have to merge the quotation "over" the nu.

You can reproduce it with SEDES tei2csv at commit [f76d1a36](https://github.com/sasansom/sedes/tree/f76d1a36aaf1080189e971fc9d1194bb588e45bf) in the perseus6 branch:

```
$ src/tei2csv Dion. canonical-greekLit/data/tlg2045/tlg001/tlg2045.tlg001.perseus-grc2.xml
[...]
Dion.,15,301,7,κεν,ἄν,10,⏑,auto,1,"αἴθε καλὴ Νίκαια πάρος πέλε, καί κεν Ἀπόλλω’ν"
Dion.,15,301,8,ἀπόλλων,ἀπόλλων,10.5,⏑––,auto,1,"αἴθε καλὴ Νίκαια πάρος πέλε, καί κεν Ἀπόλλω’ν"

Traceback (most recent call last):
  File "sedes/src/tei2csv", line 138, in <module>
    main()
  File "sedes/src/tei2csv", line 134, in main
    for row in process(f, work_identifier, merge_word):
  File "sedes/src/tei2csv", line 56, in process
    for loc, line in doc.lines():
  File "sedes/src/tei.py", line 593, in lines
    for event in filter_events(events(self.tree.find(f".//{NS}text/{NS}body"), 0, False)):
  File "sedes/src/tei.py", line 417, in filter_events
    raise ValueError("<q rend=\"merge\"> without a preceding </q>")
ValueError: <q rend="merge"> without a preceding </q>
```