### PR TITLE
Fix language ident typo 'grec' -> 'grc' in tlg0033.tlg001 per #1832

### DIFF
--- a/data/tlg0033/tlg001/tlg0033.tlg001.perseus-eng2.xml
+++ b/data/tlg0033/tlg001/tlg0033.tlg001.perseus-eng2.xml
@@ -56,7 +56,7 @@
         <profileDesc>
             <langUsage>
                 <language ident="eng">English</language>
-                <language ident="grec">Greek</language>
+                <language ident="grc">Greek</language>
                 <language ident="lat">Latin</language>
             </langUsage>
         </profileDesc>


### PR DESCRIPTION
Same defect class as #1848 — `<language ident="grec">` should be `<language ident="grc">` (ISO 639-2 for Ancient Greek).

Found by grepping the repo for remaining non-standard `<language ident>` values after PR #1848 was merged. This file (`perseus-eng2.xml`, an English translation) was not caught by the prior sweep.