### PR TITLE
(tlg2045.tlg001) text fixes

### DIFF
--- a/data/tlg2045/tlg001/tlg2045.tlg001.perseus-grc2.xml
+++ b/data/tlg2045/tlg001/tlg2045.tlg001.perseus-grc2.xml
@@ -1906,7 +1906,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="32">καὶ πόσιν ἤθελε μᾶλλον ὁμόπτολιν, ὥς κεν ἀλύξῃ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="33">συζυγίην φερέοκον ἀδωροδόκων ὑμεναίων·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="34">καὶ παλάμῃ κρατέουσα κατηφέι χεῖρα τιθήνης</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="35">δάκρυαι μυδαλέη πολυξμεμφέα ῥήξατο φωνήν· </l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="35">δάκρυσι μυδαλέη πολυξμεμφέα ῥήξατο φωνήν· </l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="36"><q>Μῆτερ ἐμή, τί παθοῦσα τεὴν ἠρνήσαο κούρην;</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="37"><q rend="merge">οὕτωι σεῖο θύγατρα νεήλυδι φωτὶ συνάπτεις;</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:4" n="38"><q rend="merge">ποῖον ἐμοί ποτε δῶρον ὁ ναυτίλος ἐγγυαλίξει;</q></l>
@@ -4290,7 +4290,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="53">καὶ βρέφος ἀρτικόμιστον ἔχων ζωαρκέι κόλπῳ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="54">εἰς δόμον ἀρτιτόκοιο λεχώιον ἤγαγεν Ἰνοῦς.</l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="55">ἡ μὲν ἀνηέρταζεν ἑῆς προθορόντα λοχείης </l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="56">νήπιον εἰσεέτι κοῦρον, ἐπωλένιον Μελικέρτην,</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="56">νήπιον εἰσέτι κοῦρον, ἐπωλένιον Μελικέρτην,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="57">παιδοκόμοις παλάμῃσιν· ἀνοιδαίνοντο δὲ μαζοὶ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="58">θλιβομένοιο γάλακτος ἀναβλύζοντες ἐέρσην.</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:9" n="59">καὶ φιλίοις στομάτεσσι θεὸς μειλίξατο νύμφην</l>
@@ -11239,7 +11239,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="254">ἱλήκοι σέο βίβλος ὁμόχρονος ἠριγενείῃ·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="255">Τρῳάδος ὑσμίνης οὐ μνήσομαι· οὐ γὰρ ἐίσκω </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="256">Αἰακίδῃ Διόνυσον ἢ Ἕκτορι Δηριαδῆα.</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="257">ὑμαήσειν μὲν ὄφελλε τόσον καὶ τοῖον ἀγῶνα</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="257">ὑμνήσειν μὲν ὄφελλε τόσον καὶ τοῖον ἀγῶνα</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="258">Μοῦσα τεὴ καὶ Βάκχον ἀκοντιστῆρα Γιγάντων,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="259">ἄλλοις δʼ ὑμνοπόλοισι πόνους Ἀχιλῆος ἐᾶσαι,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:25" n="260">εἰ μὴ τοῦτο Θέτις γέρας ἥρπασεν. ἀλλὰ λιγαίνειν </l>
@@ -12530,7 +12530,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="197">καὶ ξείνῃ ῥαθάμιγγι χαμαιγενέος νιφετοῖο</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="198">ποιητὸν προχέων μινυώριον αἴθριον ὕδωρ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="199">μιμηλαῖς λιβάδεσσι νόθος πέλεν ἀννέφελος Ζεύς.</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="200">βροντῆς δʼ ἰοοτύπου τεχνήμονα δοῦπον ἐάσας </l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="200">βροντῆς δʼ ἰσοτύπου τεχνήμονα δοῦπον ἐάσας </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="201">εἰς φόνον ἀντιβίων Σικελῷ κεκόρυστο σιδήρῳ,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="202">καὶ δονέων ῥαιστῆρα μετάρσιον ὑψόθεν ὤμων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="203">δυσμενέων ἤρασσε καρήατα πυκνὰ σιδήρῳ·</l>
@@ -12595,7 +12595,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="266">Κύκλωψ ὑψικάρηνος· ὁ δὲ πρηῶνα τινάσσων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="267">ῥῖπτε κατὰ Φλαγίου κραναὸν βέλος· αὐτὰρ ὁ φεύγων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="268">ἅρμασι βουκεράοιο παρίστατο Δηριαδῆος,</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="269">καὶ μόγις ἠερόφοετον ἀλεύατο μάρμαρον αἰχμήν,</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="269">καὶ μόγις ἠερόφοιτον ἀλεύατο μάρμαρον αἰχμήν,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="270">κεῖθι μένων· κοτέων δὲ περὶ Φλογίοιο φυγόντος </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="271">λοίγεον ἀνθερεῶνα διαπτύξας Ἁλιμήδης</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:28" n="272">δώδεκα φῶτας ἔπεφνε μιῆς μυκήματι φωνῆς,</l>
@@ -12684,7 +12684,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="12">πέμπων ἠερόφοιτον ἐπασσυτέρων νέφος ἰῶν,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="13">πῇ δὲ παλινδίνητον ἑὸν δόρυ θοῦρον ἑλίσσων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="14">Σειληνῶν κερόεσσαν ἀνεπτοίησε γενέθλην.</l>
-<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="15">Εὐχαίτης δʼ Ὑμέναιος ἐμάρνατο φάογανα σείων, </l>
+<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="15">Εὐχαίτης δʼ Ὑμέναιος ἐμάρνατο φάσγανα σείων, </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="16">Θεσσσαλικῆς ἀκίχητος ὑπὲρ ῥάχιν ἥμενος ἵππου,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="17">Ἰνδοὺς κυανέους ῥοδοειδέι χειρὶ δαΐζων·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="18">ἀγλαΐῃ δʼ ἤστραπτεν· ἴδοις δέ μιν εἰς μέσον Ἰνδῶν</l>
@@ -12891,7 +12891,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="210">αὐτόματοι σπινθῆρες ὀιστεύοντο σιδήρου. </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="213">Ἄλκων δʼ αἰθαλόεντι συνήρμοσε χεῖρα βελέμνῳ, </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="214">πατπῴης Ἑκάτης θιασώδεα πυρσὸν ἑλίσσων.</l>
-<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="215">καὶ σάλαρον σείοντες ἀερσιλόφου τρυσφαλείης	</l>
+<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="215">καὶ φάλαρον σείοντες ἀερσιλόφου τρυσφαλείης	</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="216">Δικταῖοι Κορύβαντες ἐπεστρατόωντο κυδοιμῷ,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="217">εἰς μόθον οἰστρηθέντες· ἁμιλλητῇρι δὲ χαλκῷ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="218">φάσγανα τυπτομένῃσιν ἐπέκτυπε γυμνὰ βοείαις</l>
@@ -12922,7 +12922,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="242">Τερψιχόρη κτυπέουσα χοροῦ πολεμήιον Ἠχώ.</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="243">καὶ Τρυγίη βαρύγουνος ἐλείπετο νόσφιν ὁμίλου</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="244">ὑστατίη καὶ ἔπηξε φόβῳ πόδας· οὐδέ τις αὐτῇ</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="245">Σειληνῶυ παρέμιμνε· λίπον δέ μιν αὐτόθι μούνην </l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="245">Σειληνῶν παρέμιμνε· λίπον δέ μιν αὐτόθι μούνην </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="246">ταρβαλέην, χατέουσαν ἀρηγόνος· ἀκροπότῃ δὲ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="247">χεῖρας ὄρεξε Μάρωνι, Μάρων δʼ ἀπέειπε γεραιήν,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:29" n="248">ὅττι χοροὺς ἀνέκοπτε φιλακρήτων Κορυβάντων</l>
@@ -13182,7 +13182,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="108">καὶ Φλόγιον Στροφίοιο πολύστροφον υἷα καχήσας</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="109">ἔκτανεν, ὀρχηστῆρα φιλοσκάρθμου Διονύσου,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="110">ὅς τις ἀδακρύτοιο παρʼ εἰλαπίνῃσι Λυαίου </l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="111">ἀνταιτύπων ἐλέλιζε πολύτροπα δάκτυλα χειρῶν,</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="111">ἀντιτύπων ἐλέλιζε πολύτροπα δάκτυλα χειρῶν,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="112">καὶ θάνατον Φαέθοντος ἐχέφρονι χειρὶ τινάσσων</l>
 <pb xml:id="v.2.p.406"/>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:30" n="113">δαιτυμόνας ποίησεν ἀήθεα δάκρυα λείβειν,</l>
