### PR TITLE
Add citeStructure-based refsDecl to Euripides editions and translations

### DIFF
--- a/data/tlg0006/tlg001/tlg0006.tlg001.perseus-eng2.xml
+++ b/data/tlg0006/tlg001/tlg0006.tlg001.perseus-eng2.xml
@@ -54,6 +54,12 @@
                <p>This pointer pattern extracts lines</p>
             </cRefPattern>
          </refsDecl>
+
+                  <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
       </encodingDesc>
       <profileDesc>
          <langUsage>

--- a/data/tlg0006/tlg001/tlg0006.tlg001.perseus-grc2.xml
+++ b/data/tlg0006/tlg001/tlg0006.tlg001.perseus-grc2.xml
@@ -53,6 +53,12 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
         </refsDecl>
+
+        <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
 
         <profileDesc>

--- a/data/tlg0006/tlg002/tlg0006.tlg002.perseus-eng2.xml
+++ b/data/tlg0006/tlg002/tlg0006.tlg002.perseus-eng2.xml
@@ -58,6 +58,11 @@
                <p>This pointer pattern extracts lines</p>
             </cRefPattern>
          </refsDecl>
+         <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
       </encodingDesc>
       <profileDesc>
          <langUsage>

--- a/data/tlg0006/tlg002/tlg0006.tlg002.perseus-grc2.xml
+++ b/data/tlg0006/tlg002/tlg0006.tlg002.perseus-grc2.xml
@@ -52,6 +52,12 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <profileDesc>

--- a/data/tlg0006/tlg003/tlg0006.tlg003.perseus-eng2.xml
+++ b/data/tlg0006/tlg003/tlg0006.tlg003.perseus-eng2.xml
@@ -57,6 +57,12 @@
                <p>This pointer pattern extracts lines</p>
             </cRefPattern>
          </refsDecl>
+
+         <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
       </encodingDesc>
       <profileDesc>
          <langUsage>

--- a/data/tlg0006/tlg003/tlg0006.tlg003.perseus-grc2.xml
+++ b/data/tlg0006/tlg003/tlg0006.tlg003.perseus-grc2.xml
@@ -52,6 +52,11 @@
                     <p>This pointer pattern extracts line</p>
                 </cRefPattern>
             </refsDecl> 
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <profileDesc>

--- a/data/tlg0006/tlg004/tlg0006.tlg004.perseus-eng2.xml
+++ b/data/tlg0006/tlg004/tlg0006.tlg004.perseus-eng2.xml
@@ -58,6 +58,11 @@
                <p>This pointer pattern extracts lines</p>
             </cRefPattern>
          </refsDecl>
+         <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
       </encodingDesc>
       <profileDesc>
          <langUsage>

--- a/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
+++ b/data/tlg0006/tlg004/tlg0006.tlg004.perseus-grc2.xml
@@ -55,6 +55,11 @@
                     <p>This pointer pattern extracts line</p>
                 </cRefPattern>
             </refsDecl> 
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         
         <profileDesc>

--- a/data/tlg0006/tlg005/tlg0006.tlg005.perseus-eng2.xml
+++ b/data/tlg0006/tlg005/tlg0006.tlg005.perseus-eng2.xml
@@ -58,6 +58,12 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         <profileDesc>
             <langUsage>

--- a/data/tlg0006/tlg005/tlg0006.tlg005.perseus-grc2.xml
+++ b/data/tlg0006/tlg005/tlg0006.tlg005.perseus-grc2.xml
@@ -55,6 +55,11 @@
                     <p>This pointer pattern extracts line</p>
                 </cRefPattern>
             </refsDecl> 
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         
         <profileDesc>

--- a/data/tlg0006/tlg006/tlg0006.tlg006.perseus-eng2.xml
+++ b/data/tlg0006/tlg006/tlg0006.tlg006.perseus-eng2.xml
@@ -58,6 +58,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         <profileDesc>
             <langUsage>

--- a/data/tlg0006/tlg006/tlg0006.tlg006.perseus-grc2.xml
+++ b/data/tlg0006/tlg006/tlg0006.tlg006.perseus-grc2.xml
@@ -55,6 +55,11 @@
                <p>This pointer pattern extracts line</p>
             </cRefPattern>
          </refsDecl> 
+         <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
       </encodingDesc>
       
       <profileDesc>

--- a/data/tlg0006/tlg007/tlg0006.tlg007.perseus-eng2.xml
+++ b/data/tlg0006/tlg007/tlg0006.tlg007.perseus-eng2.xml
@@ -59,6 +59,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
 
         <profileDesc>

