### PR TITLE
(tlg0533.tlg{016,017,018,020}) text fixes

### DIFF
--- a/data/tlg0533/tlg016/tlg0533.tlg016.perseus-grc3.xml
+++ b/data/tlg0533/tlg016/tlg0533.tlg016.perseus-grc3.xml
@@ -137,7 +137,7 @@
 <pb n="52"/>
 <l n="37" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">θηλείῃσʼ οὐδʼ ὅσσον ἐπὶ χνόος ἦλθε παρειαῖς.</l>
 <l n="38" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">αἱ δὲ κόμαι θυόεντα πέδῳ λείβουσιν ἔλαια·</l>
-<l n="39" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">οὐ λίπος Ἀπόλλωνος ἀποοτάζουσιν ἔθειραι,</l>
+<l n="39" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">οὐ λίπος Ἀπόλλωνος ἀποστάζουσιν ἔθειραι,</l>
 <l n="40" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">ἀλλʼ αὐτὴν πανάκειαν· ἐν ἄστεϊ δʼ ᾧ κεν ἐκεῖναι </l>
 <l n="41" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3">πρῶκες ἔραζε πέσωσιν ἀκήρια πάντʼ ἐγένοντο.</l>
 <l n="42" xml:base="urn:cts:greekLit:tlg0533.tlg016.perseus-grc3" rend="align(center)">τέχνῃ δʼ ἀμφιλαφὴς οὔ τις τόσον ὅσσον Ἀπόλλων·</l>

--- a/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
+++ b/data/tlg0533/tlg017/tlg0533.tlg017.perseus-grc3.xml
@@ -105,7 +105,7 @@
 <l n="5" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3">παῖς ἔτι κουρίζουσα τάδε προσέειπε γονῆα </l>
 <l n="6" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q>δός μοι παρθενίην αἰώνιον, ἄππα, φυλάσσειν,</q></l>
 <l n="7" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">καὶ πολυωνυμίην, ἵνα μή μοι Φοῖβος ἐρίζῃ.</q></l>
-<l n="8" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">δὸς δʼ ἰοὺς καὶ τόξα—;ἔα, πάτερ, οὔ σε Φαρέτρην</q></l>
+<l n="8" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">δὸς δʼ ἰοὺς καὶ τόξα—ἔα, πάτερ, οὔ σε Φαρέτρην</q></l>
 <l n="9" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">οὐδʼ αἰτέω μέγα τόξον· ἐμοὶ Κύκλωπες ὀιστοὺς</q></l>
 <l n="10" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">αὐτίκα τεχνήσονται, ἐμοὶ δʼ εὐκαμπὲς ἄεμμα· </q></l>
 <l n="11" xml:base="urn:cts:greekLit:tlg0533.tlg017.perseus-grc3"><q rend="merge">ἀλλὰ φαεσφορίην τε καὶ ἐς γόνυ μέχρι χιτῶνα</q></l>

--- a/data/tlg0533/tlg018/tlg0533.tlg018.perseus-grc3.xml
+++ b/data/tlg0533/tlg018/tlg0533.tlg018.perseus-grc3.xml
@@ -279,7 +279,7 @@
 <l n="175" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">ῥώσωνται νιφάδεσσιν ἐοικότες ἢ ἰσάριθμοι </q></l>
 <l n="176" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">τείρεσιν, ἡνίκα πλεῖστα κατʼ ἠέρα βουκολέονται,</q></l>
 <l n="177" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">φρούρια καὶ <del>κῶμαι Λοκρῶν καὶ Δελφίδες ἄκραι</del></q></l>
-<l n="178" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">καὶ πεδία Κρισσαῖα καὶ ἠπείροι <del>ο φάραγγες</del><note xml:lang="eng">The best MSS. and the Aldine (1513) have only <foreign xml:lang="grc">φρούρια καὶ</foreign> (177) and <foreign xml:lang="grc">καὶ πεδία Κρισσαῖα καὶ ἤπειροι</foreign> (178). The words in brackets are a worthless attempt to supply the lacunae and are found only in the late and inferior MSS. (Schneider' s LMNO).</note></q></l>
+<l n="178" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">καὶ πεδία Κρισσαῖα καὶ ἠπείροι<del>ο φάραγγες</del><note xml:lang="eng">The best MSS. and the Aldine (1513) have only <foreign xml:lang="grc">φρούρια καὶ</foreign> (177) and <foreign xml:lang="grc">καὶ πεδία Κρισσαῖα καὶ ἤπειροι</foreign> (178). The words in brackets are a worthless attempt to supply the lacunae and are found only in the late and inferior MSS. (Schneider' s LMNO).</note></q></l>
 <l n="179" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">ἀμφιπεριστείνωνται, ἴδωσι δὲ πίονα καπνὸν <note xml:lang="eng"><foreign xml:lang="grc">καρπὸν</foreign> MSS.; corr. Reiske.</note></q></l>
 <l n="180" xml:base="urn:cts:greekLit:tlg0533.tlg018.perseus-grc3"><q rend="merge">γείτονος αἰθομένοιο, καὶ οὐκέτι μοῦνον ἀκουῇ, </q></l>
 <pb n="100"/>

--- a/data/tlg0533/tlg020/tlg0533.tlg020.perseus-grc3.xml
+++ b/data/tlg0533/tlg020/tlg0533.tlg020.perseus-grc3.xml
@@ -149,7 +149,7 @@
 <l n="51" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3">ὤρεσιν ἐν Τμαρίοισιν ὑποβλέπει ἄνδρα λέαινα</l>
 <l n="52" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3">ὠμοτόκος, τᾶς φαντὶ πέλειν βλοσυρώτατον ὄμμα,</l>
 <l n="53" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3"><q>χάζευ,</q> ἔφα, <q>μή τοι πέλεκυν μέγαν ἐν χροΐ πάξω.</q></l>
-<l n="54" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3"><q rend="mereg">ταῦτα δʼ ἐμὸν θησεῖ στεγανὸν δόμον, ᾧ ἔνι δαῖτας</q></l>
+<l n="54" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3"><q rend="merge">ταῦτα δʼ ἐμὸν θησεῖ στεγανὸν δόμον, ᾧ ἔνι δαῖτας</q></l>
 <l n="55" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3"><q rend="merge">αἰὲν ἐμοῖς ἑτάροισιν ἄδην θυμαρέας ἀξῶ.</q> </l>
 <l n="56" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3">εἶπεν ὁ παῖς, Νέμεσις δὲ κακὰν ἐγράψατο φωνάν.</l>
 <l n="57" xml:base="urn:cts:greekLit:tlg0533.tlg020.perseus-grc3">Δαμάτηρ δʼ ἄφατόν τι κοτέσσατο, γείνατο <note xml:lang="eng"><foreign xml:lang="grc">γείνατο</foreign> MSS.; <foreign xml:lang="grc">γείνετο</foreign> Schneider.</note> δʼ ἁ <note xml:lang="eng"><foreign xml:lang="grc">ἁ</foreign> MSS.; <foreign xml:lang="grc">αὖ</foreign> Bergk.</note> θεύς·</l>


### PR DESCRIPTION
Found in the course of reconciling an old beta code version with SEDES corrections against the current Perseus Unicode version (https://github.com/sasansom/sedes/issues/57, https://github.com/sasansom/sedes/issues/53).

The reciprocal corrections (things that were correct in recent Perseus and incorrect in SEDES) are https://github.com/sasansom/sedes/compare/1ae2763408d22cc8fecbd9d06849722bbad65729...ca5bb81a08eb75e75cc1330c7285c2c07a12efe6.