@@ -14322,7 +14322,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="289">Καλλιστὼ σκοπίαζε καὶ ἄστατον ὁλκὸν Ἁμαξης,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="290">γινώσκων, ὅτι θῆλυς ἐδέξατο θῆλυν ἀκοίην </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="291">μιμηλῆς μεθέποντα νόθον δέμας ἰοχεαίρης</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="292">ἀγνώστοις μελέεσοιν· ὑπερτέλλοντα δὲ Ταύρου</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="292">ἀγνώστοις μελέεσσιν· ὑπερτέλλοντα δὲ Ταύρου</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="293">Μυρτίλον ἐσκοπίαζε, πυρίπνοον Ἡνιοχῆα,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="294">ὅττι γάμῳ χραίσμησε, καὶ εἰς δρόμον Ἱπποδαμείης</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:33" n="295">ἀντίτυπον ποίησε τύπον τροχοεσδέι κηρῷ, </l>
@@ -15874,7 +15874,7 @@
 <pb xml:id="v.3.p.48"/>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="157">ἄρσενα, καὶ θήλειαν ἐπεσφήκωσε Ποδάρκην,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="158">οὓς Βορέης ἔσπειρεν ἐυπτερύγων ἐπὶ λέκτρων</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="159">Στθοωίην Ἅρπυιαν ἀελλόπον εἰς γάμον ἕλκων,</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="159">Σιθονίην Ἅρπυιαν ἀελλόπον εἰς γάμον ἕλκων,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="160">καί σφεας, Ὠρείθυιαν ὅθʼ ἥρπασεν Ἀτθίδα νύμφην, </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="161">ὤπασεν ἕδνον ἕρστος Ἐρεχθέι γαμβρὸς ἀήτης.</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="162">δεύτερος Ἀκταίων Ἰσμηνίδα πάλλεν ἱμάσθλην·</l>
