### PR TITLE
(tlg0001.tlg001) text fixes, mostly uncombined diacritics

### DIFF
--- a/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
+++ b/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
@@ -518,7 +518,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="361"><q rend="double; merge">σημανέειν δείξειν τε πόρους ἁλός, εἴ κε θυηλαῖς</q></l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="362"><q rend="double; merge">οὗ ἕθεν ἐξάρχωμαι ἀεθλεύων βασιλῆι.</q></l>
 					          <milestone unit="para"/>
-                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="363">η ῥα, καὶ εἰς ἔργον πρῶτος τράπεθ̓· οἱ δʼ
+                                <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="363">η ῥα, καὶ εἰς ἔργον πρῶτος τράπεθʼ· οἱ δʼ
 						ἐπανέσταν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="364">πειθόμενοι· ἀπὸ δʼ εἵματʼ ἐπήτριμα νηήσαντο</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:1" n="365">λείῳ ἐπὶ πλαταμῶνι, τὸν οὐκ ἐπέβαλλε θάλασσα</l>
@@ -4518,7 +4518,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1319">ζεύγληθεν. καὶ τὼ μὲν ὑπὲκ πυρὸς ἂψ ἐπὶ νῆα</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1320">χαζέσθην. ὁ δʼ ἄρʼ αὖτις ἑλὼν σάκος ἔνθετο νώτῳ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1321">ἐξόπιθεν, καὶ γέντο θοῶν ἔμπλειον ὀδόντων</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1322">πήληκα βριαρὴν δόρυ τʼ ἄσχετον, ᾧ π̔ʼ ὑπὸ μέσσας</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1322">πήληκα βριαρὴν δόρυ τʼ ἄσχετον, ᾧ ῥʼ ὑπὸ μέσσας</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1323">ἐργατίνης ὥς τίς τε Πελασγίδι νύσσεν ἀκαίνῃ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1324">οὐτάζων λαγόνας· μάλα δʼ ἔμπεδον εὖ ἀραρυῖαν</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:3" n="1325">τυκτὴν ἐξ ἀδάμαντος ἐπιθύνεσκεν ἐχέτλην.</l>

--- a/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
+++ b/data/tlg0001/tlg001/tlg0001.tlg001.perseus-grc2.xml
@@ -6237,7 +6237,7 @@
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1489">λᾶι βαλών· ἐπεὶ οὐ μὲν ἀφαυρότερός γʼ ἐτέτυκτο,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1490">υἱωνὸς Φοίβοιο Λυκωρείοιο Κάφαυρος</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1491">κούρης τʼ αἰδοίης Ἀκακαλλίδος, ἥν ποτε Μίνως</l>
-					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1492">ἐς Αιβύην ἀπένασσε θεοῦ βαρὺ κῦμα φέρουσαν,</l>
+					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1492">ἐς Λιβύην ἀπένασσε θεοῦ βαρὺ κῦμα φέρουσαν,</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1493">θυγατέρα σφετέρην· ἡ δʼ ἀγλαὸν υἱέα Φοίβῳ</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1494">τίκτεν, ὃν Ἀμφίθεμιν Γαράμαντά τε κικλήσκουσιν.</l>
 					          <l xml:base="urn:cts:greekLit:tlg0001.tlg001.perseus-grc2:4" n="1495">Ἀμφίθεμις δʼ ἄρʼ ἔπειτα μίγη Τριτωνίδι νύμφῃ·</l>


### PR DESCRIPTION
Most of these changes were found by running the "uncombined" script from https://github.com/PerseusDL/canonical-greekLit/issues/1049#issuecomment-861768585. The exception is 4.1492, which is from comparison with SEDES at https://github.com/sasansom/sedes/commit/eaf15e78c6603a961f7e99726f6bacfd47ad88c9.