### PR TITLE
tlg0007-deleting extra encoding statement

### DIFF
--- a/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng3.xml
+++ b/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng3.xml
@@ -70,9 +70,7 @@
           <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p> 
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
    <refsDecl n="CTS">
    	<cRefPattern n= "section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    		<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng4.xml
+++ b/data/tlg0007/tlg068/tlg0007.tlg068.perseus-eng4.xml
@@ -60,9 +60,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p>
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
             architecture</p>
          <refsDecl n="CTS">
             <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg068/tlg0007.tlg068.perseus-grc2.xml
+++ b/data/tlg0007/tlg068/tlg0007.tlg068.perseus-grc2.xml
@@ -59,9 +59,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
 <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng3.xml
+++ b/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng3.xml
@@ -65,9 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
          	<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng4.xml
+++ b/data/tlg0007/tlg069/tlg0007.tlg069.perseus-eng4.xml
@@ -58,9 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg069/tlg0007.tlg069.perseus-grc2.xml
+++ b/data/tlg0007/tlg069/tlg0007.tlg069.perseus-grc2.xml
@@ -62,9 +62,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
 <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng3.xml
+++ b/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng3.xml
@@ -62,11 +62,8 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
-         <refsDecl n="CTS">
-            
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <refsDecl n="CTS">           
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>
          	</cRefPattern>

--- a/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng4.xml
+++ b/data/tlg0007/tlg070/tlg0007.tlg070.perseus-eng4.xml
@@ -33,7 +33,6 @@
       	  <availability>
               <licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a Creative Commons Attribution-ShareAlike 4.0 International License</licence>
             </availability>
-
       	</publicationStmt>
       	<sourceDesc>
             <biblStruct>
@@ -63,11 +62,8 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
-         <refsDecl n="CTS">
-         	
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <refsDecl n="CTS">         	
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>
          	</cRefPattern>

--- a/data/tlg0007/tlg070/tlg0007.tlg070.perseus-grc2.xml
+++ b/data/tlg0007/tlg070/tlg0007.tlg070.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng3.xml
+++ b/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng3.xml
@@ -65,9 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p> 
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p></cRefPattern>     

--- a/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng4.xml
+++ b/data/tlg0007/tlg071/tlg0007.tlg071.perseus-eng4.xml
@@ -56,9 +56,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p> 
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p> 
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p> 
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg071/tlg0007.tlg071.perseus-grc2.xml
+++ b/data/tlg0007/tlg071/tlg0007.tlg071.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng3.xml
+++ b/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng4.xml
+++ b/data/tlg0007/tlg072/tlg0007.tlg072.perseus-eng4.xml
@@ -67,9 +67,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg072/tlg0007.tlg072.perseus-grc2.xml
+++ b/data/tlg0007/tlg072/tlg0007.tlg072.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
     
 <refsDecl n="CTS">

--- a/data/tlg0007/tlg073/tlg0007.tlg073.perseus-eng3.xml
+++ b/data/tlg0007/tlg073/tlg0007.tlg073.perseus-eng3.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg073/tlg0007.tlg073.perseus-eng4.xml
+++ b/data/tlg0007/tlg073/tlg0007.tlg073.perseus-eng4.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg073/tlg0007.tlg073.perseus-grc2.xml
+++ b/data/tlg0007/tlg073/tlg0007.tlg073.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts section.</p></cRefPattern>
 </refsDecl>

--- a/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng3.xml
+++ b/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng3.xml
@@ -66,9 +66,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p> 
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
          <refsDecl n="CTS">
             <cRefPattern n= "section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
                <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng4.xml
+++ b/data/tlg0007/tlg075/tlg0007.tlg075.perseus-eng4.xml
@@ -58,9 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p> 
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>  
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>  
          <refsDecl n="CTS">
             <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
                <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg075/tlg0007.tlg075.perseus-grc2.xml
+++ b/data/tlg0007/tlg075/tlg0007.tlg075.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
  <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng3.xml
+++ b/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng4.xml
+++ b/data/tlg0007/tlg076/tlg0007.tlg076.perseus-eng4.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg076/tlg0007.tlg076.perseus-grc2.xml
+++ b/data/tlg0007/tlg076/tlg0007.tlg076.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg077/tlg0007.tlg077.perseus-eng3.xml
+++ b/data/tlg0007/tlg077/tlg0007.tlg077.perseus-eng3.xml
@@ -64,9 +64,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
          	<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg077/tlg0007.tlg077.perseus-eng4.xml
+++ b/data/tlg0007/tlg077/tlg0007.tlg077.perseus-eng4.xml
@@ -58,9 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
          <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg077/tlg0007.tlg077.perseus-grc2.xml
+++ b/data/tlg0007/tlg077/tlg0007.tlg077.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
 <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg078/tlg0007.tlg078.perseus-grc2.xml
+++ b/data/tlg0007/tlg078/tlg0007.tlg078.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <!--<state unit="chapter" delim="."/>
 <state unit="section"/>