@@ -15887,7 +15887,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="169">καὶ Σικελῶν ὀχέων ἐπεβήσατο πέμπτος Ἀχάτης,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="170">οἶστπον ἔχων Πισαῖον ἐλαιοκόμου ποταμοῖο,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="171">ἱπποσύνης ἀκόρητος, ἐπεὶ πέδον ᾤκεε νύμφης</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="172">Ἀλοειοῦ δυσέρωτος ὃς εἰς Ἀπέθουσαν ἱκάνει</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="172">Ἀλφειοῦ δυσέρωτος ὃς εἰς Ἀπέθουσαν ἱκάνει</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="173">ἄβροχον ἕδνον ἔρωτος ἄγων στεφανηφόρον ὕδωρ.</l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="174">καὶ θρασὺν Ἀκταίωνα λαβὼν ἀπάνευθεν ὁμίλου</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="175">παιδὶ πατὴρ σπεύδοντι φίλους ἐπετέλλετο μύθους· </l>
@@ -16396,7 +16396,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="657">ἢ πέλεν ἀμφήριστος ἢ ἔφθασεν ἀστὸν Ἀθἠνης. </l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="660">καὶ κτέρας αἰολόνωτον ἐκούφισεν ὠκὺς Ἐροχθεύς, </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="661">Σιδόνιον κρητῆρα τετυγμένον· Ὠκύθοος δὲ</l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="662">εἴρυοε Θεσσαλὸν ἵππον· ὁ δὲ τρίτος ἠρέμα βαίνων</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="662">εἴρυσε Θεσσαλὸν ἵππον· ὁ δὲ τρίτος ἠρέμα βαίνων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="663">Πρίασος ἆορ ἔδεκτο σὺν ἀρυγρέῳ τελαμῶνι.</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="664">καὶ Σατύρων ἐγέλασσε χορὸς φιλοπαίγμονι θυμῷ,</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="665">παπταίνων Κορύβαντα χυτῇ ῥυπόωντα κονίῃ, </l>
@@ -16415,7 +16415,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="677">καὶ τρίτος Εὐρυμέδων καὶ τέτρατος ἤλυθρν Ἄκμων·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="678">καὶ πίσυρες στοιχηδὸν ἐφέστασαν ἄλλος ἐπʼ ἄλλῳ.</l>
 <pb xml:id="v.3.p.84"/>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="679">καὶ σόλον εὐδίωητον ἑλὼν ἔρριψε Μελισσεύς·</l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="679">καὶ σόλον εὐδίνητον ἑλὼν ἔρριψε Μελισσεύς·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="680">Σειληνοὶ δʼ ἐγέλασσαν ὀλίζονα φωτὸς ἐρωήν. </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="681">δεύτερος Εὐρυμέσων παλάμην ἐπερείσατο δίσκῳ<gap reason="lost" rend=". . ."/></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="682">καὶ σόλον εὐδίνητον ἑλὼν νωμήτορι καρπῷ</l>
