### PR TITLE
(tlg0653.tlg001) text fixes

### DIFF
--- a/data/tlg0653/tlg001/tlg0653.tlg001.perseus-grc2.xml
+++ b/data/tlg0653/tlg001/tlg0653.tlg001.perseus-grc2.xml
@@ -559,7 +559,7 @@
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="428">πολλὰ μάλʼ ὀτλήσαντες ὅμως πάλιν ἐσκέψαντο</l>
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="429">ἀλλήλους ἐπὶ νηΐ. νότον δʼ ἐπὶ σήματι τούτῳ</l>
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="430">δείδιθι, μέχρι βορῆος ἀπαστράψαντος ἴδηαι. </l>
-<l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="431">εἰ δέ κεν ἑσπερίης μὲν ἁλὸς Κενταύρου ἀπείη</l>
+<l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="431">εἰ δέ κεν ἑσπερίης μὲν ἁλὸς <name type="constellation">Κενταύρου</name> ἀπείη</l>
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="432">ὦμος ὅσον προτέρης, ὀλίγη δέ μιν εἰλύοι ἀχλὺς</l>
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="433">αὐτόν, ἀτὰρ μετόπισθεν ἐοικότα σήματα τεύχοι</l>
 <l xml:base="urn:cts:greekLit:tlg0653.tlg001.perseus-grc2" n="434">νὺξ ἐπὶ παμφανόωντι Θυτηρίῳ, οὔ σε μάλα χρὴ</l>


### PR DESCRIPTION
Found in the course of reconciling an old beta code version with SEDES corrections against the current Perseus Unicode version (https://github.com/sasansom/sedes/issues/57, https://github.com/sasansom/sedes/issues/53).

Additionally, 1c3dbd3fb83ea47378e38d4e355a68cccdd7ec18 adds `<name type="constellation">` around "Κενταύρου" to match other constellations. See https://github.com/sasansom/sedes/issues/53#issuecomment-3657088857.