--- a/data/tlg0007/tlg079/tlg0007.tlg079.perseus-eng3.xml
+++ b/data/tlg0007/tlg079/tlg0007.tlg079.perseus-eng3.xml
@@ -65,8 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg079/tlg0007.tlg079.perseus-eng4.xml
+++ b/data/tlg0007/tlg079/tlg0007.tlg079.perseus-eng4.xml
@@ -59,9 +59,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg079/tlg0007.tlg079.perseus-grc2.xml
+++ b/data/tlg0007/tlg079/tlg0007.tlg079.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <!--<state unit="chapter" delim="."/>
 <state unit="section"/>

--- a/data/tlg0007/tlg080/tlg0007.tlg080.perseus-eng3.xml
+++ b/data/tlg0007/tlg080/tlg0007.tlg080.perseus-eng3.xml
@@ -60,8 +60,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg080/tlg0007.tlg080.perseus-eng4.xml
+++ b/data/tlg0007/tlg080/tlg0007.tlg080.perseus-eng4.xml
@@ -58,8 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>    
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg080/tlg0007.tlg080.perseus-grc2.xml
+++ b/data/tlg0007/tlg080/tlg0007.tlg080.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
 <!--<state unit="section" />-->
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
  <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg081/tlg0007.tlg081.perseus-eng3.xml
+++ b/data/tlg0007/tlg081/tlg0007.tlg081.perseus-eng3.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg081/tlg0007.tlg081.perseus-eng4.xml
+++ b/data/tlg0007/tlg081/tlg0007.tlg081.perseus-eng4.xml
@@ -62,9 +62,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg081/tlg0007.tlg081.perseus-grc3.xml
+++ b/data/tlg0007/tlg081/tlg0007.tlg081.perseus-grc3.xml
@@ -65,9 +65,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg081/tlg0007.tlg081.perseus-grc4.xml
+++ b/data/tlg0007/tlg081/tlg0007.tlg081.perseus-grc4.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <!-- <state delim="." unit="chapter"/>

--- a/data/tlg0007/tlg082/tlg0007.tlg082.perseus-eng3.xml
+++ b/data/tlg0007/tlg082/tlg0007.tlg082.perseus-eng3.xml
@@ -65,9 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])">
          		<p>This pointer pattern extracts chapter and section.</p>

--- a/data/tlg0007/tlg082/tlg0007.tlg082.perseus-eng4.xml
+++ b/data/tlg0007/tlg082/tlg0007.tlg082.perseus-eng4.xml
@@ -61,7 +61,7 @@
       <encodingDesc>
          <editorialDecl>
             <quotation marks="none"/>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
+      	
       	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p></editorialDecl>
       	<refsDecl n="CTS">
 		<cRefPattern matchPattern="(\w+)" n="chapter" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg082/tlg0007.tlg082.perseus-grc3.xml
+++ b/data/tlg0007/tlg082/tlg0007.tlg082.perseus-grc3.xml
@@ -65,9 +65,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
             <refsDecl n="CTS">
                 <cRefPattern n="section"
                          matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg082/tlg0007.tlg082.perseus-grc4.xml
+++ b/data/tlg0007/tlg082/tlg0007.tlg082.perseus-grc4.xml
@@ -56,9 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])">
 <p>This pointer pattern extracts chapter and section.</p>

--- a/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-eng2.xml
+++ b/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-eng2.xml
@@ -59,7 +59,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         	<p>Text encoded in accordance with the latest Epidoc standards</p>
+         	
          	<p>The following text is encoded in accordance with Epxml:idoc standards and with the CTS/CITE Architecture</p>
          </editorialDecl>
       

--- a/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-grc3.xml
+++ b/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-grc3.xml
@@ -64,8 +64,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-grc4.xml
+++ b/data/tlg0007/tlg082a/tlg0007.tlg082a.perseus-grc4.xml
@@ -53,8 +53,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
 <!--<state unit="section" />-->
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-eng2.xml
+++ b/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-eng2.xml
@@ -59,7 +59,7 @@
             <correction method="silent">
                <p>optical character recognition</p>
             </correction>
-            <p>Text encoded in accordance with the latest Epidoc standards</p>
+            
             <p>The following text is encoded in accordance with Epxml:idoc standards and with the CTS/CITE Architecture</p>
          </editorialDecl>
          <refsDecl n="CTS">

--- a/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-grc3.xml
+++ b/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-grc3.xml
@@ -64,7 +64,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-    <p>Text encoded in accordance with the latest Epidoc standards</p>
+    
     <p>The following text is encoded in accordance with Epxml:idoc standards and with the CTS/CITE Architecture</p>
 </editorialDecl>
 <refsDecl n="CTS">

--- a/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-grc4.xml
+++ b/data/tlg0007/tlg082b/tlg0007.tlg082b.perseus-grc4.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <!--<state delim="." unit="chapter" />
 <state unit="section" />-->
 <refsDecl n="CTS">

--- a/data/tlg0007/tlg083/tlg0007.tlg083.perseus-eng3.xml
+++ b/data/tlg0007/tlg083/tlg0007.tlg083.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg083/tlg0007.tlg083.perseus-eng4.xml
+++ b/data/tlg0007/tlg083/tlg0007.tlg083.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg083/tlg0007.tlg083.perseus-grc3.xml
+++ b/data/tlg0007/tlg083/tlg0007.tlg083.perseus-grc3.xml
@@ -66,9 +66,7 @@ Archive</ref>
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
     
 <refsDecl n="CTS">

