### PR TITLE
(tlg0001.tlg001) text fixes

### DIFF
--- a/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
+++ b/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
@@ -1173,7 +1173,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="938">εἰς ἅλα κεκλιμένη, ὅσσον τʼ ἐπιμύρεται ἰσθμὸς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="939">χέρσῳ ἐπιπρηνὴς καταειμένος· ἐν δέ οἱ ἀκταὶ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="940">ἀμφίδυμοι, κεῖνται δʼ ὑπὲρ ὕδατος Λἰσήποιο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="941">Λ̓́ρκτων μιν καλέουσιν ὄρος περιναιετάοντες·</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="941">Ἄρκτων μιν καλέουσιν ὄρος περιναιετάοντες·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="942">καὶ τὸ μὲν ὑβρισταί τε καὶ ἄγριοι ἐνναίουσιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="943">Γηγενέες, μέγα θαῦμα περικτιόνεσσιν ἰδέσθαι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="944">ἓξ γὰρ ἑκάστῳ χεῖρες ὑπέρβιοι ἠερέθονται,</l>
@@ -1269,7 +1269,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1029">δεινός τε ζαμενής τε Δολιονίῳ πέσε δήμῳ.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1030">οὐδʼ ὅγε δηιοτῆτος ὑπὲρ μόρον αὖτις ἔμελλεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1031">οἴκαδε νυμφιδίους θαλάμους καὶ λέκτρον ἱκέσθαι.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1032">ἀλλά μιν Λἰσονίδης τετραμμένον ἰθὺς ἑοῖο</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1032">ἀλλά μιν Αἰσονίδης τετραμμένον ἰθὺς ἑοῖο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1033">πλῆξεν ἐπαΐξας στῆθος μέσον, ἀμφὶ δὲ δουρὶ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1034">ὀστέον ἐρραίσθη· ὁ δʼ ἐνὶ ψαμάθοισιν ἐλυσθεὶς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1035">μοῖραν ἀνέπλησεν. τὴν γὰρ θέμις οὔποτʼ ἀλύξαι</l>
@@ -1410,7 +1410,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1162">πασσυδίῃ μογέοντας ἐφέλκετο κάρτεϊ χειρῶν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1163">Ἡρακλέης, ἐτίνασσε δʼ ἀρηρότα δούρατα νηός.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1164">ἀλλʼ ὅτε δὴ Μυσῶν λελιημένοι ἠπείροιο</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1165">Ῥυνδακίδας προχοὰς μέγα τʼ ἠρίον Λἰγαίωνος</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1165">Ῥυνδακίδας προχοὰς μέγα τʼ ἠρίον Αἰγαίωνος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1166">τυτθὸν ὑπὲκ Φρυγίης παρεμέτρεον εἰσορόωντες,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1167">δὴ τότʼ ἀνοχλίζων τετρηχότος οἴδματος ὁλκοὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1168">μεσσόθεν ἆξεν ἐρετμόν. ἀτὰρ τρύφος ἄλλο μὲν αὐτὸς</l>
@@ -1435,7 +1435,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1186">Ἐκβασίῳ ῥέξαντες ὑπὸ κνέφας Ἀπόλλωνι.</l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1187">αὐτὰρ ὁ δαίνυσθαι ἑτάροις οἷς εὖ ἐπιτείλας</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1188">βῆ ῥ̓ ἴμεν εἰς ὕλην υἱὸς Διός, ὥς κεν ἐρετμὸν</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1188">βῆ ῥʼ ἴμεν εἰς ὕλην υἱὸς Διός, ὥς κεν ἐρετμὸν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1189">οἷ αὐτῷ φθαίη καταχείριον ἐντύνασθαι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1190">εὗρεν ἔπειτʼ ἐλάτην ἀλαλήμενος, οὔτε τι πολλοῖς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="1191">ἀχθομένην ὄζοις, οὐδὲ μέγα τηλεθόωσαν,</l>
@@ -1718,7 +1718,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="75">δηθύνειν. ὁ δʼ ἄρʼ αἰὲν ἀνούτατος ἣν διὰ μῆτιν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="76">ἀίσσοντʼ ἀλέεινεν· ἀπηνέα δʼ αἶψα νοήσας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="77">πυγμαχίην, ᾗ κάρτος ἀάατος, ᾗ τε χερείων,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="78">στῆ ῥ̓ ἄμοτον καὶ χερσὶν ἐναντία χεῖρας ἔμιξεν.</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="78">στῆ ῥʼ ἄμοτον καὶ χερσὶν ἐναντία χεῖρας ἔμιξεν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="79">ὡς δʼ ὅτε νήια δοῦρα θοοῖς ἀντίξοα γόμφοις</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="80">ἀνέρες ὑληουργοὶ ἐπιβλήδην ἐλάοντες</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="81">θείνωσι σφύρῃσιν, ἐπʼ ἄλλῳ δʼ ἄλλος ἄηται</l>
@@ -2506,7 +2506,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="797"><q rend="double; merge">ἤματι τῷδʼ ἀέκητι θεῶν ἐπελάσσαι ἄρηα,</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="798"><q rend="double; merge">Τυνδαρίδην Βέβρυξιν, ὅτʼ ἀνέρα κεῖνον ἔπεφνεν.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="799"><q rend="double; merge">τῶ νῦν ἥντινʼ ἐγὼ τῖσαι χάριν ἄρκιός εἰμι,</q></l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="800"><q rend="double; merge">τίσω προφρονέως. ἡ γὰρ θέμις ηπεοανοισιν</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="800"><q rend="double; merge">τίσω προφρονέως. ἡ γὰρ θέμις ἠπεοανοῖσιν</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="801"><q rend="double; merge">ἀνδράσιν, εὖτʼ ἄρξωσιν ἀρείονες ἄλλοι ὀφέλλειν.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="802"><q rend="double; merge">ξυνῇ μὲν πάντεσσιν ὁμόστολον ὔμμιν ἕπεσθαι</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="803"><q rend="double; merge">Δάσκυλον ὀτρυνέω, ἐμὸν υἱέα· τοῖο δʼ ἰόντος,</q></l>
@@ -2863,7 +2863,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1118">τοὺς δʼ ἄμυδις κρατερῷ σὺν δούρατι κύματος ὁρμὴ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1119">υἱῆας Φρίξοιο μετʼ ἠιόνας βάλε νήσου</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1120">νύχθʼ ὕπο λυγαίην· τὸ δὲ μυρίον ἐκ Διὸς ὕδωρ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1121">λῆξεν ἅμʼ ἠελίω·ͅ τάχα δʼ ἐγγύθεν ἀντεβόλησαν</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1121">λῆξεν ἅμʼ ἠελίῳ· τάχα δʼ ἐγγύθεν ἀντεβόλησαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1122">ἀλλήλοις, Ἄργος δὲ παροίτατος ἔκφατο μῦθον·</l>
 					          <milestone n="1123" unit="card"/>
 					          <milestone unit="para"/>
