### PR TITLE
Fix language ident typo 'grec' -> 'grc' in tlg0007.tlg077 per #1832

### DIFF
--- a/data/tlg0007/tlg077/tlg0007.tlg077.perseus-grc2.xml
+++ b/data/tlg0007/tlg077/tlg0007.tlg077.perseus-grc2.xml
@@ -70,7 +70,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 </encodingDesc>
 <profileDesc>
 <langUsage>
-<language ident="grec">Greek</language>
+<language ident="grc">Greek</language>
 <language ident="lat">Latin</language>
 </langUsage>
 <particDesc>


### PR DESCRIPTION
All other files have been fixed, thank you :)

This is the last offender, resolves #1832 all files look fine from my scans.