--- a/data/tlg0007/tlg083/tlg0007.tlg083.perseus-grc4.xml
+++ b/data/tlg0007/tlg083/tlg0007.tlg083.perseus-grc4.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-grc4.xml
+++ b/data/tlg0007/tlg084a/tlg0007.tlg084a.perseus-grc4.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p><refsDecl n="CTS">
 
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts section.</p></cRefPattern></refsDecl>
 

--- a/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-eng3.xml
+++ b/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-eng3.xml
@@ -62,8 +62,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       		   <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-eng4.xml
+++ b/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-eng4.xml
@@ -57,8 +57,7 @@
       <encodingDesc>
       	<editorialDecl>
       		<quotation marks="none"/>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-grc3.xml
+++ b/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-grc3.xml
@@ -64,9 +64,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-               <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
                <refsDecl n="CTS">
 
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-grc4.xml
+++ b/data/tlg0007/tlg084b/tlg0007.tlg084b.perseus-grc4.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg085/tlg0007.tlg085.perseus-eng3.xml
+++ b/data/tlg0007/tlg085/tlg0007.tlg085.perseus-eng3.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg085/tlg0007.tlg085.perseus-eng4.xml
+++ b/data/tlg0007/tlg085/tlg0007.tlg085.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg085/tlg0007.tlg085.perseus-grc3.xml
+++ b/data/tlg0007/tlg085/tlg0007.tlg085.perseus-grc3.xml
@@ -66,9 +66,7 @@ Archive</ref>
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg085/tlg0007.tlg085.perseus-grc4.xml
+++ b/data/tlg0007/tlg085/tlg0007.tlg085.perseus-grc4.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg086/tlg0007.tlg086.perseus-eng3.xml
+++ b/data/tlg0007/tlg086/tlg0007.tlg086.perseus-eng3.xml
@@ -65,7 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-				<p>Text encoded in accordance with the latest EpiDoc standards</p>
+				
 				<p>The following text is encoded in accordance with EpiDoc standards and with the
 					CTS/CITE Architecture</p>
 			</editorialDecl>

--- a/data/tlg0007/tlg086/tlg0007.tlg086.perseus-eng4.xml
+++ b/data/tlg0007/tlg086/tlg0007.tlg086.perseus-eng4.xml
@@ -64,7 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-				<p>Text encoded in accordance with the latest EpiDoc standards</p>
+				
 				<p>The following text is encoded in accordance with EpiDoc standards and with the
 					CTS/CITE Architecture</p>
 			</editorialDecl>

--- a/data/tlg0007/tlg086/tlg0007.tlg086.perseus-grc3.xml
+++ b/data/tlg0007/tlg086/tlg0007.tlg086.perseus-grc3.xml
@@ -64,8 +64,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
  <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg086/tlg0007.tlg086.perseus-grc4.xml
+++ b/data/tlg0007/tlg086/tlg0007.tlg086.perseus-grc4.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg087/tlg0007.tlg087.perseus-eng3.xml
+++ b/data/tlg0007/tlg087/tlg0007.tlg087.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg087/tlg0007.tlg087.perseus-eng4.xml
+++ b/data/tlg0007/tlg087/tlg0007.tlg087.perseus-eng4.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg087/tlg0007.tlg087.perseus-grc3.xml
+++ b/data/tlg0007/tlg087/tlg0007.tlg087.perseus-grc3.xml
@@ -66,9 +66,7 @@ Archive</ref>
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
     <cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg087/tlg0007.tlg087.perseus-grc4.xml
+++ b/data/tlg0007/tlg087/tlg0007.tlg087.perseus-grc4.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
  <cRefPattern n="section" matchPattern="(\w+).(\w+)"

--- a/data/tlg0007/tlg088/tlg0007.tlg088.perseus-eng3.xml
+++ b/data/tlg0007/tlg088/tlg0007.tlg088.perseus-eng3.xml
@@ -65,8 +65,7 @@
     <correction status="high" method="silent">
        <p>optical character recognition</p>
     </correction>
- </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+ </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 	<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg088/tlg0007.tlg088.perseus-eng4.xml
+++ b/data/tlg0007/tlg088/tlg0007.tlg088.perseus-eng4.xml
@@ -58,8 +58,7 @@
  </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc3.xml
+++ b/data/tlg0007/tlg088/tlg0007.tlg088.perseus-grc3.xml
@@ -65,8 +65,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-  <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
     <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg089/tlg0007.tlg089.perseus-eng3.xml
+++ b/data/tlg0007/tlg089/tlg0007.tlg089.perseus-eng3.xml
@@ -65,9 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg089/tlg0007.tlg089.perseus-eng4.xml
+++ b/data/tlg0007/tlg089/tlg0007.tlg089.perseus-eng4.xml
@@ -59,7 +59,7 @@
       </fileDesc>
       <encodingDesc>
          <editorialDecl><quotation marks="none"/>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
+      	
       	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          </editorialDecl>
          <refsDecl n="CTS">

