### PR TITLE
(tlg0005.tlg001) text fixes

### DIFF
--- a/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc2.xml
+++ b/data/tlg0005/tlg001/tlg0005.tlg001.perseus-grc2.xml
@@ -247,7 +247,7 @@
       <lg> 
         <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="146">πλῆρές τοι μέλιτος τὸ καλὸν στόμα Θύρσι γένοιτο, </l>
         <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="147">πλῆρές τοι σχαδόνων, καὶ ἀπʼ Αἰγίλω ἰσχάδα τρώγοις </l>
-        <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="148">ἁδεῖαν, τέττιγος ἐπεὶ τύγα φέρτερον ᾁδεις. </l> <pb n="67"/>
+        <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="148">ἁδεῖαν, τέττιγος ἐπεὶ τύγα φέρτερον ᾄδεις. </l> <pb n="67"/>
         <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="149">ἠνίδε τοι τὸ δέπας· θᾶσαι φίλος, ὡς καλὸν ὄσδει· </l>
         <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="150">Ὡρᾶν πεπλύσθαί νιν ἐπὶ κράναισι δοκησεῖς. </l>
         <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:1" n="151">ὧδʼ ἴθι Κισσαίθα, τὺ δʼ ἄμελγέ νιν. αἱ δὲ χίμαιραι, </l>
@@ -470,7 +470,7 @@
     <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="47">οὐχ οὑτῶς ὥδωνις ἐπὶ πλέον ἄγαγε λύσσας, </l>
     <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="48">ὥστʼ οὐδὲ φθίμενόν νιν ἄτερ μαζοῖο τίθητι; </l>
     <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="49">ζαλωτὸς μὲν ἐμὶν ὁ τὸν ἄτροπον ὕπνον ἰαύων </l>
-    <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="50">Ἐνδυμίων, ζαλῶ δὲ φίλα γύναιἸασίωνα, </l>
+    <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="50">Ἐνδυμίων, ζαλῶ δὲ φίλα γύναι Ἰασίωνα, </l>
     <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="51">ὃς τοσσῆνʼ ἐκύρησεν, ὅσʼ οὐ πευσεῖσθε βέβαλοι. </l>
     <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="52">Ἀλγέω τὰν κεφαλάν, τὶν δʼ οὐ μέλει. οὐκέτʼ ἀείδω, </l>
     <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:3" n="53">κεισεῦμαι δὲ πεσών, καὶ τοὶ λύκοι ὧδέ μʼ ἔδονται. </l>
@@ -532,7 +532,7 @@
 <lg>  
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:4" n="20">λεπτὸς μὰν χὡ ταῦρος ὁ πυρρίχος. εἴθε λάχοιεν </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:4" n="21">τοὶ τῶ Λαμπριάδα, τοὶ δαμόται, ὅκκα θύωντι </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:4" n="22">τᾷ Ἡρᾳ, τοιόνδε· κακοχράσμων γὰρ ὁ δᾶμος.</l></lg> </sp> 
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:4" n="22">τᾷ Ἥρᾳ, τοιόνδε· κακοχράσμων γὰρ ὁ δᾶμος.</l></lg> </sp> 
 <sp> <speaker>Κορύδων</speaker> 
 <lg> 
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:4" n="23">καὶ μὰν ἐς Στομάλιμνον ἐλαύνεται ἔς τε τὰ Φύσκω, </l>
@@ -1244,7 +1244,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="23">Δάφνιδι μὲν κορύναν, τάν μοι πατρὸς ἔτρεφεν ἀγρός, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="24">αὐτοφυῆ, τὰν οὐδʼ ἂν ἴσως μωμάσατο τέκτων, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="25">τήνῳ δὲ στρόμβω καλὸν ὄστρακον, ὧ κρέας αὐτὸς </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="26">σιτήθην πέτραισιν ἐνἸκαρίαισι δοκεύσας, </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="26">σιτήθην πέτραισιν ἐν Ἰκαρίαισι δοκεύσας, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="27">πέντε ταμὼν πέντʼ οὖσιν· ὁ δʼ ἐγκαναχήσατο κόχλῳ. </l>
   <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="28">Βουκολικαὶ Μοῖσαι μάλα χαίρετε, φαίνετε δʼ ᾠδάς, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:9" n="29">τάς ποκʼ ἐγὼ τήνοισι παρὼν ἄεισα νομεῦσι, </l>
