### PR TITLE
tlg0007-minor header revisions

### DIFF
--- a/data/tlg0007/tlg067/tlg0007.tlg067.perseus-eng3.xml
+++ b/data/tlg0007/tlg067/tlg0007.tlg067.perseus-eng3.xml
@@ -5,9 +5,8 @@
       <fileDesc>
          <titleStmt>
             <title xml:lang="lat">De liberis educandis</title>
-         	<title type="alt">The Education of Children</title>
-            
-            <author n="Plut.">Plutarch</author>
+         	<title type="alt">The Education of Children</title>            
+            <author>Plutarch</author>
             <editor role="translator">Frank Cole Babbitt</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
@@ -30,7 +29,7 @@
       	</publicationStmt>
       	<sourceDesc>
             <biblStruct>
-               <analytic/>
+               
                <monogr>
                   <author>Plutarch</author>
                   <title>Moralia</title>

--- a/data/tlg0007/tlg067/tlg0007.tlg067.perseus-eng4.xml
+++ b/data/tlg0007/tlg067/tlg0007.tlg067.perseus-eng4.xml
@@ -5,9 +5,8 @@
       <fileDesc>
          <titleStmt>
             <title xml:lang="lat">De liberis educandis</title>
-         	<title type="alt">A Discourse Touching the Training of Children</title>
-            
-            <author n="Plut.">Plutarch</author>
+         	<title type="alt">A Discourse Touching the Training of Children</title>            
+            <author>Plutarch</author>
             <editor>William W. Goodwin</editor>
             <editor role="translator">Simon Ford</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/tlg0007/tlg067/tlg0007.tlg067.perseus-grc2.xml
+++ b/data/tlg0007/tlg067/tlg0007.tlg067.perseus-grc2.xml
@@ -28,7 +28,7 @@
 </publicationStmt>
 <sourceDesc>
 <biblStruct>
-<analytic/>
+
 <monogr>
 <author>Plutarch</author>
 <title>Moralia</title>

--- a/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng3.xml
+++ b/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng3.xml
@@ -6,8 +6,7 @@
       <fileDesc>
          <titleStmt>
             <title>How the Young Man Should Study Poetry</title>
-            
-            <author n="Plut.">Plutarch</author>
+            <author>Plutarch</author>
             <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
          	<principal>Gregory Crane</principal>
@@ -37,7 +36,7 @@
       	</publicationStmt>
       	<sourceDesc>
             <biblStruct>
-               <analytic/>
+               
                <monogr>
                	<author>Plutarch</author>
                   <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng3.xml
+++ b/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng3.xml
@@ -4,10 +4,9 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title xml:lang="eng">On Listening to Lectures</title>
-            
-            <author n="Plut.">Plutarch</author>
-            <editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+            <title xml:lang="eng">On Listening to Lectures</title>            
+            <author>Plutarch</author>
+            <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
          	<principal>Gregory Crane</principal>
          	<respStmt>

--- a/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng3.xml
+++ b/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng3.xml
@@ -6,7 +6,7 @@
          <titleStmt>
             <title>How to Tell a Flatterer from a Friend</title>
             <author>Plutarch</author>
-            <editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+            <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
       		<principal>Gregory Crane</principal>
       		<respStmt>

--- a/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng3.xml
+++ b/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng3.xml
@@ -5,9 +5,8 @@
       <fileDesc>
          <titleStmt>
          	<title>How a Man May Become Aware of His Progress in Virtue</title>
-
             <author>Plutarch</author>
-            <editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+            <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
          	<principal>Gregory Crane</principal>
          	<respStmt>

--- a/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng3.xml
+++ b/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng3.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title>How to Profit By One's Enemies</title>
 				<author>Plutarch</author>
-				<editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+				<editor role="translator">Frank Cole Babbitt</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>

--- a/data/tlg0007/tlg072/tlg0007.tlg072.perseus-grc2.xml
+++ b/data/tlg0007/tlg072/tlg0007.tlg072.perseus-grc2.xml
@@ -5,7 +5,7 @@
 <fileDesc>
 <titleStmt>
 <title xml:lang="grc">Πῶς ἄν τις ἀπ’ ἐχθρῶν ὠφελοῖτο</title>
-<author n="Plut.">Plutarch</author>
+<author>Plutarch</author>
     <editor>Grēgorios N. Vernardakēs</editor>
 <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>

--- a/data/tlg0007/tlg074/tlg0007.tlg074.perseus-eng3.xml
+++ b/data/tlg0007/tlg074/tlg0007.tlg074.perseus-eng3.xml
@@ -35,7 +35,7 @@
             </publicationStmt>
             <sourceDesc>
                 <biblStruct>
-                    <analytic/>
+                    
                     <monogr>
                         <author>Plutarch</author>
                         <title>Moralia</title>

--- a/data/tlg0007/tlg074/tlg0007.tlg074.perseus-eng4.xml
+++ b/data/tlg0007/tlg074/tlg0007.tlg074.perseus-eng4.xml
@@ -36,7 +36,7 @@
             </publicationStmt>
             <sourceDesc>
                 <biblStruct>
-                    <analytic/>
+                    
                     <monogr>
                         <author>Plutarch</author>
                         <title>Plutarch's Morals.</title>