--- a/data/tlg0007/tlg089/tlg0007.tlg089.perseus-grc2.xml
+++ b/data/tlg0007/tlg089/tlg0007.tlg089.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg090/tlg0007.tlg090.perseus-eng3.xml
+++ b/data/tlg0007/tlg090/tlg0007.tlg090.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg090/tlg0007.tlg090.perseus-eng4.xml
+++ b/data/tlg0007/tlg090/tlg0007.tlg090.perseus-eng4.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg090/tlg0007.tlg090.perseus-grc2.xml
+++ b/data/tlg0007/tlg090/tlg0007.tlg090.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg091/tlg0007.tlg091.perseus-eng3.xml
+++ b/data/tlg0007/tlg091/tlg0007.tlg091.perseus-eng3.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg091/tlg0007.tlg091.perseus-eng4.xml
+++ b/data/tlg0007/tlg091/tlg0007.tlg091.perseus-eng4.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg091/tlg0007.tlg091.perseus-grc2.xml
+++ b/data/tlg0007/tlg091/tlg0007.tlg091.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"><p>This pointer pattern extracts section.</p>
 </cRefPattern></refsDecl>

--- a/data/tlg0007/tlg092/tlg0007.tlg092.perseus-eng3.xml
+++ b/data/tlg0007/tlg092/tlg0007.tlg092.perseus-eng3.xml
@@ -66,8 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 					<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg092/tlg0007.tlg092.perseus-eng4.xml
+++ b/data/tlg0007/tlg092/tlg0007.tlg092.perseus-eng4.xml
@@ -64,8 +64,7 @@
 					<p>optical character recognition</p>
 				</correction>
 				<quotation marks="none"/>
-			</editorialDecl>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 					<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg092/tlg0007.tlg092.perseus-grc2.xml
+++ b/data/tlg0007/tlg092/tlg0007.tlg092.perseus-grc2.xml
@@ -57,8 +57,7 @@
                 <correction method="silent">
                     <p>optical character recognition</p>
                 </correction>
-            </editorialDecl>
-            <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+            </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
             <refsDecl n="CTS">
                 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
                     <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg093/tlg0007.tlg093.perseus-eng3.xml
+++ b/data/tlg0007/tlg093/tlg0007.tlg093.perseus-eng3.xml
@@ -65,8 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg093/tlg0007.tlg093.perseus-eng4.xml
+++ b/data/tlg0007/tlg093/tlg0007.tlg093.perseus-eng4.xml
@@ -63,8 +63,7 @@
                <p>optical character recognition</p>
             </correction>
             <quotation marks="none"/>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
             
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg093/tlg0007.tlg093.perseus-grc2.xml
+++ b/data/tlg0007/tlg093/tlg0007.tlg093.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg094/tlg0007.tlg094.perseus-eng3.xml
+++ b/data/tlg0007/tlg094/tlg0007.tlg094.perseus-eng3.xml
@@ -65,8 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg094/tlg0007.tlg094.perseus-eng4.xml
+++ b/data/tlg0007/tlg094/tlg0007.tlg094.perseus-eng4.xml
@@ -63,8 +63,7 @@
                <p>optical character recognition</p>
             </correction>
             <quotation marks="none"/>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg094/tlg0007.tlg094.perseus-grc2.xml
+++ b/data/tlg0007/tlg094/tlg0007.tlg094.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg095/tlg0007.tlg095.perseus-eng3.xml
+++ b/data/tlg0007/tlg095/tlg0007.tlg095.perseus-eng3.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg095/tlg0007.tlg095.perseus-eng4.xml
+++ b/data/tlg0007/tlg095/tlg0007.tlg095.perseus-eng4.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg095/tlg0007.tlg095.perseus-grc2.xml
+++ b/data/tlg0007/tlg095/tlg0007.tlg095.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg096/tlg0007.tlg096.perseus-eng3.xml
+++ b/data/tlg0007/tlg096/tlg0007.tlg096.perseus-eng3.xml
@@ -65,9 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg096/tlg0007.tlg096.perseus-eng4.xml
+++ b/data/tlg0007/tlg096/tlg0007.tlg096.perseus-eng4.xml
@@ -58,7 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
+      	
       	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
             

--- a/data/tlg0007/tlg096/tlg0007.tlg096.perseus-grc2.xml
+++ b/data/tlg0007/tlg096/tlg0007.tlg096.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg097/tlg0007.tlg097.perseus-grc2.xml
+++ b/data/tlg0007/tlg097/tlg0007.tlg097.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
       <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg098/tlg0007.tlg098.perseus-eng3.xml
+++ b/data/tlg0007/tlg098/tlg0007.tlg098.perseus-eng3.xml
@@ -61,8 +61,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg098/tlg0007.tlg098.perseus-grc2.xml
+++ b/data/tlg0007/tlg098/tlg0007.tlg098.perseus-grc2.xml
@@ -56,8 +56,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg099/tlg0007.tlg099.perseus-eng3.xml
+++ b/data/tlg0007/tlg099/tlg0007.tlg099.perseus-eng3.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg099/tlg0007.tlg099.perseus-eng4.xml
+++ b/data/tlg0007/tlg099/tlg0007.tlg099.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg099/tlg0007.tlg099.perseus-grc2.xml
+++ b/data/tlg0007/tlg099/tlg0007.tlg099.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg100/tlg0007.tlg100.perseus-eng3.xml
+++ b/data/tlg0007/tlg100/tlg0007.tlg100.perseus-eng3.xml
@@ -65,8 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg100/tlg0007.tlg100.perseus-grc2.xml
+++ b/data/tlg0007/tlg100/tlg0007.tlg100.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg101/tlg0007.tlg101.perseus-eng3.xml
+++ b/data/tlg0007/tlg101/tlg0007.tlg101.perseus-eng3.xml
@@ -65,8 +65,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg101/tlg0007.tlg101.perseus-grc2.xml
+++ b/data/tlg0007/tlg101/tlg0007.tlg101.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
      <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
      <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg102/tlg0007.tlg102.perseus-eng3.xml