@@ -16495,7 +16495,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="754">ὄφρα μόθῳ παίζοντι καὶ οὐ κτείνοντι σιδήρῳ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="755">μιμηλήν τελέσωσιν ἀναίμονος εἰκόνα χάρμης· </l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="756"><q>Οὗτος ἀγὼν δύο φῶτας ἀκοντιστῆρας ἐγείρων</q></l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="757"><q rend="merge">μείλιχον οἶδεν Ἄρηα καὶ κὐδιόωσαν Ἐνυώ.</q></l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="757"><q rend="merge">μείλιχον οἶδεν Ἄρηα καὶ εὐδιόωσαν Ἐνυώ.</q></l>
 <l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="758">ὣς φαμένου Βρομίοιο σιδήρεα τεύχεα πάλλων</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="759">Ἀστέριος κεκόρθστο, καὶ Αἰακὸς εὶς μέσον ἔστη</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:37" n="760">χάλκεον ἔγχος ἔχων, πολυδαίδαλον ἀσπίδα πάλλων, </l>
@@ -16746,7 +16746,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="214"><q rend="merge">χερσὶ δὲ πατρῴης φλογερῆς ἔψαυσεν ὑπήνης,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="215"><q rend="merge">ὀκλαδὸν ἐν δαπέδῳ κυκλούμενον αὐχένα κάμπτων, </q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="216"><q rend="merge">λισσόμενος· καὶ παῖδα πατὴρ ἐλέαιρε δοκεύων.</q></l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="217"><q rend="merge">καὶ κινυρὴ Κηυμένη πλέον ᾔτεεν· αὐτὰρ ὁ θυμῷ</q></l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="217"><q rend="merge">καὶ κινυρὴ Κλυμένη πλέον ᾔτεεν· αὐτὰρ ὁ θυμῷ</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="218"><q rend="merge">ἔμπεδα γινώσκων ἀμετάτροπα νήματα Μοίρης</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="219"><q rend="merge">ἀσχαλόων ἐπένευσεν, ἀποσμήξας δὲ χιτῶνι</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:38" n="220"><q rend="merge">μυρομένου Φαέθοντος ἀμειδέος ὄμβρον ὀπωπῆς </q></l>
@@ -17071,7 +17071,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="89"><q rend="merge">ἐλπίδες ἀντιβίων κενεαυχέες· εἰ δἐ μογήσας</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="90"><q rend="merge">φύλοπιν οὐκ ἐτέλεσσεν ἐπὶ χθονὸς ὄρχαμος Ἰνδῶν, </q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="91"><q rend="merge">ἠλιβάτων λοφιῇσιν ἐφεδρήσσων ἐλεφάντων,</q></l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="92"><q rend="merge">ἀγχινεφής, ἀκίχητος, ἀωούτατος, ἠέρι γείτων,</q></l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="92"><q rend="merge">ἀγχινεφής, ἀκίχητος, ἀνούτατος, ἠέρι γείτων,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="93"><q rend="merge">οὐ μὲν ἐγὼ προμάχων ποτὲ δεύομαι, οὐδὲ καλέσσω</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="94"><q rend="merge">ἄλλον ἀοσσητῆρα μετὰ Κρονίωνα τοκῆα,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="95"><q rend="merge">ἡνίοχον πόντοιο καὶ αἰθέρος· ἢν δʼ ἐθελήσω, </q></l>
@@ -17201,7 +17201,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="215">εὔστολος ἦεν Ἄρης τότε ναυτίλος, ἐν παλάμῃ δὲ </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="216">πηδάλιον Φόβος εἶχε, κυβερνήτης δὲ κυδοιμοῦ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="217">Δεῖμος ἀκοντοφόρων ἀνελύσατο πείσματα νηῶν.</l>
-<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="218">Κυκλώπων δὲ φάλαγγες ἐωαυτίλλοντο θαλάσσῃ</l>
+<l rend="align(indent)" xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="218">Κυκλώπων δὲ φάλαγγες ἐναυτίλλοντο θαλάσσῃ</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="219">ὁλκάδας ἀγχιάλοισιν ὀιστεύοντες ἐρίπναις·</l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="220">Εὐρύαλος δʼ ἀλάλαζεν, ἁλιρροίζῳ δὲ κυδοιμῷ </l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:39" n="221">ἀγχινεφὴς οἴστρησεν ἐς ὑσμίνην Ἁλιμήδης.</l>
@@ -17757,7 +17757,7 @@
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="341"><q rend="merge">φθεγγομένης κατὰ πόντον Ἀμαδρυὰς ἐγγὺς ἀκούει,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="342"><q rend="merge">καὶ Τυρίοις πελάγεσσι καὶ ἀγχιάλοισιν ἀρούραις</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="343"><q rend="merge">πνείων ἐκ Λιβάνοιο μεσημβρινὸς ἁβρὸς ἀήτης</q></l>
-<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="344"><q rend="merge">ἄσθματι καρποτόκῳ προχέει νηοσσόον ἀήτην,</q></l>
+<l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="344"><q rend="merge">ἄσθματι καρποτόκῳ προχέει νηοσσόον αὔρην,</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="345"><q rend="merge">ψύχων ἀγρονόμον καὶ ναυτίλον εἰς πλόον ἕλκων, </q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="346"><q rend="merge">καὶ χθονίην δρεπάνην βυθίῃ πελάσασα τριαίνῃ</q></l>
 <l xml:base="urn:cts:greekLit:tlg2045.tlg001.perseus-grc2:40" n="347"><q rend="merge">φθέγγεται ὑγρομέδοντι θαλυσιὰς ἐνθάδε Δηώ,</q></l>


### PR DESCRIPTION
These fixes come from SEDES commit https://github.com/sasansom/sedes/commit/eaf15e78c6603a961f7e99726f6bacfd47ad88c9. Prior to this commit, the fixes had been applied not directly to the TEI files, but in a different part of the pipeline, which is why I originally missed this batch from #1842.