@@ -1294,7 +1294,7 @@
 <sp> <speaker>Βάττος</speaker> 
 <lg>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:10" n="15b" part="F">ἁ Πολυβώτα, </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:10" n="16">ἃ πρᾶν ἀμάντεσσι παρʼ ἹΙπποκίωνι ποταύλει.</l></lg> </sp> 
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:10" n="16">ἃ πρᾶν ἀμάντεσσι παρʼ Ἱπποκίωνι ποταύλει.</l></lg> </sp> 
 <sp> <speaker>Μίλων</speaker> 
 <lg> 
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:10" n="17">εὗρε θεὸς τὸν ἀλιτρόν· ἔχεις πάλαι ὧν ἐπεθύμεις. </l>
@@ -1479,7 +1479,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="4">οἳ θνατοὶ πελόμεσθα, τὸ δʼ αὔριον οὐκ ἐσορῶμες· </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="5">ἀλλὰ καὶ ὡμφιτρύωνος ὁ χαλκεοκάρδιος υἱός, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="6">ὃς τὸν λῖν ὑπέμεινε τὸν ἄγριον, ἤρατο παιδός, </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="7">τῶ χαρίεντος Ὑλα, τῶ τὰν πλοκαμῖδα φορεῦντος, </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="7">τῶ χαρίεντος Ὕλα, τῶ τὰν πλοκαμῖδα φορεῦντος, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="8">καί νιν πάντʼ ἐδίδαξε πατὴρ ὡσεὶ φίλον υἱέα, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="9">ὅσσα μαθὼν ἀγαθὸς καὶ ἀοίδιμος αὐτὸς ἔγεντο· </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="10">χωρὶς δʼ οὐδέποκʼ ἦς, οὔτʼ εἰ μέσον ἆμαρ ὄροιτο, </l>
@@ -1488,12 +1488,12 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="13">σεισαμένας πτερὰ ματρὸς ἐπʼ αἰθαλόεντι πετεύρῳ, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="14">ὡς αὐτῷ κατὰ θυμὸν ὁ παῖς πεποναμένος εἴη, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="15">αὐτῷ δʼ εὖ ἕλκων ἐς ἀλαθινὸν ἄνδρʼ ἀποβαίη. </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="16">ἀλλʼ ὅτε τὸ χρύσειον ἔπλει μετὰ κῶαςἸήσων </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="16">ἀλλʼ ὅτε τὸ χρύσειον ἔπλει μετὰ κῶας Ἰήσων </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="17">Αἰσονίδας, οἱ δʼ αὐτῷ ἀριστῆες συνέποντο </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="18">πασᾶν ἐκ πολίων προλελεγμένοι, ὧν ὄφελός τι, </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="19">ἵκετο χὡ ταλαεργὸς ἀνὴρ ἐς ἀφνειὸνἸωλκόν, </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="19">ἵκετο χὡ ταλαεργὸς ἀνὴρ ἐς ἀφνειὸν Ἰωλκόν, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="20">Ἀλκμήνης υἱὸς Μιδεάτιδος ἡρωίνης, </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="21">σὺν δʼ αὐτῷ κατέβαινεν Ὑλας εὔεδρον ἐς Ἀργώ, </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="21">σὺν δʼ αὐτῷ κατέβαινεν Ὕλας εὔεδρον ἐς Ἀργώ, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="22">ἅτις κυανεᾶν οὐχ ἥψατο συνδρομάδων ναῦς, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="23">ἀλλὰ διεξάιξε—βαθὺν δʼ εἰσέδραμε Φᾶσιν— </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="24">αἰετὸς ἐς μέγα λαῖτμα· ἀφʼ οὗ τότε χοιράδες ἔσταν. </l>
@@ -1508,7 +1508,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="33">δειελινοί, πολλοὶ δὲ μίαν στορέσαντο χαμεύναν. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="34">λειμὼν γάρ σφιν ἔκειτο, μέγα στιβάδεσσιν ὄνειαρ, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="35">ἔνθεν βούτομον ὀξὺ βαθύν τʼ ἐτάμοντο κύπειρον. </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="36">κᾤχεθʼ Ὑλας ὁ ξανθὸς ὕδωρ ἐπιδόρπιον οἰσῶν </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="36">κᾤχεθʼ Ὕλας ὁ ξανθὸς ὕδωρ ἐπιδόρπιον οἰσῶν </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="37">αὐτῷ θʼ Ἡρακλῆι καὶ ἀστεμφεῖ Τελαμῶνι, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="38">οἳ μίαν ἄμφω ἑταῖροι ἀεὶ δαίνυντο τράπεζαν, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="39">χάλκεον ἄγγος ἔχων. τάχα δὲ κράναν ἐνόησεν </l>
@@ -1530,7 +1530,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="55">Ἀμφιτρυωνιάδας δὲ ταρασσόμενος περὶ παιδὶ </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="56">ᾤχετο, μαιωτιστὶ λαβὼν εὐκαμπέα τόξα </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="57">καὶ ῥόπαλον, τό οἱ αἰὲν ἐχάνδανε δεξιτερὴ χείρ. </l> <pb n="111"/>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="58">τρὶς μὲν Ὑλαν ἄυσεν, ὅσον βαρὺς ἤρυγε λαιμός· </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="58">τρὶς μὲν Ὕλαν ἄυσεν, ὅσον βαρὺς ἤρυγε λαιμός· </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="59">τρὶς δʼ ἄρʼ ὁ παῖς ὑπάκουσεν, ἀραιὰ δʼ ἵκετο φωνὰ </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="60">ἐξ ὕδατος, παρεὼν δὲ μάλα σχεδὸν εἴδετο πόρρω. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="61">ὡς δʼ ὁπότʼ ἠυγένειος ἀπόπροθι λῖς ἐσακούσας†, </l>
@@ -1539,12 +1539,12 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="64">Ἡρακλέης τοιοῦτος ἐν ἀτρίπτοισιν ἀκάνθαις </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="65">παῖδα ποθῶν δεδόνητο, πολὺν δʼ ἐπελάμβανε χῶρον. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="66">σχέτλιοι οἱ φιλέοντες· ἀλώμενος ὅσσʼ ἐμόγησεν </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="67">οὔρεα καὶ δρυμούς, τὰ δʼἸήσονος ὕστερα πάντʼ ἦς. </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="67">οὔρεα καὶ δρυμούς, τὰ δʼ Ἰήσονος ὕστερα πάντʼ ἦς. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="68">ναῦς γέμεν ἄρμενʼ ἔχοισα μετάρσια τῶν παρεόντων, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="69">ἱστία δʼ ἡμίθεοι μεσονύκτιον ἐξεκάθαιρον </l>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="70">Ἡρακλῆα μένοντες. ὁ δʼ ᾇ πόδες ἆγον ἐχώρει </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="71">μαινόμενος· χαλεπὸς γὰρ ἔσω θεὸς ἧπαρ ἄμυσσεν. </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="72">οὕτω μὲν κάλλιστος Ὑλας μακάρων ἀμιθρεῖται· </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="72">οὕτω μὲν κάλλιστος Ὕλας μακάρων ἀμιθρεῖται· </l>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="73">Ἡρακλέην δʼ ἥρωες ἐκερτόμεον λιποναύταν, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="74">οὕνεκεν ἠρώησε τριακοντάζυγον Ἀργώ, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:13" n="75">πεζᾷ δʼ ἐς Κόλχους τε καὶ ἄξενον ἵκετο Φᾶσιν. </l></div> 
@@ -1778,7 +1778,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="63">χρησμὼς ἁ πρεσβῦτις ἀπῴχετο θεσπίξασα.</l></lg> </sp> 
 <sp> <speaker>Πραχινόα</speaker> 
 <lg> 
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="64">πάντα γυναῖκες ἴσαντι, καὶ ὡς Ζεὺς ἠγάγεθʼ Ἡρην.</l></lg> </sp> 
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="64">πάντα γυναῖκες ἴσαντι, καὶ ὡς Ζεὺς ἠγάγεθʼ Ἥρην.</l></lg> </sp> 
 <sp> <speaker>Γοργώ</speaker> 
 <lg>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="65">θᾶσαι Πραξινόα, περὶ τὰς θύρας ὅσσος ὅμιλος. <pb n="119"/></l></lg> </sp> 