--- a/data/tlg0006/tlg007/tlg0006.tlg007.perseus-grc2.xml
+++ b/data/tlg0006/tlg007/tlg0006.tlg007.perseus-grc2.xml
@@ -53,6 +53,12 @@
                 <p>This pointer pattern extracts line</p>
             </cRefPattern>
         </refsDecl>
+
+        <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         
     </encodingDesc>
     <profileDesc>

--- a/data/tlg0006/tlg008/tlg0006.tlg008.perseus-eng2.xml
+++ b/data/tlg0006/tlg008/tlg0006.tlg008.perseus-eng2.xml
@@ -57,6 +57,11 @@
                 <p>This pointer pattern extracts lines</p>
             </cRefPattern>
         </refsDecl>
+        <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
     </encodingDesc>
     
     <profileDesc>

--- a/data/tlg0006/tlg008/tlg0006.tlg008.perseus-grc2.xml
+++ b/data/tlg0006/tlg008/tlg0006.tlg008.perseus-grc2.xml
@@ -54,7 +54,9 @@
                 </cRefPattern>
             </refsDecl>
             <refsDecl>
-                <refState unit="line"/>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
             </refsDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tlg0006/tlg009/tlg0006.tlg009.perseus-eng2.xml
+++ b/data/tlg0006/tlg009/tlg0006.tlg009.perseus-eng2.xml
@@ -53,6 +53,12 @@
                     <p>This pointer pattern extracts line</p>
                 </cRefPattern>
             </refsDecl> 
+
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         <profileDesc>
             <langUsage>

--- a/data/tlg0006/tlg009/tlg0006.tlg009.perseus-grc2.xml
+++ b/data/tlg0006/tlg009/tlg0006.tlg009.perseus-grc2.xml
@@ -55,7 +55,9 @@
             </cRefPattern>
         </refsDecl>
             <refsDecl>
-                <refState unit="line"/>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
             </refsDecl>
         </encodingDesc>
         <profileDesc>

--- a/data/tlg0006/tlg010/tlg0006.tlg010.perseus-eng2.xml
+++ b/data/tlg0006/tlg010/tlg0006.tlg010.perseus-eng2.xml
@@ -54,6 +54,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         <profileDesc>
             <langUsage>

--- a/data/tlg0006/tlg010/tlg0006.tlg010.perseus-grc2.xml
+++ b/data/tlg0006/tlg010/tlg0006.tlg010.perseus-grc2.xml
@@ -55,6 +55,12 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
         <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg011/tlg0006.tlg011.perseus-eng2.xml
+++ b/data/tlg0006/tlg011/tlg0006.tlg011.perseus-eng2.xml
@@ -57,6 +57,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+                <citeStructure use="@subtype" match="//body/div/div">
+                    <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+                </citeStructure>
+            </refsDecl>
         </encodingDesc>
 
         <!--<encodingDesc>

--- a/data/tlg0006/tlg011/tlg0006.tlg011.perseus-grc2.xml
+++ b/data/tlg0006/tlg011/tlg0006.tlg011.perseus-grc2.xml
@@ -56,6 +56,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg012/tlg0006.tlg012.perseus-eng2.xml
+++ b/data/tlg0006/tlg012/tlg0006.tlg012.perseus-eng2.xml
@@ -58,6 +58,11 @@
      <p>This pointer pattern extracts lines</p>
     </cRefPattern>
    </refsDecl>
+   <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
   </encodingDesc>
   
   <!--<encodingDesc>

--- a/data/tlg0006/tlg012/tlg0006.tlg012.perseus-grc2.xml
+++ b/data/tlg0006/tlg012/tlg0006.tlg012.perseus-grc2.xml
@@ -55,6 +55,11 @@
             <p>This pointer pattern extracts lines</p>
         </cRefPattern>
     </refsDecl>
+    <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
 </encodingDesc>
 <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg013/tlg0006.tlg013.perseus-eng2.xml
+++ b/data/tlg0006/tlg013/tlg0006.tlg013.perseus-eng2.xml
@@ -58,6 +58,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <!--<encodingDesc>

--- a/data/tlg0006/tlg013/tlg0006.tlg013.perseus-grc2.xml
+++ b/data/tlg0006/tlg013/tlg0006.tlg013.perseus-grc2.xml
@@ -53,6 +53,11 @@
                 <p>This pointer pattern extracts lines</p>
             </cRefPattern>
         </refsDecl>
+        <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
     </encodingDesc>
     <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg014/tlg0006.tlg014.perseus-eng2.xml