@@ -2898,7 +2898,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1148"><q rend="double; merge">Αἰήτης μεγάρῳ, κούρην τέ οἱ ἐγγυάλιξεν</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1149"><q rend="double; merge">Χαλκιόπην ἀνάεδνον ἐυφροσύνῃσι νόοιο.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1150"><q rend="double; merge">τῶν ἐξ ἀμφοτέρων εἰμὲν γένος. ἀλλʼ ὁ μὲν ἤδη</q></l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1151"><q rend="double; merge">γηραιὸς θάνε Φρίξος ἐν Λἰήταο δόμοισιν·</q></l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1151"><q rend="double; merge">γηραιὸς θάνε Φρίξος ἐν Αἰήταο δόμοισιν·</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1152"><q rend="double; merge">ἡμεῖς δʼ αὐτίκα πατρὸς ἐφετμάων ἀλέγοντες</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1153"><q rend="double; merge">νεύμεθʼ ἐς Ὀρχομενὸν κτεάνων Ἀθάμαντος ἕκητι.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:2" n="1154"><q rend="double; merge">εἰ δὲ καὶ οὔνομα δῆθεν ἐπιθύεις δεδαῆσθαι,</q></l>
@@ -3151,7 +3151,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="81"><q rend="double; merge">ἢ ἔπος ἠέ τι ἔργον, ὅ κεν χέρες αἵγε κάμοιεν</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="82"><q rend="double; merge">ἠπεδαναί· καὶ μή τις ἀμοιβαίη χάρις ἔστω.</q></l>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="83">ὧς ἔφαθʼ· Ἥρη δʼ αὖτις ἐπιφραδέως ἀγορευσεν·</l>
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="83">ὧς ἔφαθʼ· Ἥρη δʼ αὖτις ἐπιφραδέως ἀγόρευσεν·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="84"><q rend="double">οὔτι βίης χατέουσαι ἱκάνομεν, οὐδέ τι χειρῶν.</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="85"><q rend="double; merge">ἀλλʼ αὔτως ἀκέουσα τεῷ ἐπικέκλεο παιδὶ</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="86"><q rend="double; merge">παρθένον Αἰήτεω θέλξαι πόθῳ Αἰσονίδαο.</q></l>
@@ -3188,13 +3188,13 @@
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="111">ἦ ῥα, καὶ ἔλλιπε θῶκον· ἐφωμάρτησε δʼ Ἀθήνη·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="112">ἐκ δʼ ἴσαν ἄμφω ταίγε παλίσσυτοι. ἡ δὲ καὶ αὐτὴ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="113">βῆ ῥ̓ ἴμεν Οὐλύμποιο κατὰ πτύχας, εἴ μιν ἐφεύροι.</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="113">βῆ ῥʼ ἴμεν Οὐλύμποιο κατὰ πτύχας, εἴ μιν ἐφεύροι.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="114">εὗρε δὲ τόνγʼ ἀπάνευθε Διὸς θαλερῇ ἐν ἀλωῇ,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="115">οὐκ οἶον, μετα καὶ Γανυμήδεα, τόν ῥά ποτε Ζεὺς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="116">οὐρανῷ ἐγκατένασσεν ἐφέστιον ἀθανάτοισιν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="117">κάλλεος ἱμερθείς. ἀμφʼ ἀστραγάλοισι δὲ τώγε</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="118">χρυσείοις, ἅ τε κοῦροι ὁμήθεες, ἑψιόωντο.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="119">καί ῥ̓ ὁ μὲν ἤδη πάμπαν ἐνίπλεον ᾧ ὑπὸ μαζῷ</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="119">καί ῥʼ ὁ μὲν ἤδη πάμπαν ἐνίπλεον ᾧ ὑπὸ μαζῷ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="120">μάργος Ἔρως λαιῆς ὑποΐσχανε χειρὸς ἀγοστόν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="121">ὀρθὸς ἐφεστηώς· γλυκερὸν δέ οἱ ἀμφὶ παρειὰς</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="122">χροιῇ θάλλεν ἔρευθος. ὁ δʼ ἐγγύθεν ὀκλαδὸν ἧστο</l>
@@ -3980,7 +3980,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="819">ἄλλῃ δοιάζεσκεν· ἐέλδετο δʼ αἶψα φανῆναι</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="820">ἠῶ τελλομένην, ἵνα οἱ θελκτήρια δοίη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="821">φάρμακα συνθεσίῃσι, καὶ ἀντήσειεν ἐς ὠπήν.</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="822">πυκνὰ δʼ ἀνὰ κληῖδας ἑῶυ λύεσκε θυράων,</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="822">πυκνὰ δʼ ἀνὰ κληῖδας ἑῶν λύεσκε θυράων,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="823">αἴγλην σκεπτομένη· τῇ δʼ ἀσπάσιον βάλε φέγγος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="824">Ἠριγενής, κίνυντο δʼ ἀνὰ πτολίεθρον ἕκαστοι.</l>
 					          <milestone unit="para"/>