--- a/data/tlg0007/tlg074/tlg0007.tlg074.perseus-grc2.xml
+++ b/data/tlg0007/tlg074/tlg0007.tlg074.perseus-grc2.xml
@@ -34,7 +34,7 @@
         </publicationStmt>
         <sourceDesc>
             <biblStruct>
-                <analytic/>
+                
                 <monogr>
                     <author>Plutarch</author>
                     <title>Moralia</title>

--- a/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng3.xml
+++ b/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng3.xml
@@ -6,7 +6,7 @@
          <titleStmt>
             <title>Virtue and Vice</title>
             <author>Plutarch</author>
-            <editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+            <editor role="translator">Frank Cole Babbitt</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -32,7 +32,7 @@
          </publicationStmt>
          <sourceDesc>
             <biblStruct>
-               <analytic/>
+               
                <monogr>
                   <author>Plutarch</author>
                   <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng3.xml
+++ b/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng3.xml
@@ -6,7 +6,7 @@
 			<titleStmt>
 				<title>A letter of Condolence to Apollonius</title>
 				<author>Plutarch</author>
-				<editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+				<editor role="translator">Frank Cole Babbitt</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>

--- a/data/tlg0007/tlg078/tlg0007.tlg078.perseus-eng3.xml
+++ b/data/tlg0007/tlg078/tlg0007.tlg078.perseus-eng3.xml
@@ -6,7 +6,7 @@
          <titleStmt>
             <title>Advice to Bride and Groom</title>
             <author>Plutarch</author>
-            <editor role="translator" n="Loeb">Frank Cole Babbitt</editor>
+            <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
          	<principal>Gregory Crane</principal>
          	<respStmt>

--- a/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-eng3.xml
+++ b/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-eng3.xml
@@ -6,7 +6,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
       <fileDesc>
          <titleStmt>
             <title>The Roman Questions</title>
-            <author n="Plut.">Plutarch</author>
+            <author>Plutarch</author>
             <editor role="translator">Frank Cole Babbitt</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>
          	<principal>Gregory Crane</principal>
@@ -31,7 +31,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
       		<date type="release">2010-12-13</date></publicationStmt>
       	<sourceDesc>
             <biblStruct>
-               <analytic/>
+               
                <monogr>
                   <author>Plutarch</author>
                   <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-eng4.xml
+++ b/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-eng4.xml
@@ -6,7 +6,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
       <fileDesc>
          <titleStmt>
             <title>Roman Questions</title>
-            <author n="Plut.">Plutarch</author>
+            <author>Plutarch</author>
             <editor>William W. Goodwin</editor>
          	<editor role="translator">Isaac Chauncy</editor>
          	<sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-grc3.xml
+++ b/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-grc3.xml
@@ -32,7 +32,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 </publicationStmt>
 <sourceDesc>
 <biblStruct>
-<analytic/>
+
 <monogr>
 <author>Plutarch</author>
 <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc4.xml
+++ b/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc4.xml
@@ -31,7 +31,6 @@
 </publicationStmt>
 <sourceDesc>
 <biblStruct>
-<!---->
 <monogr>
 <author>Plutarch</author>
 <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc4.xml
+++ b/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc4.xml
@@ -31,7 +31,7 @@
 </publicationStmt>
 <sourceDesc>
 <biblStruct>
-<!--<analytic/>-->
+<!---->
 <monogr>
 <author>Plutarch</author>
 <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng3.xml
+++ b/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng3.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 			</publicationStmt>
 			<sourceDesc>
 				<biblStruct>
-					<analytic/>
+					
 					<monogr>
 						<author>Plutarch</author>
 						<title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng3.xml
+++ b/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng3.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 			</publicationStmt>
 			<sourceDesc>
 				<biblStruct>
-					<analytic/>
+					
 					<monogr>
 						<author>Plutarch</author>
 						<title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng3.xml
+++ b/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng3.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 			</publicationStmt>
 			<sourceDesc>
 				<biblStruct>
-               <analytic/>
+               
                <monogr>
                   <author>Plutarch</author>
                   <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng3.xml
+++ b/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng3.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 			</publicationStmt>
 			<sourceDesc>
 				<biblStruct>
-					<analytic/>
+					
 					<monogr>
 						<author>Plutarch</author>
 						<title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg126/tlg0007.tlg126.perseus-eng3.xml
+++ b/data/tlg0007/tlg126/tlg0007.tlg126.perseus-eng3.xml
@@ -33,7 +33,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
             <date type="release">2010-12-13</date></publicationStmt>
 <sourceDesc>
             <biblStruct>
-               <analytic/>
+               
                <monogr>
                   <author>Plutarch</author>
                   <title xml:lang="lat">Moralia</title>

--- a/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng3.xml
+++ b/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng3.xml
@@ -34,7 +34,7 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
 			</publicationStmt>
 			<sourceDesc>
 				<biblStruct>
-					<analytic/>
+					
 					<monogr>
 						<author>Plutarch</author>
 						<title>Moralia</title>


### PR DESCRIPTION
Per #1806
Removed abbreviations such as `<author n="Plut.">` and `n="Loeb"`
Removed `<analytic/>`