@@ -1842,7 +1842,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="99">φθεγξεῖταί τι σάφʼ οἶδα καλόν· διαθρύπτεται ἤδη.</l></lg> </sp> 
 <sp> <speaker>Γυνή Ἀοιδός</speaker> 
 <lg>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="100">δέσποινʼ, ἃ Γολγώς τε καὶἸδάλιον ἐφίλασας </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="100">δέσποινʼ, ἃ Γολγώς τε καὶ Ἰδάλιον ἐφίλασας </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="101">αἰπεινάν τʼ Ἐρύκαν, χρυσῷ παίζοισʼ Ἀφροδίτα· </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="102">οἷόν τοι τὸν Ἄδωνιν ἀπʼ ἀενάω Ἀχέροντος </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:15" n="103">μηνὶ δυωδεκάτῳ μαλακαὶ πόδας ἄγαγον Ὧραι. </l>
@@ -1916,7 +1916,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="17">ἄργυρον, οὐδέ κεν ἰὸν ἀποτρίψας τινὶ δοίη, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="18">ἀλλʼ εὐθὺς μυθεῖται· <q>ἀπωτέρω ἢ γόνυ κνάμα·</q> </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="19"><q rend="merge">αὐτῷ μοί τι γένοιτο· θεοὶ τιμῶσιν ἀοιδούς.</q> </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="20"><q rend="merge">τίς δέ κεν ἄλλου ἀκούσαι; ἅλις πάντεσσιν Ὁμηρος.</q> </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="20"><q rend="merge">τίς δέ κεν ἄλλου ἀκούσαι; ἅλις πάντεσσιν Ὅμηρος.</q> </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="21"><q rend="merge">οὗτος ἀοιδῶν λῷστος, ὃς ἐξ ἐμεῦ οἴσεται οὐδέν.</q> </l>
   <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="22">δαιμόνιοι, τί δὲ κέρδος ὁ μυρίος ἔνδοθι χρυσὸς </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="23">κείμενος; οὐχ ἅδε πλούτου φρονέουσιν ὄνασις, </l>
