### PR TITLE
(tlg2046.tlg001) text fixes

### DIFF
--- a/data/tlg2046/tlg001/tlg2046.tlg001.perseus-grc2.xml
+++ b/data/tlg2046/tlg001/tlg2046.tlg001.perseus-grc2.xml
@@ -3014,7 +3014,7 @@
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="523">ἀντιθέοιο Θόαντος· ἐπʼ ἄλλῳ δʼ ἄλλος ἀΰτει</l>
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="524">ἅρματι· τοὶ δʼ ἐφέροντο διʼ εὐρυχόρου πεδίοιο <note place="inline" xml:lang="eng">There is a long hiatus here: the lost verses contained an account of accidents to Thoas and Eurypylus, and the text resumes in the middle of a speech (by Nestor?) in praise of the horses of Menelaus.</note> </l>
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="525"><gap reason="lost" rend=" * * * * * * * * "/> </l>
-<l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="526"><q>Ἤλιδος ἐκ δίης, ἐπεὶ ἦ μέγα ἔργον ἔρεξε </q></l>
+<l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="526"><q cert="unknown">Ἤλιδος ἐκ δίης, ἐπεὶ ἦ μέγα ἔργον ἔρεξε </q></l>
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="527"><q rend="merge">παρφθάμενος θοὸν ἅρμα κακόφρονος Οἰνομάοιο,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="528"><q rend="merge">ὅς ῥα τότʼ ἠιθέοισιν ἀνηλέα τεῦχεν ὄλεθρον</q></l>
 <l xml:base="urn:cts:greekLit:tlg2046.tlg001.perseus-grc2:4" n="529"><q rend="merge">κούρης ἀμφὶ γάμοιο περίφρονος Ἱπποδαμείης·</q></l>


### PR DESCRIPTION
Found in the course of reconciling an old beta code version with SEDES corrections against the current Perseus Unicode version (https://github.com/sasansom/sedes/issues/57, https://github.com/sasansom/sedes/issues/53).

The complementary corrections (things that were correct in recent Perseus and incorrect in SEDES) are https://github.com/sasansom/sedes/compare/08b601b06f8946dba7fa84429237db89e33585cc...48a9947bef99db534ead88def0403ec06912a246.

I've marked the pull request as a draft because I need your input on two questions.

1. At 3.67a, there's a [literal "†" mark in the text](https://github.com/PerseusDL/canonical-greekLit/blob/16de4dedc7a7020dbab7f82438d4b9a134c3ca9b/data/tlg2046/tlg001/tlg2046.tlg001.perseus-grc2.xml#L1724), just after the gap. It's not there in the [book scan](https://archive.org/details/falloftroywithen00quinuoft/page/120/mode/1up). Is the "†" supposed to be there?
2. There is a gap between 4.524 and 4.526. Evidently, there's a quotation that begins somewhere in the gap, because there's a closing quotation mark at 4.532. (See [book scan](https://archive.org/details/falloftroywithen00quinuoft/page/204/mode/1up).) The TEI handles this situation by [starting a `<q>` element](https://github.com/PerseusDL/canonical-greekLit/blob/16de4dedc7a7020dbab7f82438d4b9a134c3ca9b/data/tlg2046/tlg001/tlg2046.tlg001.perseus-grc2.xml#L3017) immediately after the gap at 4.526. However, this makes it appear as though the quotation properly starts at 4.526, which I don't think is the case—the actual start of the quotation is lost, somewhere inside the gap.

   Is there a notation to handle a case like this? A `rend` setting that means to suppress the printing of the opening quotation mark, something like that?