+++ b/data/tlg0007/tlg102/tlg0007.tlg102.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg102/tlg0007.tlg102.perseus-eng4.xml
+++ b/data/tlg0007/tlg102/tlg0007.tlg102.perseus-eng4.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg102/tlg0007.tlg102.perseus-grc2.xml
+++ b/data/tlg0007/tlg102/tlg0007.tlg102.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg103/tlg0007.tlg103.perseus-eng2.xml
+++ b/data/tlg0007/tlg103/tlg0007.tlg103.perseus-eng2.xml
@@ -64,8 +64,7 @@
                <p>optical character recognition</p>
             </correction>
             <quotation marks="none"/>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg103/tlg0007.tlg103.perseus-grc2.xml
+++ b/data/tlg0007/tlg103/tlg0007.tlg103.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <p>optical character recognition</p>
 </correction>
    <quotation marks="none"/>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg104/tlg0007.tlg104.perseus-eng2.xml
+++ b/data/tlg0007/tlg104/tlg0007.tlg104.perseus-eng2.xml
@@ -64,8 +64,7 @@
                <p>optical character recognition</p>
             </correction>
             <quotation marks="none"/>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg104/tlg0007.tlg104.perseus-grc2.xml
+++ b/data/tlg0007/tlg104/tlg0007.tlg104.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg105/tlg0007.tlg105.perseus-eng2.xml
+++ b/data/tlg0007/tlg105/tlg0007.tlg105.perseus-eng2.xml
@@ -64,8 +64,7 @@
                <p>optical character recognition</p>
             </correction>
             <quotation marks="none"/>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg105/tlg0007.tlg105.perseus-grc2.xml
+++ b/data/tlg0007/tlg105/tlg0007.tlg105.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
  <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg106/tlg0007.tlg106.perseus-eng2.xml
+++ b/data/tlg0007/tlg106/tlg0007.tlg106.perseus-eng2.xml
@@ -64,8 +64,7 @@
       			<p>optical character recognition</p>
       		</correction>
       		<quotation marks="none"/>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg106/tlg0007.tlg106.perseus-grc2.xml
+++ b/data/tlg0007/tlg106/tlg0007.tlg106.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
    <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg107/tlg0007.tlg107.perseus-eng2.xml
+++ b/data/tlg0007/tlg107/tlg0007.tlg107.perseus-eng2.xml
@@ -64,8 +64,7 @@
       			<p>optical character recognition</p>
       		</correction>
       		<quotation marks="none"/>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg107/tlg0007.tlg107.perseus-grc2.xml
+++ b/data/tlg0007/tlg107/tlg0007.tlg107.perseus-grc2.xml
@@ -58,8 +58,7 @@
 <p>optical character recognition</p>
 </correction>
  <quotation marks="none"/> 
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
       <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg108/tlg0007.tlg108.perseus-eng2.xml
+++ b/data/tlg0007/tlg108/tlg0007.tlg108.perseus-eng2.xml
@@ -59,7 +59,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
+      	
       	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg108/tlg0007.tlg108.perseus-grc2.xml
+++ b/data/tlg0007/tlg108/tlg0007.tlg108.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg109/tlg0007.tlg109.perseus-eng2.xml
+++ b/data/tlg0007/tlg109/tlg0007.tlg109.perseus-eng2.xml
@@ -64,8 +64,7 @@
       		<correction method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg109/tlg0007.tlg109.perseus-grc2.xml
+++ b/data/tlg0007/tlg109/tlg0007.tlg109.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg110/tlg0007.tlg110.perseus-eng2.xml
+++ b/data/tlg0007/tlg110/tlg0007.tlg110.perseus-eng2.xml
@@ -63,9 +63,7 @@
    	<correction status="high" method="silent">
    		<p>optical character recognition</p>
    	</correction>
-   </editorialDecl>
-   <p>Text encoded in accordance with the latest EpiDoc standards</p>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the
+   </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
    	CTS/CITE Architecture</p>
    <refsDecl n="CTS">
    	<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg110/tlg0007.tlg110.perseus-grc2.xml
+++ b/data/tlg0007/tlg110/tlg0007.tlg110.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg111/tlg0007.tlg111.perseus-eng2.xml
+++ b/data/tlg0007/tlg111/tlg0007.tlg111.perseus-eng2.xml
@@ -64,8 +64,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg111/tlg0007.tlg111.perseus-grc2.xml
+++ b/data/tlg0007/tlg111/tlg0007.tlg111.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
                <refsDecl n="CTS">
 <!--<state unit="section" />-->
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg112/tlg0007.tlg112.perseus-eng2.xml
+++ b/data/tlg0007/tlg112/tlg0007.tlg112.perseus-eng2.xml
@@ -64,9 +64,7 @@
        <correction status="high" method="silent">
        	<p>optical character recognition</p>
        </correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
        CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
        <cRefPattern n="section" matchPattern="(\w+).(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2']/tei:div[@n='$3'])">