@@ -1953,7 +1953,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="54">δηναιὸν κλέος ἔσχεν, ἐσιγάθη δʼ ἂν ὑφορβὸς </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="55">Εὔμαιος, καὶ βουσὶ Φιλοίτιος ἀμφʼ ἀγελαίαις </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="56">ἔργον ἔχων, αὐτός τε περίσπλαγχνος Λαέρτης, </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="57">εἰ μή σφεας ὤνασανἸάονος ἀνδρὸς ἀοιδαί. </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="57">εἰ μή σφεας ὤνασαν Ἰάονος ἀνδρὸς ἀοιδαί. </l>
   <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="58">Ἐκ Μοισᾶν ἀγαθὸν κλέος ἔρχεται ἀνθρώποισι, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="59">χρήματα δὲ ζώοντες ἀμαλδύνουσι θανόντων. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:16" n="60">ἀλλʼ ἶσος γὰρ ὁ μόχθος ἐπʼ ᾀόνι κύματα μετρεῖν, </l>
@@ -2378,11 +2378,11 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="24">ἱππῆες κιθαρισταί, ἀεθλητῆρες ἀοιδοί· </l>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="25">Κάστορος ἢ πρώτου Πολυδεύκεος ἄρξομʼ ἀείδειν; </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="26">ἀμφοτέρους ὑμνέων Πολυδεύκεα πρῶτον ἀείσω. </l> 
-  <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22"  n="27">Ἡμὲν ἄρα προφυγοῦσα πέτρας εἰς ἓν ξυνιούσας </l>
+  <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22"  n="27">Ἡ μὲν ἄρα προφυγοῦσα πέτρας εἰς ἓν ξυνιούσας </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="28">Ἀργὼ καὶ νιφόεντος ἀταρτηρὸν στόμα Πόντου </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="29">Βέβρυκας εἰσαφίκανε θεῶν φίλα τέκνα φέρουσα. </l>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="30">ἔνθα μιῆς πολλοὶ κατὰ κλίμακος ἀμφοτέρων ἒξ </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="31">τοίχων ἄνδρες ἔβαινονἸησονίης ἀπὸ νηός. </l> <pb n="141"/>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="31">τοίχων ἄνδρες ἔβαινον Ἰησονίης ἀπὸ νηός. </l> <pb n="141"/>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="32">ἐκβάντες δʼ ἐπὶ θῖνα βαθὺν καὶ ὑπήνεμον ἀκτὴν </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="33">εὐνάς τʼ ἐστόρνυντο πυρεῖά τε χερσὶν ἐνώμων. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:22" n="34">Κάστωρ δʼ αἰολόπωλος ὅ τʼ οἰνωπὸς Πολυδεύκης </l>
@@ -2671,7 +2671,7 @@
 <div type="textpart" subtype="poem" xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2" n="24"> 
 <head rend="align(center)">Ἡρακλίσκος</head> 
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="1">Ἡρακλέα δεκάμηνον ἐόντα πόχʼ ἁ Μιδεᾶτις </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="2">Ἀλκμήνα καὶ νυκτὶ νεώτερονἸφικλῆα, </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="2">Ἀλκμήνα καὶ νυκτὶ νεώτερον Ἰφικλῆα, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="3">ἀμφοτέρους λούσασα καὶ ἐμπλήσασα γάλακτος, </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="4">χαλκείαν κατέθηκεν ἐς ἀσπίδα, τὰν Πτερελάου </l>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="5">Ἀμφιτρύων καλὸν ὅπλον ἀπεσκύλευσε πεσόντος. </l>
@@ -2730,7 +2730,7 @@
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="58">κουροσύνᾳ, γελάσας δὲ πάρος κατέθηκε ποδοῖιν </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="59">πατρὸς ἑοῦ θανάτῳ κεκαρωμένα δεινὰ πέλωρα. </l> <pb n="153"/>
   <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="60">Ἀλκμήνα μὲν ἔπειτα ποτὶ σφέτερον βάλε κόλπον </l>