+++ b/data/tlg0006/tlg014/tlg0006.tlg014.perseus-eng2.xml
@@ -58,6 +58,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <!--<encodingDesc>

--- a/data/tlg0006/tlg014/tlg0006.tlg014.perseus-grc2.xml
+++ b/data/tlg0006/tlg014/tlg0006.tlg014.perseus-grc2.xml
@@ -56,6 +56,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg015/tlg0006.tlg015.perseus-eng2.xml
+++ b/data/tlg0006/tlg015/tlg0006.tlg015.perseus-eng2.xml
@@ -58,6 +58,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <!--<encodingDesc>

--- a/data/tlg0006/tlg015/tlg0006.tlg015.perseus-grc2.xml
+++ b/data/tlg0006/tlg015/tlg0006.tlg015.perseus-grc2.xml
@@ -56,6 +56,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         <!--<encodingDesc>
 <refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg016/tlg0006.tlg016.perseus-eng2.xml
+++ b/data/tlg0006/tlg016/tlg0006.tlg016.perseus-eng2.xml
@@ -59,6 +59,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <!--<encodingDesc>

--- a/data/tlg0006/tlg016/tlg0006.tlg016.perseus-grc2.xml
+++ b/data/tlg0006/tlg016/tlg0006.tlg016.perseus-grc2.xml
@@ -56,6 +56,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
         <!--<encodingDesc>

--- a/data/tlg0006/tlg017/tlg0006.tlg017.perseus-eng2.xml
+++ b/data/tlg0006/tlg017/tlg0006.tlg017.perseus-eng2.xml
@@ -59,6 +59,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
 
 <!--<encodingDesc>

--- a/data/tlg0006/tlg017/tlg0006.tlg017.perseus-grc2.xml
+++ b/data/tlg0006/tlg017/tlg0006.tlg017.perseus-grc2.xml
@@ -52,6 +52,12 @@
             <p>This pointer pattern extracts line</p>
         </cRefPattern>
     </refsDecl>
+
+    <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
     
 <!--<refsDecl doctype="TEI.2">
 <step refunit="line" from="DESCENDANT (1 L N%1)" to="DITTO"/>

--- a/data/tlg0006/tlg018/tlg0006.tlg018.perseus-eng2.xml
+++ b/data/tlg0006/tlg018/tlg0006.tlg018.perseus-eng2.xml
@@ -57,6 +57,11 @@
      <p>This pointer pattern extracts lines</p>
     </cRefPattern>
    </refsDecl>
+   <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
   </encodingDesc>
 
 <!--<encodingDesc>

--- a/data/tlg0006/tlg018/tlg0006.tlg018.perseus-grc2.xml
+++ b/data/tlg0006/tlg018/tlg0006.tlg018.perseus-grc2.xml
@@ -55,6 +55,11 @@
                 <p>This pointer pattern extracts lines</p>
             </cRefPattern>
         </refsDecl>
+        <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
     </encodingDesc>
     
 <!--<encodingDesc>

--- a/data/tlg0006/tlg019/tlg0006.tlg019.perseus-eng3.xml
+++ b/data/tlg0006/tlg019/tlg0006.tlg019.perseus-eng3.xml
@@ -59,6 +59,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
 

--- a/data/tlg0006/tlg019/tlg0006.tlg019.perseus-eng4.xml
+++ b/data/tlg0006/tlg019/tlg0006.tlg019.perseus-eng4.xml
@@ -52,6 +52,11 @@
     				<p>This pointer pattern extracts lines</p>
     			</cRefPattern>
     		</refsDecl>
+			<refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
     	</encodingDesc>
     	<!--<encodingDesc>
     		<refsDecl doctype="TEI.2">

--- a/data/tlg0006/tlg019/tlg0006.tlg019.perseus-grc2.xml
+++ b/data/tlg0006/tlg019/tlg0006.tlg019.perseus-grc2.xml
@@ -55,6 +55,11 @@
                     <p>This pointer pattern extracts lines</p>
                 </cRefPattern>
             </refsDecl>
+            <refsDecl>
+            <citeStructure use="@subtype" match="//body/div/div">
+               <citeStructure unit="line" use="@n" match="//body/div/div//l" />
+            </citeStructure>
+         </refsDecl>
         </encodingDesc>
         
 <!--<encodingDesc>


### PR DESCRIPTION
@lcerrato this is part of the work for P6 -- it looks like drama is the most affected, so I was planning to take it one drama at a time.

The `citeStructure` elements make it easier for us to chunk texts according to their canonical structure.