--- a/data/tlg0007/tlg112/tlg0007.tlg112.perseus-grc2.xml
+++ b/data/tlg0007/tlg112/tlg0007.tlg112.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-         </editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p>
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
          <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+).(\w+).(\w+)"

--- a/data/tlg0007/tlg113/tlg0007.tlg113.perseus-eng2.xml
+++ b/data/tlg0007/tlg113/tlg0007.tlg113.perseus-eng2.xml
@@ -64,9 +64,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       	<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg113/tlg0007.tlg113.perseus-grc2.xml
+++ b/data/tlg0007/tlg113/tlg0007.tlg113.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg114/tlg0007.tlg114.perseus-eng3.xml
+++ b/data/tlg0007/tlg114/tlg0007.tlg114.perseus-eng3.xml
@@ -66,8 +66,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="chapter" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          	<p>This pointer pattern extracts chapter.</p>

--- a/data/tlg0007/tlg114/tlg0007.tlg114.perseus-eng4.xml
+++ b/data/tlg0007/tlg114/tlg0007.tlg114.perseus-eng4.xml
@@ -64,8 +64,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="chapter" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts chapter.</p>

--- a/data/tlg0007/tlg114/tlg0007.tlg114.perseus-grc2.xml
+++ b/data/tlg0007/tlg114/tlg0007.tlg114.perseus-grc2.xml
@@ -57,8 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="chapter" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
  <p>This pointer pattern extracts chapter.</p>

--- a/data/tlg0007/tlg115/tlg0007.tlg115.perseus-eng3.xml
+++ b/data/tlg0007/tlg115/tlg0007.tlg115.perseus-eng3.xml
@@ -66,9 +66,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg115/tlg0007.tlg115.perseus-eng4.xml
+++ b/data/tlg0007/tlg115/tlg0007.tlg115.perseus-eng4.xml
@@ -64,9 +64,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg115/tlg0007.tlg115.perseus-grc2.xml
+++ b/data/tlg0007/tlg115/tlg0007.tlg115.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
 <cRefPattern n="section"
 matchPattern="(\w+)"

--- a/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng3.xml
+++ b/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng4.xml
+++ b/data/tlg0007/tlg116/tlg0007.tlg116.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg116/tlg0007.tlg116.perseus-grc2.xml
+++ b/data/tlg0007/tlg116/tlg0007.tlg116.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg117/tlg0007.tlg117.perseus-grc2.xml
+++ b/data/tlg0007/tlg117/tlg0007.tlg117.perseus-grc2.xml
@@ -65,8 +65,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
       <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng3.xml
+++ b/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng3.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng4.xml
+++ b/data/tlg0007/tlg118/tlg0007.tlg118.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg118/tlg0007.tlg118.perseus-grc2.xml
+++ b/data/tlg0007/tlg118/tlg0007.tlg118.perseus-grc2.xml
@@ -58,9 +58,7 @@
             <correction method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p>
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
             Architecture</p>
          <refsDecl n="CTS">
             <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg119/tlg0007.tlg119.perseus-eng3.xml
+++ b/data/tlg0007/tlg119/tlg0007.tlg119.perseus-eng3.xml
@@ -66,9 +66,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg119/tlg0007.tlg119.perseus-eng4.xml
+++ b/data/tlg0007/tlg119/tlg0007.tlg119.perseus-eng4.xml
@@ -64,9 +64,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg119/tlg0007.tlg119.perseus-grc2.xml
+++ b/data/tlg0007/tlg119/tlg0007.tlg119.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng3.xml
+++ b/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng4.xml
+++ b/data/tlg0007/tlg120/tlg0007.tlg120.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg120/tlg0007.tlg120.perseus-grc2.xml
+++ b/data/tlg0007/tlg120/tlg0007.tlg120.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
    <refsDecl n="CTS">
    <!-- <state delim="." unit="chapter" />
 <state unit="section" /> -->

--- a/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng3.xml
+++ b/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng3.xml
@@ -66,9 +66,7 @@
 	<correction status="high" method="silent">
 		<p>optical character recognition</p>
 	</correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 	CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 	<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng4.xml
+++ b/data/tlg0007/tlg121/tlg0007.tlg121.perseus-eng4.xml
@@ -65,9 +65,7 @@
 	<correction status="high" method="silent">
 		<p>optical character recognition</p>
 	</correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 	CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 	<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg121/tlg0007.tlg121.perseus-grc2.xml
+++ b/data/tlg0007/tlg121/tlg0007.tlg121.perseus-grc2.xml
@@ -61,9 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section"

--- a/data/tlg0007/tlg122/tlg0007.tlg122.perseus-eng3.xml
+++ b/data/tlg0007/tlg122/tlg0007.tlg122.perseus-eng3.xml
@@ -66,9 +66,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg122/tlg0007.tlg122.perseus-eng4.xml
+++ b/data/tlg0007/tlg122/tlg0007.tlg122.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg122/tlg0007.tlg122.perseus-grc2.xml
+++ b/data/tlg0007/tlg122/tlg0007.tlg122.perseus-grc2.xml
@@ -61,9 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-    <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
     <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg123/tlg0007.tlg123.perseus-eng2.xml