@@ -4808,7 +4808,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="182">ἀνδρῶν ἠὲ θεῶν νοσφίσσεται ἀντιβολήσας. </l>
                               <milestone n="183" unit="card"/>
 					          <milestone unit="para"/>
-                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="183">Ἠὼς μέν ῥ̓ ἐπὶ γαῖαν ἐκίδνατο, τοὶ δʼ ἐς
+                              <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="183">Ἠὼς μέν ῥʼ ἐπὶ γαῖαν ἐκίδνατο, τοὶ δʼ ἐς
 						ὅμιλον</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="184">ἷξον· θάμβησαν δὲ νέοι μέγα κῶας ἰδόντες</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="185">λαμπόμενον στεροπῇ ἴκελον Διός. ὦρτο δʼ ἕκαστος</l>
@@ -4852,7 +4852,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="219">κλαγγῇ μαιμώοντες· ὁ δʼ εὐτύκτῳ ἐνὶ δίφρῳ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="220">Αἰήτης ἵπποισι μετέπρεπεν, οὕς οἱ ὄπασσεν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="221">ἠέλιος πνοιῇσιν ἐειδομένους ἀνέμοιο,</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="222">σκαιῇ μέν ῥ̓ ἐνὶ χειρὶ σάκος δινωτὸν ἀείρων,</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="222">σκαιῇ μέν ῥʼ ἐνὶ χειρὶ σάκος δινωτὸν ἀείρων,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="223">τῇ δʼ ἑτέρῃ πεύκην περιμήκεα· πὰρ δέ οἱ ἔγχος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="224">ἀντικρὺ τετάνυστο πελώριον. ἡνία δʼ ἵππων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="225">γέντο χεροῖν Ἄψυρτος. υπεκπρὸ δὲ πόντον ἔταμνεν</l>
@@ -6033,7 +6033,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1310">ἦμος ὅτʼ ἐκ πατρὸς κεφαλῆς θόρε παμφαίνουσα,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1311">ἀντόμεναι Τρίτωνος ἐφʼ ὕδασι χυτλώσαντο.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1312">ἔνδιον ἦμαρ ἔην, περὶ δʼ ὀξύταται θέρον αὐγαὶ</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1313">ἠελίου Λιβύην· αἱ δὲ σχεδὸν Λἰσονίδαο</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1313">ἠελίου Λιβύην· αἱ δὲ σχεδὸν Αἰσονίδαο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1314">ἔσταν, ἕλον δʼ ἀπὸ χερσὶ καρήατος ἠρέμα πέπλον.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1315">αὐτὰρ ὅγʼ εἰς ἑτέρωσε παλιμπετὲς ὄμματʼ ἔνεικεν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1316">δαίμονας αἰδεσθείς· αὐτὸν δέ μιν ἀμφαδὸν οἶον</l>
@@ -6166,7 +6166,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1427">Ἑσπέρη αἴγειρος, πτελέη δʼ Ἐρυθηὶς ἔγεντο·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1428">Λἴγλη δʼ ἰτείης ἱερὸν στύπος. ἐκ δέ νυ κείνων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1429">δενδρέων, οἷαι ἔσαν, τοῖαι πάλιν ἔμπεδον αὔτως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1430">ἐξέφανεν, θάμβος περιώσιον, ἔκφατο δʼ Λἴγλη</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1430">ἐξέφανεν, θάμβος περιώσιον, ἔκφατο δʼ Αἴγλη</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1431">μειλιχίοις ἐπέεσσιν ἀμειβομένη χατέοντας·</l>
 					          <milestone unit="para"/>
                               <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1432"><q rend="double">ἦ ἄρα δὴ μέγα πάμπαν ἐφʼ ὑμετέροισιν ὄνειαρ</q></l>