-<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="61">ξηρὸν ὑπαὶ δείους ἀκρόχλοονἸφικλῆα· </l>
+<l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="61">ξηρὸν ὑπαὶ δείους ἀκρόχλοον Ἰφικλῆα· </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="62">Ἀμφιτρύων δὲ τὸν ἄλλον ὑπʼ ἀμνείαν θέτο χλαῖναν </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="63">παῖδα, πάλιν δʼ ἐς λέκτρον ἰὼν ἐμνάσατο κοίτου. </l>
 <l xml:base="urn:cts:greekLit:tlg0005.tlg001.perseus-grc2:24" n="64">ὄρνιθες τρίτον ἄρτι τὸν ἔσχατον ὄρθρον ἄειδον· </l>


### PR DESCRIPTION
Found in the course of reconciling an old beta code version with SEDES corrections against the current Perseus Unicode version (https://github.com/sasansom/sedes/issues/57, https://github.com/sasansom/sedes/issues/53).

The complementary corrections (things that were correct in recent Perseus and incorrect in SEDES) are https://github.com/sasansom/sedes/compare/a687473f50d7e4b6230e993df08c6ff62304cd90...1cf6377bac5822ab9ddc20451d4a9916afb5938b.

Commit 9d49227768d721d9e232161dc87a0e0bad0fc715 adds a quotation element at 23.47–48 that wasn't there before. The [book scan](https://archive.org/details/idyllsoftheocrit00theouoft/page/148/mode/2up) actually has unbalanced quotation marks. A nested quotation appears to be the correct interpretation. (And deviates from the scan to an equal degree: instead of the TEI having one fewer open quotation mark, now it has one more close quotation mark.)