+++ b/data/tlg0007/tlg123/tlg0007.tlg123.perseus-eng2.xml
@@ -64,9 +64,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg123/tlg0007.tlg123.perseus-grc2.xml
+++ b/data/tlg0007/tlg123/tlg0007.tlg123.perseus-grc2.xml
@@ -61,9 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg125/tlg0007.tlg125.perseus-eng2.xml
+++ b/data/tlg0007/tlg125/tlg0007.tlg125.perseus-eng2.xml
@@ -63,8 +63,7 @@
       		<correction status="high" method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          		<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg125/tlg0007.tlg125.perseus-grc2.xml
+++ b/data/tlg0007/tlg125/tlg0007.tlg125.perseus-grc2.xml
@@ -61,8 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
     <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg126/tlg0007.tlg126.perseus-grc2.xml
+++ b/data/tlg0007/tlg126/tlg0007.tlg126.perseus-grc2.xml
@@ -60,9 +60,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-    <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
     <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg127/tlg0007.tlg127.perseus-eng3.xml
+++ b/data/tlg0007/tlg127/tlg0007.tlg127.perseus-eng3.xml
@@ -63,9 +63,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p>
-         <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
             <cRefPattern n="section" matchPattern="(\w+)"
                replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg127/tlg0007.tlg127.perseus-eng4.xml
+++ b/data/tlg0007/tlg127/tlg0007.tlg127.perseus-eng4.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"
 					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg127/tlg0007.tlg127.perseus-grc3.xml
+++ b/data/tlg0007/tlg127/tlg0007.tlg127.perseus-grc3.xml
@@ -60,9 +60,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-   <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
     <cRefPattern n="section" matchPattern="(\w+)"
         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg128/tlg0007.tlg128.perseus-eng3.xml
+++ b/data/tlg0007/tlg128/tlg0007.tlg128.perseus-eng3.xml
@@ -67,9 +67,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg128/tlg0007.tlg128.perseus-eng4.xml
+++ b/data/tlg0007/tlg128/tlg0007.tlg128.perseus-eng4.xml
@@ -67,9 +67,7 @@
       		<correction method="silent">
       			<p>optical character recognition</p>
       		</correction>
-      	</editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg128/tlg0007.tlg128.perseus-grc2.xml
+++ b/data/tlg0007/tlg128/tlg0007.tlg128.perseus-grc2.xml
@@ -56,8 +56,7 @@
     <correction method="silent">
     <p>optical character recognition</p>
     </correction>
-    </editorialDecl>
-    <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+    </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
         <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
             <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng3.xml
+++ b/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng3.xml
@@ -67,9 +67,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng4.xml
+++ b/data/tlg0007/tlg129/tlg0007.tlg129.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg129/tlg0007.tlg129.perseus-grc2.xml
+++ b/data/tlg0007/tlg129/tlg0007.tlg129.perseus-grc2.xml
@@ -61,9 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 

--- a/data/tlg0007/tlg130/tlg0007.tlg130.perseus-eng3.xml
+++ b/data/tlg0007/tlg130/tlg0007.tlg130.perseus-eng3.xml
@@ -67,9 +67,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg130/tlg0007.tlg130.perseus-eng4.xml
+++ b/data/tlg0007/tlg130/tlg0007.tlg130.perseus-eng4.xml
@@ -64,9 +64,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg130/tlg0007.tlg130.perseus-grc2.xml
+++ b/data/tlg0007/tlg130/tlg0007.tlg130.perseus-grc2.xml
@@ -60,8 +60,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
  <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
             <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg131/tlg0007.tlg131.perseus-eng3.xml
+++ b/data/tlg0007/tlg131/tlg0007.tlg131.perseus-eng3.xml
@@ -67,9 +67,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg131/tlg0007.tlg131.perseus-eng4.xml
+++ b/data/tlg0007/tlg131/tlg0007.tlg131.perseus-eng4.xml
@@ -59,9 +59,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg131/tlg0007.tlg131.perseus-grc2.xml
+++ b/data/tlg0007/tlg131/tlg0007.tlg131.perseus-grc2.xml
@@ -61,10 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
- 
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg132/tlg0007.tlg132.perseus-eng3.xml
+++ b/data/tlg0007/tlg132/tlg0007.tlg132.perseus-eng3.xml
@@ -64,9 +64,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg132/tlg0007.tlg132.perseus-eng4.xml
+++ b/data/tlg0007/tlg132/tlg0007.tlg132.perseus-eng4.xml
@@ -59,9 +59,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg132/tlg0007.tlg132.perseus-grc2.xml
+++ b/data/tlg0007/tlg132/tlg0007.tlg132.perseus-grc2.xml
@@ -61,9 +61,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg133/tlg0007.tlg133.perseus-eng2.xml
+++ b/data/tlg0007/tlg133/tlg0007.tlg133.perseus-eng2.xml
@@ -65,9 +65,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 				<refsDecl n="CTS">
 					<cRefPattern n="section"

--- a/data/tlg0007/tlg133/tlg0007.tlg133.perseus-grc2.xml
+++ b/data/tlg0007/tlg133/tlg0007.tlg133.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section"