@@ -6402,7 +6402,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1640">Δικταίην ὅρμοιο κατερχομένους ἐπιωγήν·</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1641">τὸν μὲν χαλκείης μελιηγενέων ἀνθρώπων</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1642">ῥίζης λοιπὸν ἐοντα μετʼ ἀνδράσιν ἡμιθέοισιν</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1643">Εὐρώπῃ Κρονίδης νήσου πόρεν ἔμμεναι σὖρον,</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1643">Εὐρώπῃ Κρονίδης νήσου πόρεν ἔμμεναι οὖρον,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1644">τρὶς περὶ χαλκείοις Κρήτην ποσὶ δινεύοντα.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1645">ἀλλʼ ἤτοι τὸ μὲν ἄλλο δέμας καὶ γυῖα τέτυκτο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1646">χάλκεος ἠδʼ ἄρρηκτος· ὑπαὶ δέ οἱ ἔσκε τένοντος</l>


### PR DESCRIPTION
Found in the course of reconciling an old beta code version with SEDES corrections against the current Perseus Unicode version (https://github.com/sasansom/sedes/issues/57, https://github.com/sasansom/sedes/issues/53).

The reciprocal corrections (things that were correct in recent Perseus and incorrect in SEDES) are https://github.com/sasansom/sedes/commit/76ddbb02421f671e1a25126a1f1860e06678f0d0.