--- a/data/tlg0007/tlg134/tlg0007.tlg134.perseus-eng2.xml
+++ b/data/tlg0007/tlg134/tlg0007.tlg134.perseus-eng2.xml
@@ -59,8 +59,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          	   <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg134/tlg0007.tlg134.perseus-grc2.xml
+++ b/data/tlg0007/tlg134/tlg0007.tlg134.perseus-grc2.xml
@@ -59,8 +59,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg135/tlg0007.tlg135.perseus-grc2.xml
+++ b/data/tlg0007/tlg135/tlg0007.tlg135.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg136/tlg0007.tlg136.perseus-eng2.xml
+++ b/data/tlg0007/tlg136/tlg0007.tlg136.perseus-eng2.xml
@@ -68,7 +68,7 @@
       			<p>optical character recognition</p>
       		</correction>
       	</editorialDecl>-->
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
+      	
       	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 

--- a/data/tlg0007/tlg136/tlg0007.tlg136.perseus-grc2.xml
+++ b/data/tlg0007/tlg136/tlg0007.tlg136.perseus-grc2.xml
@@ -56,9 +56,7 @@
     <correction method="silent">
     <p>optical character recognition</p>
     </correction>
-    </editorialDecl>
-    <p>Text encoded in accordance with the latest EpiDoc standards</p>
-    <p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+    </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
     <refsDecl n="CTS">
         <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"> 
             <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg137/tlg0007.tlg137.perseus-eng2.xml
+++ b/data/tlg0007/tlg137/tlg0007.tlg137.perseus-eng2.xml
@@ -64,9 +64,7 @@
             <correction status="high" method="silent">
                <p>optical character recognition</p>
             </correction>
-         </editorialDecl>
-         <p>Text encoded in accordance with the latest EpiDoc standards</p>
-         <p>The following text is encoded in accordance with EpiDoc standards and with the
+         </editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
             CTS/CITE Architecture</p>
          <refsDecl n="CTS">
             <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg137/tlg0007.tlg137.perseus-grc2.xml
+++ b/data/tlg0007/tlg137/tlg0007.tlg137.perseus-grc2.xml
@@ -58,9 +58,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg138/tlg0007.tlg138.perseus-eng2.xml
+++ b/data/tlg0007/tlg138/tlg0007.tlg138.perseus-eng2.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg138/tlg0007.tlg138.perseus-grc2.xml
+++ b/data/tlg0007/tlg138/tlg0007.tlg138.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg139/tlg0007.tlg139.perseus-eng2.xml
+++ b/data/tlg0007/tlg139/tlg0007.tlg139.perseus-eng2.xml
@@ -57,8 +57,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-      	<editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+      	<editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
          <refsDecl n="CTS">
          	<cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
          	   <p>This pointer pattern extracts section.</p></cRefPattern>

--- a/data/tlg0007/tlg139/tlg0007.tlg139.perseus-grc2.xml
+++ b/data/tlg0007/tlg139/tlg0007.tlg139.perseus-grc2.xml
@@ -59,8 +59,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
  
 <refsDecl n="CTS">
 <cRefPattern matchPattern="(\w+)" n="section" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">

--- a/data/tlg0007/tlg140/tlg0007.tlg140.perseus-eng2.xml
+++ b/data/tlg0007/tlg140/tlg0007.tlg140.perseus-eng2.xml
@@ -58,9 +58,7 @@
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
-         <editorialDecl><quotation marks="none"/></editorialDecl>
-      	<p>Text encoded in accordance with the latest EpiDoc standards</p>
-      	<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+         <editorialDecl><quotation marks="none"/></editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
       	<refsDecl n="CTS">
       		<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
       			<p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg140/tlg0007.tlg140.perseus-grc2.xml
+++ b/data/tlg0007/tlg140/tlg0007.tlg140.perseus-grc2.xml
@@ -60,9 +60,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
 <p>This pointer pattern extracts section.</p>

--- a/data/tlg0007/tlg141/tlg0007.tlg141.perseus-eng2.xml
+++ b/data/tlg0007/tlg141/tlg0007.tlg141.perseus-eng2.xml
@@ -63,9 +63,7 @@
 				<correction status="high" method="silent">
 					<p>optical character recognition</p>
 				</correction>
-			</editorialDecl>
-			<p>Text encoded in accordance with the latest EpiDoc standards</p>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the
+			</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture</p>
 			<refsDecl n="CTS">
 				<cRefPattern n="section" matchPattern="(\w+)"

--- a/data/tlg0007/tlg141/tlg0007.tlg141.perseus-grc2.xml
+++ b/data/tlg0007/tlg141/tlg0007.tlg141.perseus-grc2.xml
@@ -57,9 +57,7 @@
 <correction method="silent">
 <p>optical character recognition</p>
 </correction>
-</editorialDecl>
-<p>Text encoded in accordance with the latest EpiDoc standards</p>
-<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
+</editorialDecl><p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 Architecture</p>
 <refsDecl n="CTS">
 <cRefPattern n="section" matchPattern="(\w+)"


### PR DESCRIPTION
Deleted: <`p>Text encoded in accordance with the latest EpiDoc standards</p>` and
 kept:`<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE Architecture</p>`